### PR TITLE
RFC: add waitForTimersAndIntervals

### DIFF
--- a/lib/ember-test-helpers/wait.js
+++ b/lib/ember-test-helpers/wait.js
@@ -55,9 +55,56 @@ export default function wait(_options) {
   var waitForTimers = options.hasOwnProperty('waitForTimers') ? options.waitForTimers : true;
   var waitForAJAX = options.hasOwnProperty('waitForAJAX') ? options.waitForAJAX : true;
   var waitForWaiters = options.hasOwnProperty('waitForWaiters') ? options.waitForWaiters : true;
+  var waitForTimersAndIntervals = options.hasOwnProperty('waitForTimersAndIntervals') ? options.waitForTimersAndIntervals : false;
+
+  var ids = {};
+  var originalSetInterval = window.setInterval;
+  var originalClearInterval = window.clearInterval;
+  var originalSetTimeout = window.setTimeout;
+  var originalClearTimeout = window.clearTimeout;
+  if (waitForTimersAndIntervals) {
+    window.setInterval = function(fn) {
+      var id;
+      var args = Array.prototype.slice.call(arguments, 1);
+      args.unshift(function() {
+        delete ids[id];
+        if (typeof fn === 'string') {
+          eval(fn);
+        } else {
+          fn(arguments);
+        }
+      });
+      id = originalSetInterval.apply(this, args);
+      ids[id] = undefined;
+      return id;
+    };
+    window.clearInterval = function(id) {
+      delete ids[id];
+      return originalClearInterval(arguments);
+    };
+    window.setTimeout = function(fn) {
+      var id;
+      var args = Array.prototype.slice.call(arguments, 1);
+      args.unshift(function() {
+        delete ids[id];
+        if (typeof fn === 'string') {
+          eval(fn);
+        } else {
+          fn(arguments);
+        }
+      });
+      id = originalSetTimeout.apply(this, args);
+      ids[id] = undefined;
+      return id;
+    };
+    window.clearTimeout = function(id) {
+      delete ids[id];
+      return originalClearTimeout(arguments);
+    };
+  }
 
   return new Ember.RSVP.Promise(function(resolve) {
-    var watcher = self.setInterval(function() {
+    var watcher = originalSetInterval(function() {
       if (waitForTimers && (Ember.run.hasScheduledTimers() || Ember.run.currentRunLoop)) {
         return;
       }
@@ -70,6 +117,16 @@ export default function wait(_options) {
         return;
       }
 
+      if (waitForTimersAndIntervals) {
+        if (Object.keys(ids).length) {
+          return;
+        } else {
+          window.setInterval = originalSetInterval;
+          window.clearInterval = originalClearInterval;
+          window.setTimeout = originalSetTimeout;
+          window.clearTimeout = originalClearTimeout;
+        }
+      }
 
       // Stop polling
       self.clearInterval(watcher);


### PR DESCRIPTION
After reading https://github.com/emberjs/ember.js/issues/3008, I think I understand it as `Ember.run.later` blocks and `setTimeout` doesn't block `wait()`. My scenario is a library I'm using is using `setTimeout` ([here](https://github.com/jhurliman/node-rate-limiter)), yet I still want my `wait()` call to block.
I whipped this code up quick to test it out and it works as expected. The implementation is probably terrible. I just wanted to start a conversation.
