### PR TITLE
Possible fix for the error asserting issue

### DIFF
--- a/lib/ember-test-helpers/test-module-for-component.js
+++ b/lib/ember-test-helpers/test-module-for-component.js
@@ -238,6 +238,14 @@ export function setupComponentIntegrationTest() {
       outletState = { render: stateToRender, outlets: {} };
     }
 
+    // A hacky fix for the issue https://github.com/emberjs/ember.js/issues/15013 — listen
+    // for errors on the global window object and save them in order to rethrow later.
+    var uncaughtErrors = [];
+    var originalOnErrorHandler = window.onerror;
+    window.onerror = function windowErrorsHandler(error) {
+      uncaughtErrors.push(error);
+    };
+
     Ember.run(() => {
       toplevelView.setOutletState(outletState);
     });
@@ -246,6 +254,16 @@ export function setupComponentIntegrationTest() {
       Ember.run(module.component, 'appendTo', '#ember-testing');
       hasRendered = true;
     }
+
+    if (uncaughtErrors.length > 0) {
+      // Rethrow any errors caught on the window to a test framework after the component
+      // was rendered:
+      uncaughtErrors.forEach(function throwWindowError(error) {
+        throw error;
+      });
+    }
+    // Restore global onerror handler:
+    window.onerror = originalOnErrorHandler;
 
     // ensure the element is based on the wrapping toplevel view
     // Ember still wraps the main application template with a

--- a/tests/test-module-for-component-test.js
+++ b/tests/test-module-for-component-test.js
@@ -64,7 +64,7 @@ var ChangingColor = Ember.Component.extend({
 
 // A component which throws an error during render:
 var BadComponent = Ember.Component.extend({
-  layout: Ember.Handlebars.compile('<input type="text" onfocus=(action "focus")>'),
+  layout: Ember.Handlebars.compile('<input type="text" onfocus={{action "focus"}}>'),
   didInsertElement() {
     this.set('input', this.element.querySelector('input'));
   },

--- a/tests/test-module-for-component-test.js
+++ b/tests/test-module-for-component-test.js
@@ -62,6 +62,22 @@ var ChangingColor = Ember.Component.extend({
   }
 });
 
+// A component which throws an error during render:
+var BadComponent = Ember.Component.extend({
+  layout: Ember.Handlebars.compile('<input type="text" onfocus=(action "focus")>'),
+  didInsertElement() {
+    this.set('input', this.element.querySelector('input'));
+  },
+  didRender() {
+    this.get('input').focus();
+  },
+  actions: {
+    focus() {
+      this.get('unexistedMethod')();
+    }
+  }
+});
+
 function setupRegistry() {
   setResolverRegistry({
     'component:x-foo': Ember.Component.extend(),
@@ -373,7 +389,8 @@ moduleForComponent('Component Integration Tests', {
     setResolverRegistry({
       'template:components/my-component': Ember.Handlebars.compile(
         '<span>{{name}}</span>'
-      )
+      ),
+      'component:bad-component': BadComponent
     });
   }
 });
@@ -394,6 +411,13 @@ if (hasEmberVersion(1,11)) {
     ok(true, 'it renders without fail');
   });
 }
+
+test('it correctly handles uncaught errors when rendering a component', function() {
+  var self = this;
+  throws(function() {
+    self.render('{{bad-component}}');
+  });
+});
 
 test('it complains if you try to use bare render', function() {
   var self = this;


### PR DESCRIPTION
Hi, 

This pull-request is just an idea (maybe crazy) which perhaps solve the issue emberjs/ember.js#15013

The bottom line is this: we can set a global `window.onerror` handler before the component render, and save all uncaught errors ([test-module-for-component.js#L243-L247](https://github.com/filippovdaniil/ember-test-helpers/blob/264ef876b28f66f0586cdeb368480f3d7b8509bf/lib/ember-test-helpers/test-module-for-component.js#L243-L247)). 

Then, after the component was rendered, we rethrow these errors to be caught by the test framework error assertion: [test-module-for-component.js#L258-L263](https://github.com/filippovdaniil/ember-test-helpers/blob/264ef876b28f66f0586cdeb368480f3d7b8509bf/lib/ember-test-helpers/test-module-for-component.js#L258-L263)

I created a simple test with this component:

```js
// A component which throws an error during render:
var BadComponent = Ember.Component.extend({
  layout: Ember.Handlebars.compile('<input type="text" onfocus={{action "focus"}}>'),
  didInsertElement() {
    this.set('input', this.element.querySelector('input'));
  },
  didRender() {
    this.get('input').focus();
  },
  actions: {
    focus() {
      this.get('unexistedMethod')();
    }
  }
});
```

— it sets the focus to the child `<input>` element in the `didRender` hook, and this triggers the `focus()` closure action, which, in turn, throws an error (because there is a call on the undefined property).

With this hacky fix the `throws` assertion

```js
test('it correctly handles uncaught errors when rendering a component', function() {
  var self = this;
  throws(function() {
    self.render('{{bad-component}}');
  });
});
```

now successfully catches this error.

Any thoughts?