### PR TITLE
Add pauseTest and resumeTest functionality.

### DIFF
--- a/addon-test-support/index.js
+++ b/addon-test-support/index.js
@@ -5,7 +5,14 @@ export { default as TestModuleForComponent } from './legacy-0-6-x/test-module-fo
 export { default as TestModuleForModel } from './legacy-0-6-x/test-module-for-model';
 
 export { setResolver } from './resolver';
-export { default as setupContext, getContext, setContext, unsetContext } from './setup-context';
+export {
+  default as setupContext,
+  getContext,
+  setContext,
+  unsetContext,
+  pauseTest,
+  resumeTest,
+} from './setup-context';
 export { default as teardownContext } from './teardown-context';
 export { default as setupRenderingContext, render, clearRender } from './setup-rendering-context';
 export { default as teardownRenderingContext } from './teardown-rendering-context';


### PR DESCRIPTION
This is the base implementation to allow for `pauseTest()` functionality. These methods are designed to be wrapped by the host test framework so that any test timeouts are properly configured to avoid the test "failing" while being interacted with.