### PR TITLE
Reduce direct jQuery usage in tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ env:
   - EMBER_TRY_SCENARIO=ember-lts-2.12
   - EMBER_TRY_SCENARIO=ember-lts-2.16
   - EMBER_TRY_SCENARIO=ember-release
+  - EMBER_TRY_SCENARIO=ember-release-with-jquery
   - EMBER_TRY_SCENARIO=ember-beta
   - EMBER_TRY_SCENARIO=ember-canary
   - EMBER_TRY_SCENARIO=ember-default

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -58,6 +58,8 @@ module.exports = {
       npm: {
         devDependencies: {
           'ember-source': '~2.12.0',
+          'ember-native-dom-event-dispatcher': null,
+          'ember-fetch': null,
         },
       },
     },

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -12,6 +12,7 @@ module.exports = {
       npm: {
         devDependencies: {
           'ember-source': null,
+          'ember-native-dom-event-dispatcher': null,
         },
       },
     },
@@ -28,6 +29,7 @@ module.exports = {
       npm: {
         devDependencies: {
           'ember-source': null,
+          'ember-native-dom-event-dispatcher': null,
         },
       },
     },
@@ -44,6 +46,7 @@ module.exports = {
       npm: {
         devDependencies: {
           'ember-source': null,
+          'ember-native-dom-event-dispatcher': null,
         },
       },
     },
@@ -108,6 +111,14 @@ module.exports = {
       npm: {
         devDependencies: {
           'ember-source': null,
+        },
+      },
+    },
+    {
+      name: 'ember-release-with-jquery',
+      npm: {
+        devDependencies: {
+          'ember-native-dom-event-dispatcher': null,
         },
       },
     },

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -13,6 +13,7 @@ module.exports = {
         devDependencies: {
           'ember-source': null,
           'ember-native-dom-event-dispatcher': null,
+          'ember-fetch': null,
         },
       },
     },
@@ -30,6 +31,7 @@ module.exports = {
         devDependencies: {
           'ember-source': null,
           'ember-native-dom-event-dispatcher': null,
+          'ember-fetch': null,
         },
       },
     },
@@ -47,6 +49,7 @@ module.exports = {
         devDependencies: {
           'ember-source': null,
           'ember-native-dom-event-dispatcher': null,
+          'ember-fetch': null,
         },
       },
     },
