### PR TITLE
Ensure ember-testing-container is reset properly.

### DIFF
--- a/addon-test-support/legacy-0-6-x/abstract-test-module.js
+++ b/addon-test-support/legacy-0-6-x/abstract-test-module.js
@@ -104,15 +104,22 @@ export default class {
   }
 
   setupTestElements() {
+    let testElementContainer = document.querySelector('#ember-testing-container');
+    if (!testElementContainer) {
+      testElementContainer = document.createElement('div');
+      testElementContainer.setAttribute('id', 'ember-testing-container');
+      document.body.appendChild(testElementContainer);
+    }
+
     let testEl = document.querySelector('#ember-testing');
     if (!testEl) {
       let element = document.createElement('div');
       element.setAttribute('id', 'ember-testing');
 
-      document.body.appendChild(element);
+      testElementContainer.appendChild(element);
       this.fixtureResetValue = '';
     } else {
-      this.fixtureResetValue = testEl.innerHTML;
+      this.fixtureResetValue = testElementContainer.innerHTML;
     }
   }
 
@@ -171,7 +178,7 @@ export default class {
   }
 
   teardownTestElements() {
-    document.getElementById('ember-testing').innerHTML = this.fixtureResetValue;
+    document.getElementById('ember-testing-container').innerHTML = this.fixtureResetValue;
 
     // Ember 2.0.0 removed Ember.View as public API, so only do this when
     // Ember.View is present

--- a/addon-test-support/setup-rendering-context.js
+++ b/addon-test-support/setup-rendering-context.js
@@ -40,7 +40,7 @@ export default function(context) {
   let guid = guidFor(context);
 
   let testElementContainer = document.getElementById('ember-testing-container');
-  let fixtureResetValue = testElementContainer.outerHTML;
+  let fixtureResetValue = testElementContainer.innerHTML;
 
   RENDERING_CLEANUP[guid] = [
     () => {

--- a/tests/index.html
+++ b/tests/index.html
@@ -24,9 +24,7 @@
     <div id="qunit"></div>
     <div id="qunit-fixture"></div>
 
-    <div id="ember-testing-container">
-      <div id="ember-testing"></div>
-    </div>
+    <div id="ember-testing-container"><div id="ember-testing"></div></div>
 
     <script src="/testem.js" integrity=""></script>
     <script src="{{rootURL}}assets/vendor.js"></script>

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -46,6 +46,16 @@ QUnit.testDone(function({ module, name }) {
       `Ember.testing should be reset after test has completed. ${module}: ${name} did not reset Ember.testing`
     );
   }
+
+  // this is used to ensure that the testing container is always reset properly
+  let testElementContainer = document.getElementById('ember-testing-container');
+  let actual = testElementContainer.innerHTML;
+  let expected = `<div id="ember-testing"></div>`;
+  if (actual !== expected) {
+    throw new Error(
+      `Expected #ember-testing-container to be reset after ${module}: ${name}, but was \`${actual}\``
+    );
+  }
 });
 
 QUnit.assert.noDeprecations = function(callback) {

--- a/tests/unit/legacy-0-6-x/test-module-test.js
+++ b/tests/unit/legacy-0-6-x/test-module-test.js
@@ -398,24 +398,20 @@ test('ember-testing content should be reset to ""', function(assert) {
 QUnit.module('ember-testing resets to non-empty value');
 
 test('sets ember-testing content to "<div>foobar</div>"', function(assert) {
-  assert.expect(0);
+  assert.expect(1);
   document.getElementById('ember-testing').innerHTML = '<div>foobar</div>';
-});
-
-test('sets ember-testing content to ""', function(assert) {
-  assert.expect(0);
 
   testModule = new TestModule('component:x-foo', 'Foo');
   testModule.setContext(this);
-  return testModule.setup(...arguments).then(() => {
-    document.getElementById('ember-testing').innerHTML = '';
+  return testModule
+    .setup(...arguments)
+    .then(() => {
+      document.getElementById('ember-testing').innerHTML = '';
 
-    return testModule.teardown(...arguments);
-  });
-});
-
-test('ember-testing content should be reset to "<div>foobar</div>"', function(assert) {
-  assert.expect(1);
-  assert.equal(document.getElementById('ember-testing').innerHTML, '<div>foobar</div>');
-  document.getElementById('ember-testing').innerHTML = '';
+      return testModule.teardown(...arguments);
+    })
+    .then(() => {
+      assert.equal(document.getElementById('ember-testing').innerHTML, '<div>foobar</div>');
+      document.getElementById('ember-testing').innerHTML = '';
+    });
 });


### PR DESCRIPTION
The changes made in 7ad93d2c introduced a bug in the way that the testing DOM is cleaned up between tests. The error was quite simple: we were storing the `storedValue = container.outerHTML` before starting the test then resetting `container.innerHTML = storedValue`.  This created a DOM node leak for each test processed.

This fixes the issue for both the new testing API's in 0.7 and the older pre-existing system. It also adds some post-test checks to ensure that the DOM is indeed what we expect after each test is completed.

Fixes #228.