### PR TITLE
Continue to flesh out more tests for new API's.

### DIFF
--- a/tests/helpers/events.js
+++ b/tests/helpers/events.js
@@ -39,6 +39,13 @@ function isFocusable(el) {
   return focusableTags.indexOf(tagName) > -1 || el.contentEditable === 'true';
 }
 
+export function click(el, options = {}) {
+  run(() => fireEvent(el, 'mousedown', options));
+  focus(el);
+  run(() => fireEvent(el, 'mouseup', options));
+  run(() => fireEvent(el, 'click', options));
+}
+
 export function focus(el) {
   if (!el) {
     return;

--- a/tests/unit/setup-context-test.js
+++ b/tests/unit/setup-context-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import Service from '@ember/service';
+import Service, { inject as injectService } from '@ember/service';
 import { setupContext, getContext } from 'ember-test-helpers';
 import hasEmberVersion from 'ember-test-helpers/has-ember-version';
 import { setResolverRegistry, createCustomResolver } from '../helpers/resolver';
@@ -90,9 +90,33 @@ module('setupContext', function(hooks) {
         })
       );
 
-      let subject = context.owner.lookup('service:Foo');
+      let subject = context.owner.lookup('service:foo');
 
       assert.equal(subject.someMethod(), 'hello thar!');
+    });
+
+    test('can access a service instance (instead of this.inject.service("thing") in 0.6)', function(
+      assert
+    ) {
+      context.owner.register('service:bar', Service.extend());
+      context.owner.register(
+        'service:foo',
+        Service.extend({
+          bar: injectService(),
+          someMethod() {
+            this.set('bar.someProp', 'derp');
+          },
+        })
+      );
+
+      let subject = context.owner.lookup('service:foo');
+      let bar = context.owner.lookup('service:bar');
+
+      assert.notOk(bar.get('someProp'), 'precond - initially undefined');
+
+      subject.someMethod();
+
+      assert.equal(bar.get('someProp'), 'derp', 'property updated');
     });
   });
 

