### PR TITLE
Set Ember.testing only while actually running a test.

### DIFF
--- a/addon-test-support/index.js
+++ b/addon-test-support/index.js
@@ -10,6 +10,3 @@ export { default as teardownContext } from './teardown-context';
 export { default as setupRenderingContext, render, clearRender } from './setup-rendering-context';
 export { default as teardownRenderingContext } from './teardown-rendering-context';
 export { default as settled } from './settled';
-
-import Ember from 'ember';
-Ember.testing = true;

--- a/addon-test-support/legacy-0-6-x/abstract-test-module.js
+++ b/addon-test-support/legacy-0-6-x/abstract-test-module.js
@@ -23,6 +23,7 @@ export default class {
   }
 
   setup(assert) {
+    Ember.testing = true;
     return this.invokeSteps(this.setupSteps, this, assert).then(() => {
       this.contextualizeCallbacks();
       return this.invokeSteps(this.contextualizedSetupSteps, this.context, assert);
@@ -37,6 +38,9 @@ export default class {
       .then(() => {
         this.cache = null;
         this.cachedCalls = null;
+      })
+      .finally(function() {
+        Ember.testing = false;
       });
   }
 

--- a/addon-test-support/setup-context.js
+++ b/addon-test-support/setup-context.js
@@ -3,6 +3,7 @@ import { set, setProperties, get, getProperties } from '@ember/object';
 import buildOwner from './build-owner';
 import { _setupPromiseListeners } from './ext/rsvp';
 import { _setupAJAXHooks } from './settled';
+import Ember from 'ember';
 
 let __test_context__;
 
@@ -28,6 +29,7 @@ export function unsetContext() {
  * - setting up RSVP promise integration
  */
 export default function(context, options = {}) {
+  Ember.testing = true;
   setContext(context);
 
   let resolver = options.resolver;

--- a/addon-test-support/teardown-context.js
+++ b/addon-test-support/teardown-context.js
@@ -1,6 +1,7 @@
 import { run } from '@ember/runloop';
 import { _teardownPromiseListeners } from './ext/rsvp';
 import { _teardownAJAXHooks } from './settled';
+import Ember from 'ember';
 
 export default function(context) {
   let { owner } = context;
@@ -9,4 +10,5 @@ export default function(context) {
   _teardownAJAXHooks();
 
   run(owner, 'destroy');
+  Ember.testing = false;
 }

--- a/tests/helpers/module-for-acceptance.js
+++ b/tests/helpers/module-for-acceptance.js
@@ -2,10 +2,12 @@ import { resolve } from 'rsvp';
 import { module } from 'qunit';
 import startApp from '../helpers/start-app';
 import destroyApp from '../helpers/destroy-app';
+import Ember from 'ember';
 
 export default function(name, options = {}) {
   module(name, {
     beforeEach() {
+      Ember.testing = true;
       this.application = startApp();
 
       if (options.beforeEach) {
@@ -15,7 +17,9 @@ export default function(name, options = {}) {
 
     afterEach() {
       let afterEach = options.afterEach && options.afterEach.apply(this, arguments);
-      return resolve(afterEach).then(() => destroyApp(this.application));
+      return resolve(afterEach)
+        .then(() => destroyApp(this.application))
+        .finally(() => (Ember.testing = false));
     },
   });
 }

--- a/tests/helpers/qunit-module-for.js
+++ b/tests/helpers/qunit-module-for.js
@@ -5,12 +5,23 @@ import QUnitTestAdapter from './qunit-test-adapter';
 export default function qunitModuleFor(testModule) {
   module(testModule.name, {
     beforeEach(assert) {
+      if (Ember.testing) {
+        throw new Error('should not have Ember.testing === true in beforeEach');
+      }
       Ember.Test.adapter = QUnitTestAdapter.create();
       testModule.setContext(this);
-      return testModule.setup(assert);
+      return testModule.setup(assert).finally(() => {
+        if (!Ember.testing) {
+          throw new Error('should have Ember.testing === true after tests have started');
+        }
+      });
     },
     afterEach(assert) {
-      return testModule.teardown(assert);
+      return testModule.teardown(assert).finally(() => {
+        if (Ember.testing) {
+          throw new Error('should not have Ember.testing === true after tests have finished');
+        }
+      });
     },
   });
 }

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -1,6 +1,7 @@
 import QUnit from 'qunit';
 import { registerDeprecationHandler } from '@ember/debug';
 import AbstractTestLoader from 'ember-cli-test-loader/test-support/index';
+import Ember from 'ember';
 
 let moduleLoadFailures = [];
 
@@ -36,6 +37,15 @@ registerDeprecationHandler((message, options, next) => {
 
 QUnit.testStart(function() {
   deprecations = [];
+});
+
+QUnit.testDone(function({ module, name }) {
+  // this is used to ensure that no tests accidentally leak `Ember.testing` state
+  if (Ember.testing) {
+    throw new Error(
+      `Ember.testing should be reset after test has completed. ${module}: ${name} did not reset Ember.testing`
+    );
+  }
 });
 
 QUnit.assert.noDeprecations = function(callback) {

--- a/tests/unit/legacy-0-6-x/test-module-for-component-test.js
+++ b/tests/unit/legacy-0-6-x/test-module-for-component-test.js
@@ -372,7 +372,10 @@ QUnit.module('moduleForComponent: handles errors thrown during setup', {
           'correct error was thrown from module setup'
         );
       })
-      .finally(done);
+      .finally(() => {
+        done();
+        Ember.testing = false;
+      });
   },
 });
 

--- a/tests/unit/teardown-context-test.js
+++ b/tests/unit/teardown-context-test.js
@@ -3,6 +3,7 @@ import Service from '@ember/service';
 import { setupContext, teardownContext } from 'ember-test-helpers';
 import { setResolverRegistry } from '../helpers/resolver';
 import hasEmberVersion from 'ember-test-helpers/has-ember-version';
+import Ember from 'ember';
 
 module('teardownContext', function(hooks) {
   if (!hasEmberVersion(2, 4)) {
@@ -30,5 +31,13 @@ module('teardownContext', function(hooks) {
 
     assert.ok(instance.isDestroyed, 'destroyed');
     assert.ok(instance.isDestroying, 'destroying');
+  });
+
+  test('it sets Ember.testing to false', function(assert) {
+    assert.ok(Ember.testing, 'precond - Ember.testing is truthy');
+
+    teardownContext(context);
+
+    assert.notOk(Ember.testing, 'Ember.testing is falsey after teardown');
   });
 });


### PR DESCRIPTION
Previously, `Ember.testing` was set to `true` in module scope of `ember-test-helpers` module. This causes issues due to how Ember handles RSVP promises that happen while `Ember.testing` is truthy.

This commit updates the various machinery to set `Ember.testing = true` when tests are starting, and reset it to `false` once they've finished their teardown. It also adds assertions to ensure that each test properly cleans up after itself.

Note: In some cases, instead of adding new assertions I used `throw new Error()`. This was only done in the "legacy" tests as a way of ensuring the required functionality without modifying all `assert.expect()` counts throughout those test files.

Partially addresses https://github.com/emberjs/ember-qunit/issues/246.