@@ -119,6 +122,7 @@ module.exports = {
       npm: {
         devDependencies: {
           'ember-native-dom-event-dispatcher': null,
+          'ember-fetch': null,
         },
       },
     },

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -4,11 +4,17 @@
 const EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 
 module.exports = function(defaults) {
-  let app = new EmberAddon(defaults, {
+  let options = {
     eslint: {
       testGenerator: 'qunit',
     },
-  });
+  };
+
+  if (defaults.project.findAddonByName('ember-native-dom-event-dispatcher')) {
+    options.vendorFiles = { 'jquery.js': null };
+  }
+
+  let app = new EmberAddon(defaults, options);
 
   /*
     This build file specifies the options for the dummy test app of this

--- a/package-lock.json
+++ b/package-lock.json
@@ -3810,6 +3810,15 @@
         "ember-cli-babel": "6.8.2"
       }
     },
+    "ember-native-dom-event-dispatcher": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/ember-native-dom-event-dispatcher/-/ember-native-dom-event-dispatcher-0.6.3.tgz",
+      "integrity": "sha1-Oy8Q3PgvmqpN0hGnBKxRH9hxRyA=",
+      "dev": true,
+      "requires": {
+        "ember-cli-babel": "6.8.2"
+      }
+    },
     "ember-resolver": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/ember-resolver/-/ember-resolver-4.5.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1984,6 +1984,134 @@
         }
       }
     },
+    "broccoli-templater": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/broccoli-templater/-/broccoli-templater-1.0.0.tgz",
+      "integrity": "sha1-fAVKrPWW0YaNGkQpH57HuQfTDs8=",
+      "dev": true,
+      "requires": {
+        "broccoli-filter": "0.1.14",
+        "broccoli-stew": "1.5.0",
+        "lodash.template": "3.6.2"
+      },
+      "dependencies": {
+        "broccoli-filter": {
+          "version": "0.1.14",
+          "resolved": "https://registry.npmjs.org/broccoli-filter/-/broccoli-filter-0.1.14.tgz",
+          "integrity": "sha1-I8rjiR/567e019sAxtzwNTXa960=",
+          "dev": true,
+          "requires": {
+            "broccoli-kitchen-sink-helpers": "0.2.9",
+            "broccoli-writer": "0.1.1",
+            "mkdirp": "0.3.5",
+            "promise-map-series": "0.2.3",
+            "quick-temp": "0.1.8",
+            "rsvp": "3.6.2",
+            "symlink-or-copy": "1.1.8",
+            "walk-sync": "0.1.3"
+          }
+        },
+        "broccoli-kitchen-sink-helpers": {
+          "version": "0.2.9",
+          "resolved": "https://registry.npmjs.org/broccoli-kitchen-sink-helpers/-/broccoli-kitchen-sink-helpers-0.2.9.tgz",
+          "integrity": "sha1-peCYbtjXb7WYS2jD8EUNOpbjbsw=",
+          "dev": true,
+          "requires": {
+            "glob": "5.0.15",
+            "mkdirp": "0.5.1"
+          },
+          "dependencies": {
+            "mkdirp": {
+              "version": "0.5.1",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+              "dev": true,
+              "requires": {
+                "minimist": "0.0.8"
+              }
+            }
+          }
+        },
+        "glob": {
+          "version": "5.0.15",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+          "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+          "dev": true,
+          "requires": {
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "lodash._reinterpolate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+          "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
+          "dev": true
+        },
+        "lodash.escape": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
+          "integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
+          "dev": true,
+          "requires": {
+            "lodash._root": "3.0.1"
+          }
+        },
+        "lodash.keys": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+          "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+          "dev": true,
+          "requires": {
+            "lodash._getnative": "3.9.1",
+            "lodash.isarguments": "3.1.0",
+            "lodash.isarray": "3.0.4"
+          }
+        },
+        "lodash.template": {
+          "version": "3.6.2",
+          "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
+          "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
+          "dev": true,
+          "requires": {
+            "lodash._basecopy": "3.0.1",
+            "lodash._basetostring": "3.0.1",
+            "lodash._basevalues": "3.0.0",
+            "lodash._isiterateecall": "3.0.9",
+            "lodash._reinterpolate": "3.0.0",
+            "lodash.escape": "3.2.0",
+            "lodash.keys": "3.1.2",
+            "lodash.restparam": "3.6.1",
+            "lodash.templatesettings": "3.1.1"
+          }
+        },
+        "lodash.templatesettings": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
+          "integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
+          "dev": true,
+          "requires": {
+            "lodash._reinterpolate": "3.0.0",
+            "lodash.escape": "3.2.0"
+          }
+        },
+        "mkdirp": {
+          "version": "0.3.5",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
+          "integrity": "sha1-3j5fiWHIjHh+4TaN+EmsRBPsqNc=",
+          "dev": true
+        },
+        "walk-sync": {
+          "version": "0.1.3",
+          "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.1.3.tgz",
+          "integrity": "sha1-igcmGgC9ps+xviXp8QD61XVG9YM=",
+          "dev": true
+        }
+      }
+    },
     "broccoli-test-helper": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/broccoli-test-helper/-/broccoli-test-helper-1.2.0.tgz",
@@ -3790,6 +3918,50 @@
       "dev": true,
       "requires": {
         "ember-cli-babel": "6.8.2"
+      }
+    },
+    "ember-fetch": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/ember-fetch/-/ember-fetch-3.4.0.tgz",
+      "integrity": "sha512-T8isYKpE4HljM49eTpgSmqgtoFLY85CC4gCZZwMtC4sRpbQd/mewTR/OUtfcUFsb6MKzu5sDugzEXCePXyp7fg==",
+      "dev": true,
+      "requires": {
+        "broccoli-funnel": "1.2.0",
+        "broccoli-stew": "1.5.0",
+        "broccoli-templater": "1.0.0",
+        "ember-cli-babel": "6.8.2",
+        "node-fetch": "2.0.0-alpha.9",
+        "whatwg-fetch": "2.0.3"
+      },
+      "dependencies": {
+        "broccoli-funnel": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-1.2.0.tgz",
+          "integrity": "sha1-zdw6/F/xaFqAI0iP/3TOb7WlEpY=",
+          "dev": true,
+          "requires": {
+            "array-equal": "1.0.0",
+            "blank-object": "1.0.2",
+            "broccoli-plugin": "1.3.0",
+            "debug": "2.6.9",
+            "exists-sync": "0.0.4",
+            "fast-ordered-set": "1.0.3",
+            "fs-tree-diff": "0.5.6",
+            "heimdalljs": "0.2.5",
+            "minimatch": "3.0.4",
+            "mkdirp": "0.5.1",
+            "path-posix": "1.0.0",
+            "rimraf": "2.6.2",
+            "symlink-or-copy": "1.1.8",
+            "walk-sync": "0.3.2"
+          }
+        },
+        "node-fetch": {
+          "version": "2.0.0-alpha.9",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.0.0-alpha.9.tgz",
+          "integrity": "sha512-I7wP1QkmBNX1mt4BS5zyLRTegl5Ii+MSalpfFefn+EZFrGVsdfCvLTKt9eHkNlU4phKgp3tqLWW8VXDcCm9m9w==",
+          "dev": true
+        }
       }
     },
     "ember-inflector": {
@@ -6971,6 +7143,18 @@
         "lodash.isarray": "3.0.4"
       }
     },
+    "lodash._basetostring": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
+      "integrity": "sha1-0YYdh3+CSlL2aYMtyvPuFVZqB9U=",
+      "dev": true
+    },
+    "lodash._basevalues": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
+      "integrity": "sha1-W3dXYoAr3j0yl1A+JjAIIP32Ybc=",
+      "dev": true
+    },
     "lodash._bindcallback": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
@@ -7059,6 +7243,12 @@
         "lodash._htmlescapes": "2.3.0",
         "lodash.keys": "2.3.0"
       }
+    },
+    "lodash._root": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
+      "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI=",
+      "dev": true
     },
     "lodash._setbinddata": {
       "version": "2.3.0",
@@ -9568,6 +9758,12 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.2.tgz",
       "integrity": "sha1-Dhh4HeYpoYMIzhSBZQ9n/6JpOl0=",
+      "dev": true
+    },
+    "whatwg-fetch": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
+      "integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ=",
       "dev": true
     },
     "which": {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "ember-debug-handlers-polyfill": "^1.0.3",
     "ember-disable-prototype-extensions": "^1.1.2",
     "ember-export-application-global": "^2.0.0",
+    "ember-fetch": "^3.4.0",
     "ember-load-initializers": "^1.0.0",
     "ember-native-dom-event-dispatcher": "^0.6.3",
     "ember-resolver": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "ember-disable-prototype-extensions": "^1.1.2",
     "ember-export-application-global": "^2.0.0",
     "ember-load-initializers": "^1.0.0",
+    "ember-native-dom-event-dispatcher": "^0.6.3",
     "ember-resolver": "^4.0.0",
     "ember-source": "~2.15.0",
     "ember-welcome-page": "^3.0.0",

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,5 +1,0 @@
-{{!-- The following component displays Ember's default welcome message. --}}
-{{welcome-page}}
-{{!-- Feel free to remove this! --}}
-
-{{outlet}}

--- a/tests/helpers/events.js
+++ b/tests/helpers/events.js
@@ -1,0 +1,134 @@
+import { run } from '@ember/runloop';
+import { merge } from '@ember/polyfills';
+
+const DEFAULT_EVENT_OPTIONS = { canBubble: true, cancelable: true };
+const KEYBOARD_EVENT_TYPES = ['keydown', 'keypress', 'keyup'];
+const MOUSE_EVENT_TYPES = [
+  'click',
+  'mousedown',
+  'mouseup',
+  'dblclick',
+  'mouseenter',
+  'mouseleave',
+  'mousemove',
+  'mouseout',
+  'mouseover',
+];
+
+export const elMatches =
+  typeof Element !== 'undefined' &&
+  (Element.prototype.matches ||
+    Element.prototype.matchesSelector ||
+    Element.prototype.mozMatchesSelector ||
+    Element.prototype.msMatchesSelector ||
+    Element.prototype.oMatchesSelector ||
+    Element.prototype.webkitMatchesSelector);
+
+export function matches(el, selector) {
+  return elMatches.call(el, selector);
+}
+
+export function focus(el) {
+  if (!el) {
+    return;
+  }
+  if (matches(el, 'input, textarea, select, button, [contenteditable=true]')) {
+    let type = el.type;
+    if (type !== 'checkbox' && type !== 'radio' && type !== 'hidden') {
+      run(function() {
+        // Firefox does not trigger the `focusin` event if the window
+        // does not have focus. If the document doesn't have focus just
+        // use trigger('focusin') instead.
+
+        if (!document.hasFocus || document.hasFocus()) {
+          el.focus();
+        }
+      });
+    }
+  }
+}
+
+export function fireEvent(element, type, options = {}) {
+  if (!element) {
+    return;
+  }
+  let event;
+  if (KEYBOARD_EVENT_TYPES.indexOf(type) > -1) {
+    event = buildKeyboardEvent(type, options);
+  } else if (MOUSE_EVENT_TYPES.indexOf(type) > -1) {
+    let rect = element.getBoundingClientRect();
+    let x = rect.left + 1;
+    let y = rect.top + 1;
+    let simulatedCoordinates = {
+      screenX: x + 5,
+      screenY: y + 95,
+      clientX: x,
+      clientY: y,
+    };
+    event = buildMouseEvent(type, merge(simulatedCoordinates, options));
+  } else {
+    event = buildBasicEvent(type, options);
+  }
+  element.dispatchEvent(event);
+}
+
+function buildBasicEvent(type, options = {}) {
+  let event = document.createEvent('Events');
+  event.initEvent(type, true, true);
+  merge(event, options);
+  return event;
+}
+
+function buildMouseEvent(type, options = {}) {
+  let event;
+  try {
+    event = document.createEvent('MouseEvents');
+    let eventOpts = merge({}, DEFAULT_EVENT_OPTIONS);
+    merge(eventOpts, options);
+
+    event.initMouseEvent(
+      type,
+      eventOpts.canBubble,
+      eventOpts.cancelable,
+      window,
+      eventOpts.detail,
+      eventOpts.screenX,
+      eventOpts.screenY,
+      eventOpts.clientX,
+      eventOpts.clientY,
+      eventOpts.ctrlKey,
+      eventOpts.altKey,
+      eventOpts.shiftKey,
+      eventOpts.metaKey,
+      eventOpts.button,
+      eventOpts.relatedTarget
+    );
+  } catch (e) {
+    event = buildBasicEvent(type, options);
+  }
+  return event;
+}
+
+function buildKeyboardEvent(type, options = {}) {
+  let event;
+  try {
+    event = document.createEvent('KeyEvents');
+    let eventOpts = merge({}, DEFAULT_EVENT_OPTIONS);
+    merge(eventOpts, options);
+    event.initKeyEvent(
+      type,
+      eventOpts.canBubble,
+      eventOpts.cancelable,
+      window,
+      eventOpts.ctrlKey,
+      eventOpts.altKey,
+      eventOpts.shiftKey,
+      eventOpts.metaKey,
+      eventOpts.keyCode,
+      eventOpts.charCode
+    );
+  } catch (e) {
+    event = buildBasicEvent(type, options);
+  }
+  return event;
+}

--- a/tests/helpers/has-jquery.js
+++ b/tests/helpers/has-jquery.js
@@ -1,0 +1,3 @@
+export default function() {
+  return !!self.jQuery;
+}

--- a/tests/helpers/resolver.js
+++ b/tests/helpers/resolver.js
@@ -4,6 +4,7 @@ import { dasherize } from '@ember/string';
 import AppResolver from '../../resolver';
 import config from '../../config/environment';
 import { setResolver } from 'ember-test-helpers';
+import require from 'require';
 
 const Resolver = AppResolver.extend({
   registry: {},
@@ -33,6 +34,17 @@ export default {
 };
 
 export function createCustomResolver(registry) {
+  if (require.has('ember-native-dom-event-dispatcher')) {
+    // the raw value looked up by ember and these test helpers
+    registry[
+      'event_dispatcher:main'
+    ] = require('ember-native-dom-event-dispatcher').default;
+    // the normalized value looked up
+    registry[
+      'event-dispatcher:main'
+    ] = require('ember-native-dom-event-dispatcher').default;
+  }
+
   var Resolver = Ember.DefaultResolver.extend({
     registry: null,
 

--- a/tests/helpers/resolver.js
+++ b/tests/helpers/resolver.js
@@ -1,17 +1,19 @@
 import Ember from 'ember';
 import { run } from '@ember/runloop';
 import { dasherize } from '@ember/string';
-import Resolver from '../../resolver';
+import AppResolver from '../../resolver';
 import config from '../../config/environment';
 import { setResolver } from 'ember-test-helpers';
 
-const resolver = Resolver.create({
+const Resolver = AppResolver.extend({
   registry: {},
 
   resolve(fullName) {
-    return this.registry[fullName];
+    return this.registry[fullName] || this._super(...arguments);
   },
 });
+
+const resolver = Resolver.create();
 
 resolver.namespace = {
   modulePrefix: config.modulePrefix,

--- a/tests/unit/test-module-for-acceptance-test.js
+++ b/tests/unit/test-module-for-acceptance-test.js
@@ -1,5 +1,4 @@
 import { test } from 'qunit';
-import $ from 'jquery';
 import EmberRouter from '@ember/routing/router';
 import EmberApplication from '@ember/application';
 import { TestModuleForAcceptance } from 'ember-test-helpers';
@@ -40,7 +39,8 @@ moduleForAcceptance('TestModuleForAcceptance | Lifecycle', {
 
   afterTeardown(assert) {
     assert.strictEqual(getContext(), undefined);
-    assert.strictEqual($('#ember-testing').children().length, 0);
+    let testingElement = document.getElementById('ember-testing');
+    assert.strictEqual(testingElement.children.length, 0);
   },
 });
 
@@ -63,7 +63,8 @@ test('Basic acceptance test using instance test helpers', function(assert) {
   this.application.testHelpers.visit('/');
 
   this.application.testHelpers.andThen(function() {
-    assert.equal($('#ember-testing').text(), 'This is the index page.');
+    let testingElement = document.getElementById('ember-testing');
+    assert.equal(testingElement.textContent, 'This is the index page.');
   });
 });
 
@@ -71,7 +72,8 @@ test('Basic acceptance test using global test helpers', function(assert) {
   window.visit('/');
 
   window.andThen(function() {
-    assert.equal($('#ember-testing').text(), 'This is the index page.');
+    let testingElement = document.getElementById('ember-testing');
+    assert.equal(testingElement.textContent, 'This is the index page.');
   });
 });
 

--- a/tests/unit/test-module-for-component-test.js
+++ b/tests/unit/test-module-for-component-test.js
@@ -14,6 +14,7 @@ import hasEmberVersion from 'ember-test-helpers/has-ember-version';
 import { setResolverRegistry } from '../helpers/resolver';
 import wait from 'ember-test-helpers/wait';
 import qunitModuleFor from '../helpers/qunit-module-for';
+import hasjQuery from '../helpers/has-jquery';
 import hbs from 'htmlbars-inline-precompile';
 
 var Service = EmberService || EmberObject;
@@ -100,22 +101,31 @@ test('renders', function(assert) {
   assert.equal(component._state, 'inDOM');
 });
 
-test('append', function(assert) {
-  assert.expect(4);
+if (hasjQuery()) {
+  test('append', function(assert) {
+    assert.expect(4);
 
-  var $el;
-  var component;
+    var $el;
+    var component;
 
-  component = this.subject();
-  assert.equal(component._state, 'preRender');
-  $el = this.append();
-  assert.equal(component._state, 'inDOM');
-  assert.ok($el && $el.length, 'append returns $el');
+    component = this.subject();
+    assert.equal(component._state, 'preRender');
+    $el = this.append();
+    assert.equal(component._state, 'inDOM');
+    assert.ok($el && $el.length, 'append returns $el');
 
-  assert.deprecationsInclude(
-    'this.append() is deprecated. Please use this.render() or this.$() instead.'
-  );
-});
+    assert.deprecationsInclude(
+      'this.append() is deprecated. Please use this.render() or this.$() instead.'
+    );
+  });
+
+  test('$', function(assert) {
+    this.subject({ name: 'green' });
+
+    assert.equal(this.$('.color-name').text(), 'green');
+    assert.equal(this.$().text(), 'Pretty Color: green');
+  });
+}
 
 test('yields', function(assert) {
   assert.expect(2);
@@ -182,13 +192,6 @@ test('template', function(assert) {
   });
 
   assert.equal(this._element.textContent, 'Pretty Color: green');
-});
-
-test('$', function(assert) {
-  this.subject({ name: 'green' });
-
-  assert.equal(this.$('.color-name').text(), 'green');
-  assert.equal(this.$().text(), 'Pretty Color: green');
 });
 
 test('it can access the element', function(assert) {

--- a/tests/unit/test-module-for-component-test.js
+++ b/tests/unit/test-module-for-component-test.js
@@ -16,7 +16,7 @@ import wait from 'ember-test-helpers/wait';
 import qunitModuleFor from '../helpers/qunit-module-for';
 import hasjQuery from '../helpers/has-jquery';
 import hbs from 'htmlbars-inline-precompile';
-import { fireEvent } from '../helpers/events';
+import { fireEvent, focus, blur } from '../helpers/events';
 
 var Service = EmberService || EmberObject;
 
@@ -119,13 +119,6 @@ if (hasjQuery()) {
       'this.append() is deprecated. Please use this.render() or this.$() instead.'
     );
   });
-
-  test('$', function(assert) {
-    this.subject({ name: 'green' });
-
-    assert.equal(this.$('.color-name').text(), 'green');
-    assert.equal(this.$().text(), 'Pretty Color: green');
-  });
 }
 
 test('yields', function(assert) {
@@ -201,6 +194,15 @@ test('it can access the element', function(assert) {
 
   assert.equal(this._element.textContent, 'Pretty Color: green');
 });
+
+if (hasjQuery()) {
+  test('$', function(assert) {
+    this.subject({ name: 'green' });
+
+    assert.equal(this.$('.color-name').text(), 'green');
+    assert.equal(this.$().text(), 'Pretty Color: green');
+  });
+}
 
 moduleForComponent(
   'pretty-color',
@@ -507,13 +509,14 @@ test('it supports dom triggered focus events', function(assert) {
     }),
   });
   this.render(hbs`{{my-input}}`);
+
   let input = this._element.querySelector('input');
   assert.equal(input.value, 'init');
 
-  fireEvent(input, 'focusin');
+  focus(input);
   assert.equal(input.value, 'focusin');
 
-  fireEvent(input, 'focusout');
+  blur(input);
   assert.equal(input.value, 'focusout');
 });
 

--- a/tests/unit/test-module-for-component-test.js
+++ b/tests/unit/test-module-for-component-test.js
@@ -16,6 +16,7 @@ import wait from 'ember-test-helpers/wait';
 import qunitModuleFor from '../helpers/qunit-module-for';
 import hasjQuery from '../helpers/has-jquery';
 import hbs from 'htmlbars-inline-precompile';
+import { fireEvent } from '../helpers/events';
 
 var Service = EmberService || EmberObject;
 
@@ -484,9 +485,10 @@ test('it supports updating an input', function(assert) {
     }),
   });
   this.render(hbs`{{my-input value=value}}`);
-  this.$('input')
-    .val('1')
-    .change();
+  let input = this._element.querySelector('input');
+  input.value = '1';
+
+  fireEvent(input, 'change');
   assert.equal(this.get('value'), '1');
 });
 
@@ -505,13 +507,14 @@ test('it supports dom triggered focus events', function(assert) {
     }),
   });
   this.render(hbs`{{my-input}}`);
-  assert.equal(this.$('input').val(), 'init');
+  let input = this._element.querySelector('input');
+  assert.equal(input.value, 'init');
 
-  this.$('input').trigger('focusin');
-  assert.equal(this.$('input').val(), 'focusin');
+  fireEvent(input, 'focusin');
+  assert.equal(input.value, 'focusin');
 
-  this.$('input').trigger('focusout');
-  assert.equal(this.$('input').val(), 'focusout');
+  fireEvent(input, 'focusout');
+  assert.equal(input.value, 'focusout');
 });
 
 moduleForComponent('Component Integration Tests: render during setup', {
@@ -824,7 +827,7 @@ test('it can set and get properties', function(assert) {
   });
   this.render(hbs`{{my-component}}`);
 
-  let testElement = this.$()[0];
+  let testElement = this._element;
   let instanceElement = instance.element;
 
   assert.ok(
@@ -884,6 +887,6 @@ test('does not require manual run wrapping', function(assert) {
       return wait();
     })
     .then(() => {
-      assert.equal(this.$().text(), 'async value');
+      assert.equal(this._element.textContent, 'async value');
     });
 });

--- a/tests/unit/test-module-for-integration-test.js
+++ b/tests/unit/test-module-for-integration-test.js
@@ -9,6 +9,7 @@ import { TestModuleForIntegration } from 'ember-test-helpers';
 import { setResolverRegistry, createCustomResolver } from '../helpers/resolver';
 import qunitModuleFor from '../helpers/qunit-module-for';
 import hbs from 'htmlbars-inline-precompile';
+import { fireEvent } from '../helpers/events';
 
 const Service = EmberService || EmberObject;
 
@@ -91,9 +92,10 @@ test('it supports updating an input', function(assert) {
     }),
   });
   this.render(hbs`{{my-input value=value}}`);
-  this.$('input')
-    .val('1')
-    .change();
+
+  let input = this._element.querySelector('input');
+  input.value = '1';
+  fireEvent(input, 'change');
   assert.equal(this.get('value'), '1');
 });
 
@@ -112,13 +114,14 @@ test('it supports dom triggered focus events', function(assert) {
     }),
   });
   this.render(hbs`{{my-input}}`);
-  assert.equal(this.$('input').val(), 'init');
+  let input = this._element.querySelector('input');
+  assert.equal(input.value, 'init');
 
-  this.$('input').trigger('focusin');
-  assert.equal(this.$('input').val(), 'focusin');
+  fireEvent(input, 'focusin');
+  assert.equal(input.value, 'focusin');
 
-  this.$('input').trigger('focusout');
-  assert.equal(this.$('input').val(), 'focusout');
+  fireEvent(input, 'focusout');
+  assert.equal(input.value, 'focusout');
 });
 
 test('`toString` returns the test name', function(assert) {

--- a/tests/unit/test-module-for-integration-test.js
+++ b/tests/unit/test-module-for-integration-test.js
@@ -9,7 +9,7 @@ import { TestModuleForIntegration } from 'ember-test-helpers';
 import { setResolverRegistry, createCustomResolver } from '../helpers/resolver';
 import qunitModuleFor from '../helpers/qunit-module-for';
 import hbs from 'htmlbars-inline-precompile';
-import { fireEvent } from '../helpers/events';
+import { fireEvent, focus, blur } from '../helpers/events';
 
 const Service = EmberService || EmberObject;
 
@@ -117,10 +117,10 @@ test('it supports dom triggered focus events', function(assert) {
   let input = this._element.querySelector('input');
   assert.equal(input.value, 'init');
 
-  fireEvent(input, 'focusin');
+  focus(input);
   assert.equal(input.value, 'focusin');
 
-  fireEvent(input, 'focusout');
+  blur(input);
   assert.equal(input.value, 'focusout');
 });
 


### PR DESCRIPTION
* add test scenarios that run without jQuery (defaulting to jQueryless setup)
* refactor all tests to avoid jQuery usage
* embed custom eventing test helpers (until we can bring ember-native-dom-helpers into the fold)