### PR TITLE
Use `Application.create().buildInstance()` if possible.

### DIFF
--- a/addon-test-support/application.js
+++ b/addon-test-support/application.js
@@ -1,0 +1,9 @@
+var __application__;
+
+export function setApplication(application) {
+  __application__ = application;
+}
+
+export function getApplication() {
+  return __application__;
+}

--- a/addon-test-support/build-owner.js
+++ b/addon-test-support/build-owner.js
@@ -1,23 +1,7 @@
-/* globals requirejs */
-import global from './global';
-
-import ApplicationInstance from '@ember/application/instance';
-import Application from '@ember/application';
-import EmberObject from '@ember/object';
 import { Promise } from 'rsvp';
 
-import require from 'require';
-import Ember from 'ember';
+import legacyBuildRegistry from './legacy-0-6-x/build-registry';
 
-let Owner;
-
-// different than the legacy-0-6-x version (build-registry.js)
-// in the following ways:
-//
-// * Accepts an application to _actually_ boot if possible
-// * falls back to "fake owner" if application is not present
-// * fewer fallbacks (supports only Ember 2.4+)
-// * returns "owner" (instead of a POJO with registry/container)
 export default function({ application, resolver }) {
   if (application) {
     return application.boot().then(app => app.buildInstance().boot());
@@ -29,88 +13,6 @@ export default function({ application, resolver }) {
     );
   }
 
-  if (Owner === undefined) {
-    Owner = EmberObject.extend(Ember._RegistryProxyMixin, Ember._ContainerProxyMixin, {
-      _emberTestHelpersMockOwner: true,
-    });
-  }
-
-  let fallbackRegistry, registry, container;
-  let namespace = EmberObject.create({
-    Resolver: {
-      create() {
-        return resolver;
-      },
-    },
-  });
-
-  function register(name, factory) {
-    let thingToRegisterWith = registry || container;
-    let existingFactory = container.factoryFor
-      ? container.factoryFor(name)
-      : container.lookupFactory(name);
-
-    if (!existingFactory) {
-      thingToRegisterWith.register(name, factory);
-    }
-  }
-
-  fallbackRegistry = Application.buildRegistry(namespace);
-  fallbackRegistry.register('component-lookup:main', Ember.ComponentLookup);
-
-  registry = new Ember.Registry({
-    fallback: fallbackRegistry,
-  });
-
-  // Ember.ApplicationInstance was exposed in Ember 2.8
-  if (ApplicationInstance && ApplicationInstance.setupRegistry) {
-    ApplicationInstance.setupRegistry(registry);
-  }
-
-  // these properties are set on the fallback registry by `buildRegistry`
-  // and on the primary registry within the ApplicationInstance constructor
-  // but we need to manually recreate them since ApplicationInstance's are not
-  // exposed externally
-  registry.normalizeFullName = fallbackRegistry.normalizeFullName;
-  registry.makeToString = fallbackRegistry.makeToString;
-  registry.describe = fallbackRegistry.describe;
-
-  let owner = Owner.create({
-    __registry__: registry,
-    __container__: null,
-  });
-
-  container = registry.container({ owner: owner });
-  owner.__container__ = container;
-
-  // TODO: this manual Ember Data setup should be removed in favor of
-  // running the applications `initializers` to ensure the container is
-  // properly setup, this would only need to be done once per test suite
-  if (
-    (typeof require.has === 'function' && require.has('ember-data/setup-container')) ||
-    requirejs.entries['ember-data/setup-container']
-  ) {
-    // ember-data is a proper ember-cli addon since 2.3; if no 'import
-    // 'ember-data'' is present somewhere in the tests, there is also no `DS`
-    // available on the globalContext and hence ember-data wouldn't be setup
-    // correctly for the tests; that's why we import and call setupContainer
-    // here; also see https://github.com/emberjs/data/issues/4071 for context
-    let setupContainer = require('ember-data/setup-container')['default'];
-    setupContainer(registry);
-  } else if (global.DS) {
-    let DS = global.DS;
-    if (DS._setupContainer) {
-      DS._setupContainer(registry);
-    } else {
-      register('transform:boolean', DS.BooleanTransform);
-      register('transform:date', DS.DateTransform);
-      register('transform:number', DS.NumberTransform);
-      register('transform:string', DS.StringTransform);
-      register('serializer:-default', DS.JSONSerializer);
-      register('serializer:-rest', DS.RESTSerializer);
-      register('adapter:-rest', DS.RESTAdapter);
-    }
-  }
-
-  return Promise.resolve().then(() => owner);
+  let { owner } = legacyBuildRegistry(resolver);
+  return Promise.resolve(owner);
 }

--- a/addon-test-support/index.js
+++ b/addon-test-support/index.js
@@ -5,6 +5,7 @@ export { default as TestModuleForComponent } from './legacy-0-6-x/test-module-fo
 export { default as TestModuleForModel } from './legacy-0-6-x/test-module-for-model';
 
 export { setResolver } from './resolver';