--- a/tests/unit/setup-context-test.js
+++ b/tests/unit/setup-context-test.js
@@ -79,6 +79,21 @@ module('setupContext', function(hooks) {
     test('it calls setContext with the provided context', function(assert) {
       assert.equal(getContext(), context);
     });
+
+    test('can be used for unit style testing', function(assert) {
+      context.owner.register(
+        'service:foo',
+        Service.extend({
+          someMethod() {
+            return 'hello thar!';
+          },
+        })
+      );
+
+      let subject = context.owner.lookup('service:Foo');
+
+      assert.equal(subject.someMethod(), 'hello thar!');
+    });
   });
 
   module('with custom options', function() {

--- a/tests/unit/setup-rendering-context-test.js
+++ b/tests/unit/setup-rendering-context-test.js
@@ -292,6 +292,9 @@ module('setupRenderingContext', function(hooks) {
       hbs`<button {{action 'clicked'}}>{{foo}}</button>`
     );
 
+    // using two arguments here to ensure the two way binding
+    // works both for things rendered in the component's layout
+    // and those only used in the components JS file
     await this.render(hbs`{{my-component foo=foo bar=bar}}`);
     click(this.element.querySelector('button'));
 

--- a/tests/unit/setup-rendering-context-test.js
+++ b/tests/unit/setup-rendering-context-test.js
@@ -205,19 +205,19 @@ module('setupRenderingContext', function(hooks) {
   });
 
   test('can update a passed in argument with an <input>', async function(assert) {
-    this.owner.register(
-      'component:my-input',
-      TextField.extend({
-        value: null,
-      })
-    );
+    this.owner.register('component:my-input', TextField.extend({}));
 
     await this.render(hbs`{{my-input value=value}}`);
 
     let input = this.element.querySelector('input');
-    input.value = '1';
 
+    assert.strictEqual(this.get('value'), undefined, 'precond - property is initially null');
+    assert.equal(input.value, '', 'precond - element value is initially empty');
+
+    // trigger the change
+    input.value = '1';
     fireEvent(input, 'change');
+
     assert.equal(this.get('value'), '1');
   });
 

--- a/tests/unit/setup-rendering-context-test.js
+++ b/tests/unit/setup-rendering-context-test.js
@@ -1,6 +1,7 @@
 import { module, test, skip } from 'qunit';
 import Service from '@ember/service';
 import Component from '@ember/component';
+import TextField from '@ember/component/text-field';
 import { helper } from '@ember/component/helper';
 import {
   setupContext,
@@ -11,6 +12,7 @@ import {
 import hasEmberVersion from 'ember-test-helpers/has-ember-version';
 import hasjQuery from '../helpers/has-jquery';
 import { setResolverRegistry } from '../helpers/resolver';
+import { focus, blur, fireEvent, click } from '../helpers/events';
 import hbs from 'htmlbars-inline-precompile';
 
 module('setupRenderingContext', function(hooks) {
@@ -114,5 +116,188 @@ module('setupRenderingContext', function(hooks) {
     await this.render(hbs`{{outer-comp}}`);
 
     assert.equal(this.element.textContent, 'outerinnerouter');
+  });
+
+  test('can use the component helper in its layout', async function(assert) {
+    this.owner.register('template:components/x-foo', hbs`x-foo here`);
+
+    await this.render(hbs`{{component 'x-foo'}}`);
+
+    assert.equal(this.element.textContent, 'x-foo here');
+  });
+
+  test('can create a component instance for direct testing without a template', function(assert) {
+    this.owner.register(
+      'component:foo-bar',
+      Component.extend({
+        someMethod() {
+          return 'hello thar!';
+        },
+      })
+    );
+
+    let subject;
+    if (hasEmberVersion(2, 12)) {
+      subject = this.owner.lookup('component:foo-bar');
+    } else {
+      subject = this.owner._lookupFactory('component:foo-bar').create();
+    }
+
+    assert.equal(subject.someMethod(), 'hello thar!');
+  });
+
+  test('can handle a click event', async function(assert) {
+    assert.expect(2);
+
+    this.owner.register(
+      'component:x-foo',
+      Component.extend({
+        click() {
+          assert.ok(true, 'click was fired');
+        },
+      })
+    );
+    this.owner.register('template:components/x-foo', hbs`<button>Click me!</button>`);
+
+    await this.render(hbs`{{x-foo}}`);
+
+    assert.equal(this.element.textContent, 'Click me!', 'precond - component was rendered');
+    click(this.element.querySelector('button'));
+  });
+
+  test('can use action based event handling', async function(assert) {
+    assert.expect(2);
+
+    this.owner.register(
+      'component:x-foo',
+      Component.extend({
+        actions: {
+          clicked() {
+            assert.ok(true, 'click was fired');
+          },
+        },
+      })
+    );
+    this.owner.register(
+      'template:components/x-foo',
+      hbs`<button {{action 'clicked'}}>Click me!</button>`
+    );
+
+    await this.render(hbs`{{x-foo}}`);
+
+    assert.equal(this.element.textContent, 'Click me!', 'precond - component was rendered');
+    click(this.element.querySelector('button'));
+  });
+
+  test('can pass function to be used as a "closure action"', async function(assert) {
+    assert.expect(2);
+
+    this.owner.register(
+      'template:components/x-foo',
+      hbs`<button onclick={{action clicked}}>Click me!</button>`
+    );
+
+    this.set('clicked', () => assert.ok(true, 'action was triggered'));
+    await this.render(hbs`{{x-foo clicked=clicked}}`);
+
+    assert.equal(this.element.textContent, 'Click me!', 'precond - component was rendered');
+    click(this.element.querySelector('button'));
+  });
+
+  test('can update a passed in argument with an <input>', async function(assert) {
+    this.owner.register(
+      'component:my-input',
+      TextField.extend({
+        value: null,
+      })
+    );
+
+    await this.render(hbs`{{my-input value=value}}`);
+
+    let input = this.element.querySelector('input');
+    input.value = '1';
+
+    fireEvent(input, 'change');
+    assert.equal(this.get('value'), '1');
+  });
+
+  test('it supports dom triggered focus events', async function(assert) {
+    this.owner.register(
+      'component:my-input',
+      TextField.extend({
+        init() {
+          this._super(...arguments);
+
+          this.set('value', 'init');
+        },
+        focusIn() {
+          this.set('value', 'focusin');
+        },
+        focusOut() {
+          this.set('value', 'focusout');
+        },
+      })
+    );
+    await this.render(hbs`{{my-input}}`);
+
+    let input = this.element.querySelector('input');
+    assert.equal(input.value, 'init');
+
+    focus(input);
+    assert.equal(input.value, 'focusin');
+
+    blur(input);
+    assert.equal(input.value, 'focusout');
+  });
+
+  test('two way bound arguments are updated', async function(assert) {
+    this.owner.register(
+      'component:my-component',
+      Component.extend({
+        actions: {
+          clicked() {
+            this.set('foo', 'updated!');
+          },
+        },
+      })
+    );
+    this.owner.register(
+      'template:components/my-component',
+      hbs`<button {{action 'clicked'}}>{{foo}}</button>`
+    );
+
+    this.set('foo', 'original');
+    await this.render(hbs`{{my-component foo=foo}}`);
+    assert.equal(this.element.textContent, 'original', 'value after initial render');
+
+    click(this.element.querySelector('button'));
+    assert.equal(this.element.textContent, 'updated!', 'value after updating');
+    assert.equal(this.get('foo'), 'updated!');
+  });
+
+  test('two way bound arguments are available after clearRender is called', async function(assert) {
+    this.owner.register(
+      'component:my-component',
+      Component.extend({
+        actions: {
+          clicked() {
+            this.set('foo', 'updated!');
+            this.set('bar', 'updated bar!');
+          },
+        },
+      })
+    );
+    this.owner.register(
+      'template:components/my-component',
+      hbs`<button {{action 'clicked'}}>{{foo}}</button>`
+    );
+
+    await this.render(hbs`{{my-component foo=foo bar=bar}}`);
+    click(this.element.querySelector('button'));
+
+    await this.clearRender();
+
+    assert.equal(this.get('foo'), 'updated!');
+    assert.equal(this.get('bar'), 'updated bar!');
   });
 });


### PR DESCRIPTION
Carries over many tests from the previous (now "legacy-0-6-x" suite) into the new system. This is largely to ensure that the regressions previously caught by these tests, are still checked for long after the legacy-0-6-x suite is gone.