### PR TITLE
Replace hard-coded guides link with /current

### DIFF
--- a/addon-test-support/ember-test-helpers/legacy-0-6-x/test-module-for-component.js
+++ b/addon-test-support/ember-test-helpers/legacy-0-6-x/test-module-for-component.js
@@ -67,7 +67,7 @@ export default class extends TestModule {
     } else {
       this.callbacks.subject = function() {
         throw new Error(
-          "component integration tests do not support `subject()`. Instead, render the component as if it were HTML: `this.render('<my-component foo=true>');`. For more information, read: http://guides.emberjs.com/v2.2.0/testing/testing-components/"
+          "component integration tests do not support `subject()`. Instead, render the component as if it were HTML: `this.render('<my-component foo=true>');`. For more information, read: http://guides.emberjs.com/current/testing/testing-components/"
         );
       };
       this.setupSteps.push(this.setupComponentIntegrationTest);


### PR DESCRIPTION
This type of link works fine for guides at this point.  We might also want to use the Ember version of the app in question, thoughts?