### PR TITLE
Deprecation Warning thrown with `needs:[]`

### DIFF
--- a/lib/ember-test-helpers/test-module-for-component.js
+++ b/lib/ember-test-helpers/test-module-for-component.js
@@ -25,12 +25,13 @@ export default class extends TestModule {
     }
 
     let integrationOption = callbacks.integration;
+    let hasNeeds = Array.isArray(callbacks.needs);
 
     super('component:' + componentName, description, callbacks);
 
     this.componentName = componentName;
 
-    if (callbacks.needs || callbacks.unit || integrationOption === false) {
+    if (hasNeeds || callbacks.unit || integrationOption === false) {
       this.isUnitTest = true;
     } else if (integrationOption) {
       this.isUnitTest = false;

--- a/tests/test-module-for-component-test.js
+++ b/tests/test-module-for-component-test.js
@@ -9,6 +9,8 @@ var $ = Ember.$;
 
 var Service = Ember.Service || Ember.Object;
 
+const TEST_TYPE_DEPRECATION_ID = 'ember-test-helpers.test-module-for-component.test-type';
+
 function moduleForComponent(name, description, callbacks) {
   var module = new TestModuleForComponent(name, description, callbacks);
   if (module.isIntegration) {
@@ -303,7 +305,9 @@ QUnit.module('moduleForComponent: will not raise deprecation if needs is specifi
   beforeEach() {
     originalDeprecate = Ember.deprecate;
     Ember.deprecate = function() {
-      deprecations.push(arguments);
+      if (arguments.length === 3) {
+        deprecations.push(arguments[2].id);
+      }
     }
   },
   afterEach() {
@@ -313,12 +317,9 @@ QUnit.module('moduleForComponent: will not raise deprecation if needs is specifi
 });
 
 test('deprecation is not raised', function() {
-  let deprecationId = 'ember-test-helpers.test-module-for-component.test-type';
   setupRegistry();
   testModule = new TestModuleForComponent('pretty-color', { needs: ['x:foo'] });
-  notOk(deprecations.find(function(deprecation) {
-    return deprecation.length === 3 && deprecation[2].id === deprecationId;
-  }), `deprecation with id "${deprecationId}" should not be raised if needs is provided`);
+  ok(deprecations.indexOf(TEST_TYPE_DEPRECATION_ID) === -1, `deprecation with id "${TEST_TYPE_DEPRECATION_ID}" should not be raised if needs is provided`);
   ok(testModule.isUnitTest);
 });
 

--- a/tests/test-module-for-component-test.js
+++ b/tests/test-module-for-component-test.js
@@ -298,6 +298,27 @@ test('it allows missing callbacks', function() {
   ok(true, 'no errors are thrown');
 });
 
+let deprecations = [];
+QUnit.module('moduleForComponent: will not raise deprecation if needs is specified', {
+  beforeEach() {
+    originalDeprecate = Ember.deprecate;
+    Ember.deprecate = function() {
+      deprecations.push(arguments);
+    }
+  },
+  afterEach() {
+    Ember.deprecate = originalDeprecate;
+    deprecations = [];
+  }
+});
+
+test('deprecation is not raised', function() {
+  setupRegistry();
+  testModule = new TestModuleForComponent('pretty-color', { needs: ['x:foo'] });
+  equal(deprecations.length, 0);
+  ok(testModule.isUnitTest);
+});
+
 QUnit.module('moduleForComponent: can be invoked with the component name and description', {
   beforeEach(assert) {
     var done = assert.async();

--- a/tests/test-module-for-component-test.js
+++ b/tests/test-module-for-component-test.js
@@ -313,9 +313,12 @@ QUnit.module('moduleForComponent: will not raise deprecation if needs is specifi
 });
 
 test('deprecation is not raised', function() {
+  let deprecationId = 'ember-test-helpers.test-module-for-component.test-type';
   setupRegistry();
   testModule = new TestModuleForComponent('pretty-color', { needs: ['x:foo'] });
-  equal(deprecations.length, 0);
+  notOk(deprecations.find(function(deprecation) {
+    return deprecation.length === 3 && deprecation[2].id === deprecationId;
+  }), `deprecation with id "${deprecationId}" should not be raised if needs is provided`);
   ok(testModule.isUnitTest);
 });
 


### PR DESCRIPTION
- Fix `moduleForComponent` unit test deprecation being raised even if `needs` is provided.
- Add a test case.

Fixes: #195 