### PR TITLE
Import `require` (avoid using global require).

### DIFF
--- a/lib/ember-test-helpers/build-registry.js
+++ b/lib/ember-test-helpers/build-registry.js
@@ -1,5 +1,6 @@
-/* globals global, self, requirejs, require */
+/* globals global, self, requirejs */
 
+import require from 'require';
 import Ember from 'ember';
 
 function exposeRegistryMethodsWithoutDeprecations(container) {

--- a/lib/ember-test-helpers/test-module-for-model.js
+++ b/lib/ember-test-helpers/test-module-for-model.js
@@ -1,5 +1,6 @@
-/* global DS, require, requirejs */ // added here to prevent an import from erroring when ED is not present
+/* global DS, requirejs */ // added here to prevent an import from erroring when ED is not present
 
+import require from 'require';
 import TestModule from './test-module';
 import Ember from 'ember';
 


### PR DESCRIPTION
Relying on global `require` calls causes issues in babel@6.