### PR TITLE
Overriding toString() to return the test subject name

### DIFF
--- a/lib/ember-test-helpers/abstract-test-module.js
+++ b/lib/ember-test-helpers/abstract-test-module.js
@@ -132,15 +132,15 @@ export default Klass.extend({
   },
 
   setToString() {
-    this.context.toString = function() {
+    this.context.toString = () =>  {
       if(this.subjectName) {
         return `test for: ${this.subjectName}`;
       }
-      
+
       if(this.name) {
         return `test for: ${this.name}`;
       }
-    }.bind(this);
+    };
   },
 
   setupAJAXListeners() {

--- a/lib/ember-test-helpers/abstract-test-module.js
+++ b/lib/ember-test-helpers/abstract-test-module.js
@@ -134,11 +134,11 @@ export default Klass.extend({
   setToString() {
     this.context.toString = () =>  {
       if(this.subjectName) {
-        return `test for: ${this.subjectName}`;
+        return `test context for: ${this.subjectName}`;
       }
 
       if(this.name) {
-        return `test for: ${this.name}`;
+        return `test context for: ${this.name}`;
       }
     };
   },

--- a/lib/ember-test-helpers/abstract-test-module.js
+++ b/lib/ember-test-helpers/abstract-test-module.js
@@ -116,6 +116,7 @@ export default Klass.extend({
     });
     merge(context, options);
 
+    this.setToString();
     setContext(context);
     this.context = context;
   },
@@ -128,6 +129,18 @@ export default Klass.extend({
     if (this.context) { return this.context; }
 
     return this.context = getContext() || {};
+  },
+
+  setToString() {
+    this.context.toString = function() {
+      if(this.subjectName) {
+        return `test for: ${this.subjectName}`;
+      }
+      
+      if(this.name) {
+        return `test for: ${this.name}`;
+      }
+    }.bind(this);
   },
 
   setupAJAXListeners() {

--- a/tests/test-module-for-acceptance-test.js
+++ b/tests/test-module-for-acceptance-test.js
@@ -70,3 +70,7 @@ test('Basic acceptance test using global test helpers', function() {
     equal(Ember.$('#ember-testing').text(), 'This is the index page.');
   });
 });
+
+test("`toString` returns the test name", function(){
+  equal(this.toString(), 'test for: TestModuleForAcceptance | Basic acceptance tests', 'toString returns `test for: name`');
+});

--- a/tests/test-module-for-acceptance-test.js
+++ b/tests/test-module-for-acceptance-test.js
@@ -72,5 +72,5 @@ test('Basic acceptance test using global test helpers', function() {
 });
 
 test("`toString` returns the test name", function(){
-  equal(this.toString(), 'test for: TestModuleForAcceptance | Basic acceptance tests', 'toString returns `test for: name`');
+  equal(this.toString(), 'test context for: TestModuleForAcceptance | Basic acceptance tests', 'toString returns `test context for: name`');
 });

--- a/tests/test-module-for-component-test.js
+++ b/tests/test-module-for-component-test.js
@@ -219,7 +219,7 @@ test("className", function(){
 });
 
 test("`toString` returns the test subject", function(){
-  equal(this.toString(), 'test for: component:pretty-color', 'toString returns `test for: subjectName`');
+  equal(this.toString(), 'test context for: component:pretty-color', 'toString returns `test context for: subjectName`');
 });
 
 moduleForComponent('boring-color', 'component:boring-color -- still in DOM in willDestroyElement', {

--- a/tests/test-module-for-component-test.js
+++ b/tests/test-module-for-component-test.js
@@ -218,6 +218,10 @@ test("className", function(){
   equal($.trim($('#ember-testing').text()), 'Pretty Color: red');
 });
 
+test("`toString` returns the test subject", function(){
+  equal(this.toString(), 'test for: component:pretty-color', 'toString returns `test for: subjectName`');
+});
+
 moduleForComponent('boring-color', 'component:boring-color -- still in DOM in willDestroyElement', {
   unit: true,
   beforeSetup: function() {

--- a/tests/test-module-for-integration-test.js
+++ b/tests/test-module-for-integration-test.js
@@ -115,7 +115,7 @@ test('it supports dom triggered focus events', function() {
 });
 
 test("`toString` returns the test name", function(){
-  equal(this.toString(), 'test for: Component Integration Tests', 'toString returns `test for: name`');
+  equal(this.toString(), 'test context for: Component Integration Tests', 'toString returns `test context for: name`');
 });
 
 moduleForIntegration('TestModuleForIntegration | render during setup', {

--- a/tests/test-module-for-integration-test.js
+++ b/tests/test-module-for-integration-test.js
@@ -114,6 +114,10 @@ test('it supports dom triggered focus events', function() {
   equal(this.$('input').val(), 'focusout');
 });
 
+test("`toString` returns the test name", function(){
+  equal(this.toString(), 'test for: Component Integration Tests', 'toString returns `test for: name`');
+});
+
 moduleForIntegration('TestModuleForIntegration | render during setup', {
   beforeSetup: function() {
     setResolverRegistry({

--- a/tests/test-module-for-model-test.js
+++ b/tests/test-module-for-model-test.js
@@ -81,7 +81,7 @@ test('JSONAPIAdapter (ED >= 2) or FixtureAdapter (ED < 2) is registered for mode
 });
 
 test("`toString` returns the test subject", function(){
-  equal(this.toString(), 'test for: model:whazzit', 'toString returns `test for: subjectName`');
+  equal(this.toString(), 'test context for: model:whazzit', 'toString returns `test context for: subjectName`');
 });
 
 

--- a/tests/test-module-for-model-test.js
+++ b/tests/test-module-for-model-test.js
@@ -80,6 +80,11 @@ test('JSONAPIAdapter (ED >= 2) or FixtureAdapter (ED < 2) is registered for mode
   ok(!(store.adapterFor(model.constructor.modelName) instanceof WhazzitAdapter));
 });
 
+test("`toString` returns the test subject", function(){
+  equal(this.toString(), 'test for: model:whazzit', 'toString returns `test for: subjectName`');
+});
+
+
 moduleForModel('whazzit', 'subject does not share the store', {
   beforeSetup: function() {
     setupRegistry();

--- a/tests/test-module-test.js
+++ b/tests/test-module-test.js
@@ -93,7 +93,7 @@ test("can lookup factory registered in setup", function() {
 });
 
 test("overrides `toString` to return the test subject", function(){
-  equal(this.toString(), 'test for: component:x-foo', 'toString returns `test for: subjectName`');
+  equal(this.toString(), 'test context for: component:x-foo', 'toString returns `test context for: subjectName`');
 });
 
 moduleFor('component:x-foo', 'component:x-foo -- callback context', {
@@ -356,7 +356,7 @@ test('subject created using custom resolver', function() {
 });
 
 test("`toString` returns the test subject", function(){
-  equal(this.toString(), 'test for: component:y-foo', 'toString returns `test for: subjectName`');
+  equal(this.toString(), 'test context for: component:y-foo', 'toString returns `test context for: subjectName`');
 });
 
 moduleFor('component:x-foo', 'ember-testing resets to empty value');

--- a/tests/test-module-test.js
+++ b/tests/test-module-test.js
@@ -92,6 +92,10 @@ test("can lookup factory registered in setup", function() {
   equal(Ember.get(this, 'blah.purpose'), 'blabering');
 });
 
+test("overrides `toString` to return the test subject", function(){
+  equal(this.toString(), 'test for: component:x-foo', 'toString returns `test for: subjectName`');
+});
+
 moduleFor('component:x-foo', 'component:x-foo -- callback context', {
   beforeSetup: function() {
     setupRegistry();
@@ -349,6 +353,10 @@ moduleFor('component:y-foo', 'Custom resolver', {
 
 test('subject created using custom resolver', function() {
   equal(this.subject().name, 'Y u no foo?!');
+});
+
+test("`toString` returns the test subject", function(){
+  equal(this.toString(), 'test for: component:y-foo', 'toString returns `test for: subjectName`');
 });
 
 moduleFor('component:x-foo', 'ember-testing resets to empty value');


### PR DESCRIPTION
A fix for: https://github.com/emberjs/ember-qunit/issues/247

In an integration test where a component is instantiated the test is the outside context.  Ember when makes an assertion at that point the test is the object that ember is using in the assertion object hench `test.toString()` returns `[object Object]` not a helpful error.

After this PR for this test: 
```js
moduleFor('component:x-foo', 'component:x-foo -- callback context', { ...

this.toString() >> 'test for:  component:x-foo'
```

```js
moduleForAcceptance('TestModuleForAcceptance | Basic acceptance tests', { ...
 
this.toString() >> 'test for: TestModuleForAcceptance | Basic acceptance tests'
```

```js
moduleForIntegration('Component Integration Tests', { ...
 
this.toString() >> 'test for: Component Integration Tests'
```

```js 
moduleForComponent('pretty-color', 'component:pretty-color -- this.render in setup', { ...

this.toString() >> 'test for: component:pretty-color'
```

```js 
moduleForModel('kiwis', 'model test', { ...

this.toString() >> 'test for: model:kiwis'
```