+export { setApplication } from './application';
 export {
   default as setupContext,
   getContext,

--- a/addon-test-support/legacy-0-6-x/build-registry.js
+++ b/addon-test-support/legacy-0-6-x/build-registry.js
@@ -38,10 +38,14 @@ function exposeRegistryMethodsWithoutDeprecations(container) {
 
 var Owner = (function() {
   if (Ember._RegistryProxyMixin && Ember._ContainerProxyMixin) {
-    return EmberObject.extend(Ember._RegistryProxyMixin, Ember._ContainerProxyMixin);
+    return EmberObject.extend(Ember._RegistryProxyMixin, Ember._ContainerProxyMixin, {
+      _emberTestHelpersMockOwner: true,
+    });
   }
 
-  return EmberObject.extend();
+  return EmberObject.extend({
+    _emberTestHelpersMockOwner: true,
+  });
 })();
 
 export default function(resolver) {
@@ -136,7 +140,8 @@ export default function(resolver) {
   }
 
   return {
-    registry: registry,
-    container: container,
+    registry,
+    container,
+    owner,
   };
 }

--- a/addon-test-support/resolver.js
+++ b/addon-test-support/resolver.js
@@ -5,9 +5,5 @@ export function setResolver(resolver) {
 }
 
 export function getResolver() {
-  if (__resolver__ == null) {
-    throw new Error('you must set a resolver with `testResolver.set(resolver)`');
-  }
-
   return __resolver__;
 }

--- a/addon-test-support/setup-rendering-context.js
+++ b/addon-test-support/setup-rendering-context.js
@@ -53,8 +53,15 @@ export default function(context) {
     next(() => {
       let { owner } = context;
 
-      let dispatcher = owner.lookup('event_dispatcher:main') || Ember.EventDispatcher.create();
-      dispatcher.setup({}, '#ember-testing');
+      // When the host app uses `setApplication` (instead of `setResolver`) the event dispatcher has
+      // already been setup via `applicationInstance.boot()` in `./build-owner`. If using
+      // `setResolver` (instead of `setApplication`) a "mock owner" is created by extending
+      // `Ember._ContainerProxyMixin` and `Ember._RegistryProxyMixin` in this scenario we need to
+      // manually start the event dispatcher.
+      if (owner._emberTestHelpersMockOwner) {
+        let dispatcher = owner.lookup('event_dispatcher:main') || Ember.EventDispatcher.create();
+        dispatcher.setup({}, '#ember-testing');
+      }
 
       let OutletView = owner.factoryFor
         ? owner.factoryFor('view:-outlet')

--- a/tests/dummy/app/resolver.js
+++ b/tests/dummy/app/resolver.js
@@ -1,3 +1,12 @@
 import Resolver from 'ember-resolver';
 
-export default Resolver;
+export let registry = Object.create(null);
+export function setRegistry(newRegistry) {
+  registry = newRegistry;
+}
+
+export default Resolver.extend({
+  resolve(fullName) {
+    return registry[fullName] || this._super(...arguments);
+  },
+});

--- a/tests/helpers/resolver.js
+++ b/tests/helpers/resolver.js
@@ -6,7 +6,8 @@ import { setResolver, setApplication } from 'ember-test-helpers';
 import require from 'require';
 import App from '../../app';
 
-const resolver = AppResolver.create();
+export const resolver = AppResolver.create();
+export const application = App.create({ autoboot: false });
 
 resolver.namespace = {
   modulePrefix: config.modulePrefix,
@@ -14,7 +15,7 @@ resolver.namespace = {
 };
 
 setResolver(resolver);
-setApplication(App.create({ autoboot: false }));
+setApplication(application);
 
 export function setResolverRegistry(registry) {
   setRegistry(registry);

--- a/tests/helpers/resolver.js
+++ b/tests/helpers/resolver.js
@@ -1,20 +1,12 @@
 import Ember from 'ember';
-import { run } from '@ember/runloop';
 import { dasherize } from '@ember/string';
-import AppResolver from '../../resolver';
+import AppResolver, { setRegistry } from '../../resolver';
 import config from '../../config/environment';
-import { setResolver } from 'ember-test-helpers';
+import { setResolver, setApplication } from 'ember-test-helpers';
 import require from 'require';
+import App from '../../app';
 
-const Resolver = AppResolver.extend({
-  registry: {},
-
-  resolve(fullName) {
-    return this.registry[fullName] || this._super(...arguments);
-  },
-});
-
-const resolver = Resolver.create();
+const resolver = AppResolver.create();
 
 resolver.namespace = {
   modulePrefix: config.modulePrefix,
@@ -22,9 +14,10 @@ resolver.namespace = {
 };
 
 setResolver(resolver);
+setApplication(App.create({ autoboot: false }));
 
 export function setResolverRegistry(registry) {
-  run(resolver, 'set', 'registry', registry);
+  setRegistry(registry);
 }
 
 export default {

--- a/tests/unit/setup-context-test.js
+++ b/tests/unit/setup-context-test.js
@@ -6,9 +6,16 @@ import {
   getContext,
   pauseTest,
   resumeTest,
+  setApplication,
+  setResolver,
 } from 'ember-test-helpers';
 import hasEmberVersion from 'ember-test-helpers/has-ember-version';
-import { setResolverRegistry, createCustomResolver } from '../helpers/resolver';
+import {
+  setResolverRegistry,
+  createCustomResolver,
+  application,
+  resolver,
+} from '../helpers/resolver';
 import Ember from 'ember';
 
 module('setupContext', function(hooks) {
@@ -16,13 +23,13 @@ module('setupContext', function(hooks) {
     return;
   }
 
-  let context;
   hooks.before(function() {
     setResolverRegistry({
       'service:foo': Service.extend({ isFoo: true }),
     });
   });
 
+  let context;
   hooks.afterEach(async function() {
     if (context) {
       await teardownContext(context);
@@ -30,203 +37,237 @@ module('setupContext', function(hooks) {
     }
   });
 
-  module('without options', function(hooks) {
-    hooks.beforeEach(function() {
-      context = {};
-      return setupContext(context);
-    });
+  hooks.after(function() {
+    setApplication(application);
+    setResolver(resolver);
+  });
 
-    test('it sets up this.owner', function(assert) {
-      let { owner } = context;
-      assert.ok(owner, 'owner was setup');
-      assert.equal(typeof owner.lookup, 'function', 'has expected lookup interface');
-
-      if (hasEmberVersion(2, 12)) {
-        assert.equal(typeof owner.factoryFor, 'function', 'has expected factory interface');
-      }
-    });
-
-    test('it uses the default resolver if no override specified', function(assert) {
-      let { owner } = context;
-      let instance = owner.lookup('service:foo');
-      assert.equal(instance.isFoo, true, 'uses the default resolver');
-    });
-
-    test('it sets up this.set', function(assert) {
-      context.set('foo', 'bar');
-      assert.equal(context.foo, 'bar', 'this.set sets the property');
-    });
-
-    test('it sets up this.setProperties', function(assert) {
-      context.setProperties({
-        foo: 'bar',
-        baz: 'qux',
+  function setupContextTests() {
+    module('without options', function(hooks) {
+      hooks.beforeEach(function() {
+        context = {};
+        return setupContext(context);
       });
 
-      assert.equal(context.foo, 'bar', 'this.setProperties sets the first property');
-      assert.equal(context.baz, 'qux', 'this.setProperties sets the second property');
-    });
+      test('it sets up this.owner', function(assert) {
+        let { owner } = context;
+        assert.ok(owner, 'owner was setup');
+        assert.equal(typeof owner.lookup, 'function', 'has expected lookup interface');
 
-    test('it sets up this.get', function(assert) {
-      context.set('foo', 'bar');
-
-      assert.equal(context.get('foo'), 'bar', 'this.get can read previously set property');
-    });
-
-    test('it sets up this.getProperties', function(assert) {
-      context.setProperties({
-        foo: 'bar',
-        baz: 'qux',
+        if (hasEmberVersion(2, 12)) {
+          assert.equal(typeof owner.factoryFor, 'function', 'has expected factory interface');
+        }
       });
 
-      let result = context.getProperties('foo', 'baz');
-      assert.deepEqual(
-        result,
-        {
+      test('it uses the default resolver if no override specified', function(assert) {
+        let { owner } = context;
+        let instance = owner.lookup('service:foo');
+        assert.equal(instance.isFoo, true, 'uses the default resolver');
+      });
+
+      test('it sets up this.set', function(assert) {
+        context.set('foo', 'bar');
+        assert.equal(context.foo, 'bar', 'this.set sets the property');
+      });
+
+      test('it sets up this.setProperties', function(assert) {
+        context.setProperties({
           foo: 'bar',
           baz: 'qux',
-        },
-        'getProperties reads content from context'
-      );
-    });
+        });
 
-    test('it calls setContext with the provided context', function(assert) {
-      assert.equal(getContext(), context);
-    });
-
-    test('can be used for unit style testing', function(assert) {
-      context.owner.register(
-        'service:foo',
-        Service.extend({
-          someMethod() {
-            return 'hello thar!';
-          },
-        })
-      );
-
-      let subject = context.owner.lookup('service:foo');
-
-      assert.equal(subject.someMethod(), 'hello thar!');
-    });
-
-    test('can access a service instance (instead of this.inject.service("thing") in 0.6)', function(
-      assert
-    ) {
-      context.owner.register('service:bar', Service.extend());
-      context.owner.register(
-        'service:foo',
-        Service.extend({
-          bar: injectService(),
-          someMethod() {
-            this.set('bar.someProp', 'derp');
-          },
-        })
-      );
-
-      let subject = context.owner.lookup('service:foo');
-      let bar = context.owner.lookup('service:bar');
-
-      assert.notOk(bar.get('someProp'), 'precond - initially undefined');
-
-      subject.someMethod();
-
-      assert.equal(bar.get('someProp'), 'derp', 'property updated');
-    });
-
-    test('can pauseTest to be resumed "later"', async function(assert) {
-      assert.expect(5);
-
-      let promise = context.pauseTest();
-
-      // do some random things while "paused"
-      setTimeout(function() {
-        assert.step('5 ms');
-      }, 5);
-
-      setTimeout(function() {
-        assert.step('20 ms');
-      }, 20);
-
-      setTimeout(function() {
-        assert.step('30 ms');
-      }, 30);
-
-      setTimeout(function() {
-        assert.step('50 ms');
-        context.resumeTest();
-      }, 50);
-
-      await promise;
-
-      assert.verifySteps(['5 ms', '20 ms', '30 ms', '50 ms']);
-    });
-
-    test('imported pauseTest and resumeTest allow customizations by test frameworks', async function(
-      assert
-    ) {
-      assert.expect(2);
-
-      let originalPauseTest = context.pauseTest;
-      context.pauseTest = () => {
-        assert.ok(true, 'contexts pauseTest was called');
-        return originalPauseTest();
-      };
-
-      let originalResumeTest = context.resumeTest;
-      context.resumeTest = () => {
-        assert.ok(true, 'customized resumeTest was called');
-        return originalResumeTest();
-      };
-
-      let promise = pauseTest();
-
-      resumeTest();
-
-      await promise;
-    });
-
-    test('pauseTest sets up a window.resumeTest to easily resume', async function(assert) {
-      assert.equal(window.resumeTest, undefined, 'precond - starts out as undefined');
-
-      let promise = context.pauseTest();
-
-      assert.equal(
-        resumeTest,
-        window.resumeTest,
-        'window.resumeTest is the same as this.resumeTest'
-      );
-
-      context.resumeTest();
-
-      assert.equal(window.resumeTest, undefined, 'window.resumeTest is cleared after invocation');
-
-      await promise;
-    });
-  });
-
-  module('with custom options', function() {
-    test('it can specify a custom resolver', async function(assert) {
-      context = {};
-      let resolver = createCustomResolver({
-        'service:foo': Service.extend({ isFoo: 'maybe?' }),
+        assert.equal(context.foo, 'bar', 'this.setProperties sets the first property');
+        assert.equal(context.baz, 'qux', 'this.setProperties sets the second property');
       });
-      await setupContext(context, { resolver });
-      let { owner } = context;
-      let instance = owner.lookup('service:foo');
-      assert.equal(instance.isFoo, 'maybe?', 'uses the custom resolver');
+
+      test('it sets up this.get', function(assert) {
+        context.set('foo', 'bar');
+
+        assert.equal(context.get('foo'), 'bar', 'this.get can read previously set property');
+      });
+
+      test('it sets up this.getProperties', function(assert) {
+        context.setProperties({
+          foo: 'bar',
+          baz: 'qux',
+        });
+
+        let result = context.getProperties('foo', 'baz');
+        assert.deepEqual(
+          result,
+          {
+            foo: 'bar',
+            baz: 'qux',
+          },
+          'getProperties reads content from context'
+        );
+      });
+
+      test('it calls setContext with the provided context', function(assert) {
+        assert.equal(getContext(), context);
+      });
+
+      test('can be used for unit style testing', function(assert) {
+        context.owner.register(
+          'service:foo',
+          Service.extend({
+            someMethod() {
+              return 'hello thar!';
+            },
+          })
+        );
+
+        let subject = context.owner.lookup('service:foo');
+
+        assert.equal(subject.someMethod(), 'hello thar!');
+      });
+
+      test('can access a service instance (instead of this.inject.service("thing") in 0.6)', function(
+        assert
+      ) {
+        context.owner.register('service:bar', Service.extend());
+        context.owner.register(
+          'service:foo',
+          Service.extend({
+            bar: injectService(),
+            someMethod() {
+              this.set('bar.someProp', 'derp');
+            },
+          })
+        );
+
+        let subject = context.owner.lookup('service:foo');
+        let bar = context.owner.lookup('service:bar');
+
+        assert.notOk(bar.get('someProp'), 'precond - initially undefined');
+
+        subject.someMethod();
+
+        assert.equal(bar.get('someProp'), 'derp', 'property updated');
+      });
+
+      test('can pauseTest to be resumed "later"', async function(assert) {
+        assert.expect(5);
+
+        let promise = context.pauseTest();
+
+        // do some random things while "paused"
+        setTimeout(function() {
+          assert.step('5 ms');
+        }, 5);
+
+        setTimeout(function() {
+          assert.step('20 ms');
+        }, 20);
+
+        setTimeout(function() {
+          assert.step('30 ms');
+        }, 30);
+
+        setTimeout(function() {
+          assert.step('50 ms');
+          context.resumeTest();
+        }, 50);
+
+        await promise;
+
+        assert.verifySteps(['5 ms', '20 ms', '30 ms', '50 ms']);
+      });
+
+      test('imported pauseTest and resumeTest allow customizations by test frameworks', async function(
+        assert
+      ) {
+        assert.expect(2);
+
+        let originalPauseTest = context.pauseTest;
+        context.pauseTest = () => {
+          assert.ok(true, 'contexts pauseTest was called');
+          return originalPauseTest();
+        };
+
+        let originalResumeTest = context.resumeTest;
+        context.resumeTest = () => {
+          assert.ok(true, 'customized resumeTest was called');
+          return originalResumeTest();
+        };
+
+        let promise = pauseTest();
+
+        resumeTest();
+
+        await promise;
+      });
+
+      test('pauseTest sets up a window.resumeTest to easily resume', async function(assert) {
+        assert.equal(window.resumeTest, undefined, 'precond - starts out as undefined');
+
+        let promise = context.pauseTest();
+
+        assert.equal(
+          resumeTest,
+          window.resumeTest,
+          'window.resumeTest is the same as this.resumeTest'
+        );
+
+        context.resumeTest();
+
+        assert.equal(window.resumeTest, undefined, 'window.resumeTest is cleared after invocation');
+
+        await promise;
+      });
     });
+
+    module('with custom options', function() {
+      test('it can specify a custom resolver', async function(assert) {
+        context = {};
+        let resolver = createCustomResolver({
+          'service:foo': Service.extend({ isFoo: 'maybe?' }),
+        });
+        await setupContext(context, { resolver });
+        let { owner } = context;
+        let instance = owner.lookup('service:foo');
+        assert.equal(instance.isFoo, 'maybe?', 'uses the custom resolver');
+      });
+    });
+
+    test('Ember.testing', async function(assert) {
+      assert.notOk(Ember.testing, 'precond - Ember.testing is falsey before setup');
+
+      context = {};
+      let promise = setupContext(context);
+
+      assert.ok(Ember.testing, 'Ember.testing is truthy sync after setup');
+
+      await promise;
+
+      assert.ok(Ember.testing, 'Ember.testing is truthy async after setup');
+    });
+  }
+
+  module('with only application set', function(hooks) {
+    hooks.beforeEach(function() {
+      setResolver(null);
+      setApplication(application);
+    });
+
+    setupContextTests();
   });
 
-  test('Ember.testing', async function(assert) {
-    assert.notOk(Ember.testing, 'precond - Ember.testing is falsey before setup');
+  module('with application and resolver set', function(hooks) {
+    hooks.beforeEach(function() {
+      setResolver(resolver);
+      setApplication(application);
+    });
 
-    context = {};
-    let promise = setupContext(context);
+    setupContextTests();
+  });
 
-    assert.ok(Ember.testing, 'Ember.testing is truthy sync after setup');
+  module('with only resolver set', function(hooks) {
+    hooks.beforeEach(function() {
+      setResolver(resolver);
+      setApplication(null);
+    });
 
-    await promise;
-
-    assert.ok(Ember.testing, 'Ember.testing is truthy async after setup');
+    setupContextTests();
   });
 });

--- a/tests/unit/setup-rendering-context-test.js
+++ b/tests/unit/setup-rendering-context-test.js
@@ -10,10 +10,12 @@ import {
   teardownRenderingContext,
   render,
   clearRender,
+  setApplication,
+  setResolver,
 } from 'ember-test-helpers';
 import hasEmberVersion from 'ember-test-helpers/has-ember-version';
 import hasjQuery from '../helpers/has-jquery';
-import { setResolverRegistry } from '../helpers/resolver';
+import { setResolverRegistry, application, resolver } from '../helpers/resolver';
 import { focus, blur, fireEvent, click } from '../helpers/events';
 import hbs from 'htmlbars-inline-precompile';
 
@@ -22,307 +24,345 @@ module('setupRenderingContext', function(hooks) {
     return;
   }
 
-  hooks.beforeEach(async function() {
-    setResolverRegistry({
-      'service:foo': Service.extend({ isFoo: true }),
-      'template:components/template-only': hbs`template-only component here`,
-      'component:js-only': Component.extend({
-        classNames: ['js-only'],
-      }),
-      'helper:jax': helper(([name]) => `${name}-jax`),
-      'template:components/outer-comp': hbs`outer{{inner-comp}}outer`,
-      'template:components/inner-comp': hbs`inner`,
+  hooks.after(function() {
+    setApplication(application);
+    setResolver(resolver);
+  });
+
+  function setupRenderingContextTests(hooks) {
+    hooks.beforeEach(async function() {
+      setResolverRegistry({
+        'service:foo': Service.extend({ isFoo: true }),
+        'template:components/template-only': hbs`template-only component here`,
+        'component:js-only': Component.extend({
+          classNames: ['js-only'],
+        }),
+        'helper:jax': helper(([name]) => `${name}-jax`),
+        'template:components/outer-comp': hbs`outer{{inner-comp}}outer`,
+        'template:components/inner-comp': hbs`inner`,
+      });
+
+      await setupContext(this);
+      await setupRenderingContext(this);
     });
 
-    await setupContext(this);
-    await setupRenderingContext(this);
-  });
+    hooks.afterEach(async function() {
+      await teardownRenderingContext(this);
+      await teardownContext(this);
+    });
 
-  hooks.afterEach(async function() {
-    await teardownRenderingContext(this);
-    await teardownContext(this);
-  });
+    test('render exposes an `.element` property', async function(assert) {
+      await this.render(hbs`<p>Hello!</p>`);
 
-  test('render exposes an `.element` property', async function(assert) {
-    await this.render(hbs`<p>Hello!</p>`);
+      assert.equal(this.element.textContent, 'Hello!');
+    });
 
-    assert.equal(this.element.textContent, 'Hello!');
-  });
+    test('render can be used multiple times', async function(assert) {
+      await this.render(hbs`<p>Hello!</p>`);
+      assert.equal(this.element.textContent, 'Hello!');
 
-  test('render can be used multiple times', async function(assert) {
-    await this.render(hbs`<p>Hello!</p>`);
-    assert.equal(this.element.textContent, 'Hello!');
+      await this.render(hbs`<p>World!</p>`);
+      assert.equal(this.element.textContent, 'World!');
+    });
 
-    await this.render(hbs`<p>World!</p>`);
-    assert.equal(this.element.textContent, 'World!');
-  });
+    test('render does not run sync', async function(assert) {
+      assert.equal(this.element, undefined, 'precond - this.element is not set before this.render');
 
-  test('render does not run sync', async function(assert) {
-    assert.equal(this.element, undefined, 'precond - this.element is not set before this.render');
+      let renderPromise = this.render(hbs`<p>Hello!</p>`);
 
-    let renderPromise = this.render(hbs`<p>Hello!</p>`);
+      assert.equal(this.element, undefined, 'precond - this.element is not set sync');
 
-    assert.equal(this.element, undefined, 'precond - this.element is not set sync');
+      await renderPromise;
+      assert.equal(this.element.textContent, 'Hello!');
+    });
 
-    await renderPromise;
-    assert.equal(this.element.textContent, 'Hello!');
-  });
+    test('clearRender can be used to clear the previously rendered template', async function(
+      assert
+    ) {
+      let testingRootElement = document.getElementById('ember-testing');
 
-  test('clearRender can be used to clear the previously rendered template', async function(assert) {
-    let testingRootElement = document.getElementById('ember-testing');
+      await this.render(hbs`<p>Hello!</p>`);
 
-    await this.render(hbs`<p>Hello!</p>`);
+      assert.equal(this.element.textContent, 'Hello!', 'has rendered content');
+      assert.equal(testingRootElement.textContent, 'Hello!', 'has rendered content');
 
-    assert.equal(this.element.textContent, 'Hello!', 'has rendered content');
-    assert.equal(testingRootElement.textContent, 'Hello!', 'has rendered content');
+      await this.clearRender();
+      assert.equal(this.element, undefined, 'this.element is reset');
 
-    await this.clearRender();
-    assert.equal(this.element, undefined, 'this.element is reset');
+      assert.equal(testingRootElement.textContent, '', 'content is cleared');
+    });
 
-    assert.equal(testingRootElement.textContent, '', 'content is cleared');
-  });
+    (hasjQuery() ? test : skip)('this.$ is exposed when jQuery is present', async function(assert) {
+      await this.render(hbs`<p>Hello!</p>`);
 
-  (hasjQuery() ? test : skip)('this.$ is exposed when jQuery is present', async function(assert) {
-    await this.render(hbs`<p>Hello!</p>`);
+      assert.equal(this.$().text(), 'Hello!');
+    });
 
-    assert.equal(this.$().text(), 'Hello!');
-  });
+    test('can invoke template only components', async function(assert) {
+      await this.render(hbs`{{template-only}}`);
 
-  test('can invoke template only components', async function(assert) {
-    await this.render(hbs`{{template-only}}`);
+      assert.equal(this.element.textContent, 'template-only component here');
+    });
 
-    assert.equal(this.element.textContent, 'template-only component here');
-  });
+    test('can invoke JS only components', async function(assert) {
+      await this.render(hbs`{{js-only}}`);
 
-  test('can invoke JS only components', async function(assert) {
-    await this.render(hbs`{{js-only}}`);
+      assert.ok(this.element.querySelector('.js-only'), 'element found for js-only component');
+    });
 
-    assert.ok(this.element.querySelector('.js-only'), 'element found for js-only component');
-  });
+    test('can invoke helper', async function(assert) {
+      await this.render(hbs`{{jax "max"}}`);
 
-  test('can invoke helper', async function(assert) {
-    await this.render(hbs`{{jax "max"}}`);
+      assert.equal(this.element.textContent, 'max-jax');
+    });
 
-    assert.equal(this.element.textContent, 'max-jax');
-  });
+    test('can pass arguments to helper from context', async function(assert) {
+      this.set('name', 'james');
 
-  test('can pass arguments to helper from context', async function(assert) {
-    this.set('name', 'james');
+      await this.render(hbs`{{jax name}}`);
 
-    await this.render(hbs`{{jax name}}`);
+      assert.equal(this.element.textContent, 'james-jax');
+    });
 
-    assert.equal(this.element.textContent, 'james-jax');
-  });
+    test('can render a component that renders other components', async function(assert) {
+      await this.render(hbs`{{outer-comp}}`);
 
-  test('can render a component that renders other components', async function(assert) {
-    await this.render(hbs`{{outer-comp}}`);
+      assert.equal(this.element.textContent, 'outerinnerouter');
+    });
 
-    assert.equal(this.element.textContent, 'outerinnerouter');
-  });
+    test('can use the component helper in its layout', async function(assert) {
+      this.owner.register('template:components/x-foo', hbs`x-foo here`);
 
-  test('can use the component helper in its layout', async function(assert) {
-    this.owner.register('template:components/x-foo', hbs`x-foo here`);
+      await this.render(hbs`{{component 'x-foo'}}`);
 
-    await this.render(hbs`{{component 'x-foo'}}`);
+      assert.equal(this.element.textContent, 'x-foo here');
+    });
 
-    assert.equal(this.element.textContent, 'x-foo here');
-  });
+    test('can create a component instance for direct testing without a template', function(assert) {
+      this.owner.register(
+        'component:foo-bar',
+        Component.extend({
+          someMethod() {
+            return 'hello thar!';
+          },
+        })
+      );
 
-  test('can create a component instance for direct testing without a template', function(assert) {
-    this.owner.register(
-      'component:foo-bar',
-      Component.extend({
-        someMethod() {
-          return 'hello thar!';
-        },
-      })
-    );
+      let subject;
+      if (hasEmberVersion(2, 12)) {
+        subject = this.owner.lookup('component:foo-bar');
+      } else {
+        subject = this.owner._lookupFactory('component:foo-bar').create();
+      }
 
-    let subject;
-    if (hasEmberVersion(2, 12)) {
-      subject = this.owner.lookup('component:foo-bar');
-    } else {
-      subject = this.owner._lookupFactory('component:foo-bar').create();
-    }
+      assert.equal(subject.someMethod(), 'hello thar!');
+    });
 
-    assert.equal(subject.someMethod(), 'hello thar!');
-  });
+    test('can handle a click event', async function(assert) {
+      assert.expect(2);
 
-  test('can handle a click event', async function(assert) {
-    assert.expect(2);
-
-    this.owner.register(
-      'component:x-foo',
-      Component.extend({
-        click() {
-          assert.ok(true, 'click was fired');
-        },
-      })
-    );
-    this.owner.register('template:components/x-foo', hbs`<button>Click me!</button>`);
-
-    await this.render(hbs`{{x-foo}}`);
-
-    assert.equal(this.element.textContent, 'Click me!', 'precond - component was rendered');
-    click(this.element.querySelector('button'));
-  });
-
-  test('can use action based event handling', async function(assert) {
-    assert.expect(2);
-
-    this.owner.register(
-      'component:x-foo',
-      Component.extend({
-        actions: {
-          clicked() {
+      this.owner.register(
+        'component:x-foo',
+        Component.extend({
+          click() {
             assert.ok(true, 'click was fired');
           },
-        },
-      })
-    );
-    this.owner.register(
-      'template:components/x-foo',
-      hbs`<button {{action 'clicked'}}>Click me!</button>`
-    );
+        })
+      );
+      this.owner.register('template:components/x-foo', hbs`<button>Click me!</button>`);
 
-    await this.render(hbs`{{x-foo}}`);
+      await this.render(hbs`{{x-foo}}`);
 
-    assert.equal(this.element.textContent, 'Click me!', 'precond - component was rendered');
-    click(this.element.querySelector('button'));
-  });
+      assert.equal(this.element.textContent, 'Click me!', 'precond - component was rendered');
+      click(this.element.querySelector('button'));
+    });
 
-  test('can pass function to be used as a "closure action"', async function(assert) {
-    assert.expect(2);
+    test('can use action based event handling', async function(assert) {
+      assert.expect(2);
 
-    this.owner.register(
-      'template:components/x-foo',
-      hbs`<button onclick={{action clicked}}>Click me!</button>`
-    );
-
-    this.set('clicked', () => assert.ok(true, 'action was triggered'));
-    await this.render(hbs`{{x-foo clicked=clicked}}`);
-
-    assert.equal(this.element.textContent, 'Click me!', 'precond - component was rendered');
-    click(this.element.querySelector('button'));
-  });
-
-  test('can update a passed in argument with an <input>', async function(assert) {
-    this.owner.register('component:my-input', TextField.extend({}));
-
-    await this.render(hbs`{{my-input value=value}}`);
-
-    let input = this.element.querySelector('input');
-
-    assert.strictEqual(this.get('value'), undefined, 'precond - property is initially null');
-    assert.equal(input.value, '', 'precond - element value is initially empty');
-
-    // trigger the change
-    input.value = '1';
-    fireEvent(input, 'change');
-
-    assert.equal(this.get('value'), '1');
-  });
-
-  test('it supports dom triggered focus events', async function(assert) {
-    this.owner.register(
-      'component:my-input',
-      TextField.extend({
-        init() {
-          this._super(...arguments);
-
-          this.set('value', 'init');
-        },
-        focusIn() {
-          this.set('value', 'focusin');
-        },
-        focusOut() {
-          this.set('value', 'focusout');
-        },
-      })
-    );
-    await this.render(hbs`{{my-input}}`);
-
-    let input = this.element.querySelector('input');
-    assert.equal(input.value, 'init');
-
-    focus(input);
-    assert.equal(input.value, 'focusin');
-
-    blur(input);
-    assert.equal(input.value, 'focusout');
-  });
-
-  test('two way bound arguments are updated', async function(assert) {
-    this.owner.register(
-      'component:my-component',
-      Component.extend({
-        actions: {
-          clicked() {
-            this.set('foo', 'updated!');
+      this.owner.register(
+        'component:x-foo',
+        Component.extend({
+          actions: {
+            clicked() {
+              assert.ok(true, 'click was fired');
+            },
           },
-        },
-      })
-    );
-    this.owner.register(
-      'template:components/my-component',
-      hbs`<button {{action 'clicked'}}>{{foo}}</button>`
-    );
+        })
+      );
+      this.owner.register(
+        'template:components/x-foo',
+        hbs`<button {{action 'clicked'}}>Click me!</button>`
+      );
 
-    this.set('foo', 'original');
-    await this.render(hbs`{{my-component foo=foo}}`);
-    assert.equal(this.element.textContent, 'original', 'value after initial render');
+      await this.render(hbs`{{x-foo}}`);
 
-    click(this.element.querySelector('button'));
-    assert.equal(this.element.textContent, 'updated!', 'value after updating');
-    assert.equal(this.get('foo'), 'updated!');
-  });
+      assert.equal(this.element.textContent, 'Click me!', 'precond - component was rendered');
+      click(this.element.querySelector('button'));
+    });
 
-  test('two way bound arguments are available after clearRender is called', async function(assert) {
-    this.owner.register(
-      'component:my-component',
-      Component.extend({
-        actions: {
-          clicked() {
-            this.set('foo', 'updated!');
-            this.set('bar', 'updated bar!');
+    test('can pass function to be used as a "closure action"', async function(assert) {
+      assert.expect(2);
+
+      this.owner.register(
+        'template:components/x-foo',
+        hbs`<button onclick={{action clicked}}>Click me!</button>`
+      );
+
+      this.set('clicked', () => assert.ok(true, 'action was triggered'));
+      await this.render(hbs`{{x-foo clicked=clicked}}`);
+
+      assert.equal(this.element.textContent, 'Click me!', 'precond - component was rendered');
+      click(this.element.querySelector('button'));
+    });
+
+    test('can update a passed in argument with an <input>', async function(assert) {
+      this.owner.register('component:my-input', TextField.extend({}));
+
+      await this.render(hbs`{{my-input value=value}}`);
+
+      let input = this.element.querySelector('input');
+
+      assert.strictEqual(this.get('value'), undefined, 'precond - property is initially null');
+      assert.equal(input.value, '', 'precond - element value is initially empty');
+
+      // trigger the change
+      input.value = '1';
+      fireEvent(input, 'change');
+
+      assert.equal(this.get('value'), '1');
+    });
+
+    test('it supports dom triggered focus events', async function(assert) {
+      this.owner.register(
+        'component:my-input',
+        TextField.extend({
+          init() {
+            this._super(...arguments);
+
+            this.set('value', 'init');
           },
-        },
-      })
-    );
-    this.owner.register(
-      'template:components/my-component',
-      hbs`<button {{action 'clicked'}}>{{foo}}</button>`
-    );
+          focusIn() {
+            this.set('value', 'focusin');
+          },
+          focusOut() {
+            this.set('value', 'focusout');
+          },
+        })
+      );
+      await this.render(hbs`{{my-input}}`);
 
-    // using two arguments here to ensure the two way binding
-    // works both for things rendered in the component's layout
-    // and those only used in the components JS file
-    await this.render(hbs`{{my-component foo=foo bar=bar}}`);
-    click(this.element.querySelector('button'));
+      let input = this.element.querySelector('input');
+      assert.equal(input.value, 'init');
 
-    await this.clearRender();
+      focus(input);
+      assert.equal(input.value, 'focusin');
 
-    assert.equal(this.get('foo'), 'updated!');
-    assert.equal(this.get('bar'), 'updated bar!');
+      blur(input);
+      assert.equal(input.value, 'focusout');
+    });
+
+    test('two way bound arguments are updated', async function(assert) {
+      this.owner.register(
+        'component:my-component',
+        Component.extend({
+          actions: {
+            clicked() {
+              this.set('foo', 'updated!');
+            },
+          },
+        })
+      );
+      this.owner.register(
+        'template:components/my-component',
+        hbs`<button {{action 'clicked'}}>{{foo}}</button>`
+      );
+
+      this.set('foo', 'original');
+      await this.render(hbs`{{my-component foo=foo}}`);
+      assert.equal(this.element.textContent, 'original', 'value after initial render');
+
+      click(this.element.querySelector('button'));
+      assert.equal(this.element.textContent, 'updated!', 'value after updating');
+      assert.equal(this.get('foo'), 'updated!');
+    });
+
+    test('two way bound arguments are available after clearRender is called', async function(
+      assert
+    ) {
+      this.owner.register(
+        'component:my-component',
+        Component.extend({
+          actions: {
+            clicked() {
+              this.set('foo', 'updated!');
+              this.set('bar', 'updated bar!');
+            },
+          },
+        })
+      );
+      this.owner.register(
+        'template:components/my-component',
+        hbs`<button {{action 'clicked'}}>{{foo}}</button>`
+      );
+
+      // using two arguments here to ensure the two way binding
+      // works both for things rendered in the component's layout
+      // and those only used in the components JS file
+      await this.render(hbs`{{my-component foo=foo bar=bar}}`);
+      click(this.element.querySelector('button'));
+
+      await this.clearRender();
+
+      assert.equal(this.get('foo'), 'updated!');
+      assert.equal(this.get('bar'), 'updated bar!');
+    });
+
+    test('imported `render` can be used instead of this.render', async function(assert) {
+      await render(hbs`yippie!!`);
+
+      assert.equal(this.element.textContent, 'yippie!!');
+    });
+
+    test('imported clearRender can be used instead of this.clearRender', async function(assert) {
+      let testingRootElement = document.getElementById('ember-testing');
+
+      await this.render(hbs`<p>Hello!</p>`);
+
+      assert.equal(this.element.textContent, 'Hello!', 'has rendered content');
+      assert.equal(testingRootElement.textContent, 'Hello!', 'has rendered content');
+
+      await clearRender();
+      assert.equal(this.element, undefined, 'this.element is reset');
+
+      assert.equal(testingRootElement.textContent, '', 'content is cleared');
+    });
+  }
+
+  module('with only application set', function(hooks) {
+    hooks.beforeEach(function() {
+      setResolver(null);
+      setApplication(application);
+    });
+
+    setupRenderingContextTests(hooks);
   });
 
-  test('imported `render` can be used instead of this.render', async function(assert) {
-    await render(hbs`yippie!!`);
+  module('with application and resolver set', function(hooks) {
+    hooks.beforeEach(function() {
+      setResolver(resolver);
+      setApplication(application);
+    });
 
-    assert.equal(this.element.textContent, 'yippie!!');
+    setupRenderingContextTests(hooks);
   });
 
-  test('imported clearRender can be used instead of this.clearRender', async function(assert) {
-    let testingRootElement = document.getElementById('ember-testing');
+  module('with only resolver set', function(hooks) {
+    hooks.beforeEach(function() {
+      setResolver(resolver);
+      setApplication(null);
+    });
 
-    await this.render(hbs`<p>Hello!</p>`);
-
-    assert.equal(this.element.textContent, 'Hello!', 'has rendered content');
-    assert.equal(testingRootElement.textContent, 'Hello!', 'has rendered content');
-
-    await clearRender();
-    assert.equal(this.element, undefined, 'this.element is reset');
-
-    assert.equal(testingRootElement.textContent, '', 'content is cleared');
+    setupRenderingContextTests(hooks);
   });
 });


### PR DESCRIPTION
When the host project properly registers their application, the testing context will now boot a lightweight instance of the application (similar to what FastBoot does).

In this scenario both `initializers` and `instance-initializers` will run so no more manual initializer setup shenanigans (as [documented here fore mirage](http://www.ember-cli-mirage.com/docs/v0.3.x/manually-starting-mirage/)). This has been a very long standing point of confusion for folks while testing, and I'm **very** excited to finally have a path forward that is both performant and intuitive.

For those curious, `initializers` will run only once for the entire test suite (unlike acceptance tests prior to https://github.com/emberjs/rfcs/pull/268), and the `instance-initializers` will run once per test (which also mirrors how FastBoot works internally).

This new system nearly identically matches how _real_ applications work in the wild, and is a much less brittle platform for our continued testing "unification".

Fixes https://github.com/emberjs/ember-test-helpers/issues/234
