### PR TITLE
Ensure RSVP promises do not need manual Ember.run wrapping.

### DIFF
--- a/lib/ember-test-helpers/abstract-test-module.js
+++ b/lib/ember-test-helpers/abstract-test-module.js
@@ -1,3 +1,4 @@
+import { _setupPromiseListeners, _teardownPromiseListeners } from './ext/rsvp';
 import { _setupAJAXHooks, _teardownAJAXHooks } from './wait';
 import { getContext, setContext, unsetContext } from './test-context';
 
@@ -46,6 +47,7 @@ export default class {
     this.setupSteps.push(this.setupContext);
     this.setupSteps.push(this.setupTestElements);
     this.setupSteps.push(this.setupAJAXListeners);
+    this.setupSteps.push(this.setupPromiseListeners);
 
     if (this.callbacks.setup) {
       this.contextualizedSetupSteps.push( this.callbacks.setup );
@@ -86,6 +88,7 @@ export default class {
     this.teardownSteps.push(this.teardownContext);
     this.teardownSteps.push(this.teardownTestElements);
     this.teardownSteps.push(this.teardownAJAXListeners);
+    this.teardownSteps.push(this.teardownPromiseListeners);
 
     if (this.callbacks.afterTeardown) {
       this.teardownSteps.push( this.callbacks.afterTeardown );
@@ -148,6 +151,14 @@ export default class {
 
   teardownAJAXListeners() {
     _teardownAJAXHooks();
+  }
+
+  setupPromiseListeners() {
+    _setupPromiseListeners();
+  }
+
+  teardownPromiseListeners() {
+    _teardownPromiseListeners();
   }
 
   teardownTestElements() {

--- a/lib/ember-test-helpers/ext/rsvp.js
+++ b/lib/ember-test-helpers/ext/rsvp.js
@@ -1,0 +1,18 @@
+import Ember from 'ember';
+
+const { RSVP, run } = Ember;
+
+let originalAsync;
+export function _setupPromiseListeners() {
+  originalAsync = RSVP.configure('async');
+
+  RSVP.configure('async', function(callback, promise) {
+    run.backburner.schedule('actions', () => {
+      callback(promise);
+    });
+  });
+}
+
+export function _teardownPromiseListeners() {
+  RSVP.configure('async', originalAsync);
+}

--- a/lib/ember-test-helpers/test-module.js
+++ b/lib/ember-test-helpers/test-module.js
@@ -64,6 +64,7 @@ export default class extends AbstractTestModule {
     this.setupSteps.push(this.setupContext);
     this.setupSteps.push(this.setupTestElements);
     this.setupSteps.push(this.setupAJAXListeners);
+    this.setupSteps.push(this.setupPromiseListeners);
 
     if (this.callbacks.setup) {
       this.contextualizedSetupSteps.push( this.callbacks.setup );
@@ -85,6 +86,7 @@ export default class extends AbstractTestModule {
     this.teardownSteps.push(this.teardownContext);
     this.teardownSteps.push(this.teardownTestElements);
     this.teardownSteps.push(this.teardownAJAXListeners);
+    this.teardownSteps.push(this.teardownPromiseListeners);
 
     if (this.callbacks.afterTeardown) {
       this.teardownSteps.push( this.callbacks.afterTeardown );


### PR DESCRIPTION
This is essentially doing the same thing that was added way back in Ember 1.6/1.7 by Stef.

The basic gist is that whenever something is triggering RSVP's `async` it will wrap that in a `Ember.run`. This prevents folks from getting the autorun error for just resolving promises...

This brings the ember-metal-test-friendly-promises feature (from https://github.com/emberjs/ember.js/pull/4176) to ember-test-helpers.