### PR TITLE
[FEATURE] Export helpers that add help tracking requests

### DIFF
--- a/lib/ember-test-helpers/wait.js
+++ b/lib/ember-test-helpers/wait.js
@@ -4,33 +4,30 @@ import Ember from 'ember';
 
 const jQuery = Ember.$;
 
-var requests;
-function incrementAjaxPendingRequests(_, xhr) {
-  requests.push(xhr);
+var pendingRequestsCounter = 0;
+
+function incrementPendingRequestsCounter() {
+  pendingRequestsCounter++;
 }
 
-function decrementAjaxPendingRequests(_, xhr) {
-  for (var i = 0;i < requests.length;i++) {
-    if (xhr === requests[i]) {
-      requests.splice(i, 1);
-    }
-  }
+function decrementPendingRequestsCounter() {
+  pendingRequestsCounter--;
 }
 
 export function _teardownAJAXHooks() {
   if (!jQuery) { return; }
 
-  jQuery(document).off('ajaxSend', incrementAjaxPendingRequests);
-  jQuery(document).off('ajaxComplete', decrementAjaxPendingRequests);
+  jQuery(document).off('ajaxSend', incrementPendingRequestsCounter);
+  jQuery(document).off('ajaxComplete', decrementPendingRequestsCounter);
 }
 
 export function _setupAJAXHooks() {
-  requests = [];
+  pendingRequestsCounter = 0;
 
   if (!jQuery) { return; }
 
-  jQuery(document).on('ajaxSend', incrementAjaxPendingRequests);
-  jQuery(document).on('ajaxComplete', decrementAjaxPendingRequests);
+  jQuery(document).on('ajaxSend', incrementPendingRequestsCounter);
+  jQuery(document).on('ajaxComplete', decrementPendingRequestsCounter);
 }
 
 var _internalCheckWaiters;
@@ -50,6 +47,10 @@ function checkWaiters() {
   return false;
 }
 
+function checkPendingRequests() {
+  return pendingRequestsCounter > 0;
+}
+
 export default function wait(_options) {
   var options = _options || {};
   var waitForTimers = options.hasOwnProperty('waitForTimers') ? options.waitForTimers : true;
@@ -62,14 +63,13 @@ export default function wait(_options) {
         return;
       }
 
-      if (waitForAJAX && requests && requests.length > 0) {
+      if (waitForAJAX && checkPendingRequests()) {
         return;
       }
 
       if (waitForWaiters && checkWaiters()) {
         return;
       }
-
 
       // Stop polling
       self.clearInterval(watcher);

--- a/tests/wait-test.js
+++ b/tests/wait-test.js
@@ -13,7 +13,6 @@ function moduleForComponent(name, description, callbacks) {
   qunitModuleFor(module);
 }
 
-
 moduleForComponent('wait helper tests', {
   integration: true,
   setup() {


### PR DESCRIPTION
This very simple addition already helps with 80% of what I want to 
accomplish. I think that all networking libraries should increment
the counter of pending ajax requests.

If this two utilities are expored networking libraries can use them.

I decided to leave the `ajax` terminology in the options the waiter
can receive because it is a defacto synonym of “request”.