### PR TITLE
Update QUnit module example

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ function moduleFor(name, description, callbacks) {
   var module = new TestModule(name, description, callbacks);
 
   QUnit.module(module.name, {
-    setup: function() {
+    beforeEach() {
       module.setup();
     },
-    teardown: function() {
+    afterEach() {
       module.teardown();
     }
   });


### PR DESCRIPTION
It was still written with the deprecated `setup` and `teardown` callbacks.