### PR TITLE
Expose importable helper functions.

### DIFF
--- a/addon-test-support/index.js
+++ b/addon-test-support/index.js
@@ -7,7 +7,12 @@ export { default as TestModuleForModel } from './legacy-0-6-x/test-module-for-mo
 export { setResolver } from './resolver';
 export { default as setupContext, getContext, setContext, unsetContext } from './setup-context';
 export { default as teardownContext } from './teardown-context';
-export { default as setupRenderingContext } from './setup-rendering-context';
+export {
+  default as setupRenderingContext,
+  render,
+  clearRender,
+  element,
+} from './setup-rendering-context';
 export { default as teardownRenderingContext } from './teardown-rendering-context';
 
 import Ember from 'ember';

--- a/addon-test-support/index.js
+++ b/addon-test-support/index.js
@@ -7,12 +7,7 @@ export { default as TestModuleForModel } from './legacy-0-6-x/test-module-for-mo
 export { setResolver } from './resolver';
 export { default as setupContext, getContext, setContext, unsetContext } from './setup-context';
 export { default as teardownContext } from './teardown-context';
-export {
-  default as setupRenderingContext,
-  render,
-  clearRender,
-  element,
-} from './setup-rendering-context';
+export { default as setupRenderingContext, render, clearRender } from './setup-rendering-context';
 export { default as teardownRenderingContext } from './teardown-rendering-context';
 
 import Ember from 'ember';

--- a/addon-test-support/setup-rendering-context.js
+++ b/addon-test-support/setup-rendering-context.js
@@ -29,8 +29,6 @@ export function clearRender() {
   return context.clearRender();
 }
 
-export let element = undefined;
-
 /*
  * Responsible for:
  *
@@ -78,7 +76,7 @@ export default function(context) {
     outlets: {},
   };
 
-  let hasRendered;
+  let element, hasRendered;
   let templateId = 0;
 
   if (hasOutletTemplate) {

--- a/addon-test-support/setup-rendering-context.js
+++ b/addon-test-support/setup-rendering-context.js
@@ -3,8 +3,33 @@ import { run, next } from '@ember/runloop';
 import { Promise } from 'rsvp';
 import Ember from 'ember';
 import global from './global';
+import { getContext } from './setup-context';
 
 export const RENDERING_CLEANUP = Object.create(null);
+
+export function render(template) {
+  let context = getContext();
+
+  if (!context || typeof context.render !== 'function') {
+    throw new Error('Cannot call `render` without having first called `setupRenderingContext`.');
+  }
+
+  return context.render(template);
+}
+
+export function clearRender() {
+  let context = getContext();
+
+  if (!context || typeof context.clearRender !== 'function') {
+    throw new Error(
+      'Cannot call `clearRender` without having first called `setupRenderingContext`.'
+    );
+  }
+
+  return context.clearRender();
+}
+
+export let element = undefined;
 
 /*
  * Responsible for:
@@ -22,6 +47,7 @@ export default function(context) {
   RENDERING_CLEANUP[guid] = [
     () => {
       rootTestElement.innerHTML = fixtureResetValue;
+      element = undefined;
     },
   ];
 
@@ -52,7 +78,7 @@ export default function(context) {
     outlets: {},
   };
 
-  let element, hasRendered;
+  let hasRendered;
   let templateId = 0;
 
   if (hasOutletTemplate) {

--- a/tests/unit/setup-rendering-context-test.js
+++ b/tests/unit/setup-rendering-context-test.js
@@ -8,6 +8,9 @@ import {
   setupRenderingContext,
   teardownContext,
   teardownRenderingContext,
+  render,
+  clearRender,
+  element,
 } from 'ember-test-helpers';
 import hasEmberVersion from 'ember-test-helpers/has-ember-version';
 import hasjQuery from '../helpers/has-jquery';
@@ -302,5 +305,32 @@ module('setupRenderingContext', function(hooks) {
 
     assert.equal(this.get('foo'), 'updated!');
     assert.equal(this.get('bar'), 'updated bar!');
+  });
+
+  test('imported `render` can be used instead of this.render', async function(assert) {
+    await render(hbs`yippie!!`);
+
+    assert.equal(this.element.textContent, 'yippie!!');
+  });
+
+  test('imported `element` can be used instead of this.element', async function(assert) {
+    await this.render(hbs`yippie!!`);
+
+    assert.equal(element.textContent, 'yippie!!');
+    assert.equal(element, this.element);
+  });
+
+  test('imported clearRender can be used instead of this.clearRender', async function(assert) {
+    let testingRootElement = document.getElementById('ember-testing');
+
+    await this.render(hbs`<p>Hello!</p>`);
+
+    assert.equal(this.element.textContent, 'Hello!', 'has rendered content');
+    assert.equal(testingRootElement.textContent, 'Hello!', 'has rendered content');
+
+    await clearRender();
+    assert.equal(this.element, undefined, 'this.element is reset');
+
+    assert.equal(testingRootElement.textContent, '', 'content is cleared');
   });
 });

--- a/tests/unit/setup-rendering-context-test.js
+++ b/tests/unit/setup-rendering-context-test.js
@@ -10,7 +10,6 @@ import {
   teardownRenderingContext,
   render,
   clearRender,
-  element,
 } from 'ember-test-helpers';
 import hasEmberVersion from 'ember-test-helpers/has-ember-version';
 import hasjQuery from '../helpers/has-jquery';
@@ -311,13 +310,6 @@ module('setupRenderingContext', function(hooks) {
     await render(hbs`yippie!!`);
 
     assert.equal(this.element.textContent, 'yippie!!');
-  });
-
-  test('imported `element` can be used instead of this.element', async function(assert) {
-    await this.render(hbs`yippie!!`);
-
-    assert.equal(element.textContent, 'yippie!!');
-    assert.equal(element, this.element);
   });
 
   test('imported clearRender can be used instead of this.clearRender', async function(assert) {


### PR DESCRIPTION
These functions can be used instead of repeating `this.` throughout the testing code.

Example:

```js
import { module, test } from 'qunit';
import { setupRenderingTest, render, element } from 'ember-qunit';
import hbs from 'htmlbars-inline-precompile';

module('x-foo', function(hooks) {
  setupRenderingTest(hooks);

  test('renders', async function(assert) {
    assert.expect(1);

    await render(hbs`{{pretty-color name="red"}}`);

    assert.equal(element.querySelector('.color-name').textContent, 'red');
  });
});
```

This is essentially the compromise made with the rest of the core team while working on the the "Grand Unified Testing RFC". The helpers will continue to live on `this` (for easy discoverability), but are also importable (for cleaner looking tests). Using the non `this.` form of helpers obviously means that we cannot run concurrent tests, but that is extremely unlikely to work anyways.