### PR TITLE
Ember 2.12: Use factoryFor instead of lookupFactory, if available

### DIFF
--- a/lib/ember-test-helpers/build-registry.js
+++ b/lib/ember-test-helpers/build-registry.js
@@ -47,7 +47,7 @@ export default function(resolver) {
   function register(name, factory) {
     var thingToRegisterWith = registry || container;
 
-    if (!container.lookupFactory(name)) {
+    if (!(container.factoryFor ? container.factoryFor(name) : container.lookupFactory(name))) {
       thingToRegisterWith.register(name, factory);
     }
   }

--- a/lib/ember-test-helpers/test-module-for-component.js
+++ b/lib/ember-test-helpers/test-module-for-component.js
@@ -151,7 +151,7 @@ export default class extends TestModule {
 
     // only setup the injection if we are running against a version
     // of Ember that has `-view-registry:main` (Ember >= 1.12)
-    if (this.container.lookupFactory('-view-registry:main')) {
+    if (this.container.factoryFor ? this.container.factoryFor('-view-registry:main') : this.container.lookupFactory('-view-registry:main')) {
       (this.registry || this.container).injection('component', '_viewRegistry', '-view-registry:main');
     }
 
@@ -178,7 +178,7 @@ export function setupComponentIntegrationTest() {
   context.dispatcher.setup({}, '#ember-testing');
 
   var hasRendered = false;
-  var OutletView = module.container.lookupFactory('view:-outlet');
+  var OutletView = module.container.factoryFor ? module.container.factoryFor('view:-outlet') : module.container.lookupFactory('view:-outlet');
   var OutletTemplate = module.container.lookup('template:-outlet');
   var toplevelView = module.component = OutletView.create();
   var hasOutletTemplate = !!OutletTemplate;

--- a/lib/ember-test-helpers/test-module-for-integration.js
+++ b/lib/ember-test-helpers/test-module-for-integration.js
@@ -85,7 +85,7 @@ export default class extends AbstractTestModule {
     var container = this.container;
 
     var factory = function() {
-      return container.lookupFactory(subjectName);
+      return container.factoryFor ? container.factoryFor(subjectName) : container.lookupFactory(subjectName);
     };
 
     super.setupContext({
@@ -118,7 +118,7 @@ export default class extends AbstractTestModule {
 
     // only setup the injection if we are running against a version
     // of Ember that has `-view-registry:main` (Ember >= 1.12)
-    if (this.container.lookupFactory('-view-registry:main')) {
+    if (this.container.factoryFor ? this.container.factoryFor('-view-registry:main') : this.container.lookupFactory('-view-registry:main')) {
       (this.registry || this.container).injection('component', '_viewRegistry', '-view-registry:main');
     }
   }

--- a/lib/ember-test-helpers/test-module-for-model.js
+++ b/lib/ember-test-helpers/test-module-for-model.js
@@ -18,7 +18,7 @@ export default class extends TestModule {
     var callbacks = this.callbacks;
     var modelName = this.modelName;
 
-    var adapterFactory = container.lookupFactory('adapter:application');
+    var adapterFactory = container.factoryFor ? container.factoryFor('adapter:application') : container.lookupFactory('adapter:application');
     if (!adapterFactory) {
       if (requirejs.entries['ember-data/adapters/json-api']) {
         adapterFactory = require('ember-data/adapters/json-api')['default'];

--- a/lib/ember-test-helpers/test-module.js
+++ b/lib/ember-test-helpers/test-module.js
@@ -105,7 +105,7 @@ export default class extends AbstractTestModule {
     var container = this.container;
 
     var factory = function() {
-      return container.lookupFactory(subjectName);
+      return container.factoryFor ? container.factoryFor(subjectName) : container.lookupFactory(subjectName);
     };
 
     super.setupContext({


### PR DESCRIPTION
Ember 2.12 introduces `container.factoryFor()` as a public API and deprecates `container.lookupFactory()`.

This change silences the deprecation warning and retains backward compatibility with Ember 2.11 and earlier.

It introduces one breaking change, which is that unit tests will fail if they do not provide all services injected into the class under test. An error will be thrown during object creation when calling `this.subject()`. Previously, these missing dependencies would be silently ignored.

Tests failing for this reason would need to be updated to add the service dependency to `needs` or to register a stub service in `beforeEach`.

IMHO this is acceptable, and perhaps even preferable to the prior behavior.
