### PR TITLE
Automatically set resolver when `setApplication` is called.

### DIFF
--- a/addon-test-support/@ember/test-helpers/application.js
+++ b/addon-test-support/@ember/test-helpers/application.js
@@ -1,7 +1,16 @@
+import { getResolver, setResolver } from './resolver';
+
 var __application__;
 
 export function setApplication(application) {
   __application__ = application;
+
+  if (!getResolver()) {
+    let Resolver = application.Resolver;
+    let resolver = Resolver.create({ namespace: application });
+
+    setResolver(resolver);
+  }
 }
 
 export function getApplication() {

--- a/tests/helpers/resolver.js
+++ b/tests/helpers/resolver.js
@@ -1,18 +1,15 @@
 import Ember from 'ember';
 import { dasherize } from '@ember/string';
-import AppResolver, { setRegistry } from '../../resolver';
-import config from '../../config/environment';
+import { setRegistry } from '../../resolver';
 import { setResolver, setApplication } from 'ember-test-helpers';
 import require from 'require';
 import App from '../../app';
 
-export const resolver = AppResolver.create();
 export const application = App.create({ autoboot: false });
-
-resolver.namespace = {
-  modulePrefix: config.modulePrefix,
-  podModulePrefix: config.podModulePrefix,
-};
+export const resolver = application.Resolver.create({
+  namespace: application,
+  isResolverFromTestHelpers: true,
+});
 
 setResolver(resolver);
 setApplication(application);

--- a/tests/unit/application-test.js
+++ b/tests/unit/application-test.js
@@ -1,0 +1,43 @@
+import { module, test } from 'qunit';
+import { application, resolver } from '../helpers/resolver';
+import { setApplication, setResolver, getResolver } from '@ember/test-helpers';
+
+module('application', function(hooks) {
+  hooks.beforeEach(function() {
+    setApplication(null);
+    setResolver(null);
+  });
+
+  hooks.afterEach(function() {
+    setApplication(application);
+    setResolver(resolver);
+  });
+
+  test('calling setApplication sets resolver when resolver is unset', function(assert) {
+    setApplication(application);
+
+    let actualResolver = getResolver();
+    assert.ok(
+      actualResolver instanceof application.Resolver,
+      'a resolver instance was created from the provided application'
+    );
+    assert.equal(actualResolver.namespace, application, 'resolver has proper namespace specified');
+    assert.notOk(
+      actualResolver.isResolverFromTestHelpers,
+      'should not have used resolver created in tests/helpers/resolver.js'
+    );
+  });
+
+  test('calling setApplication when a resolver is set does not clobber existing resolver', function(
+    assert
+  ) {
+    setResolver(resolver);
+    setApplication(application);
+
+    let actualResolver = getResolver();
+    assert.ok(
+      actualResolver.isResolverFromTestHelpers,
+      'should have used resolver created in tests/helpers/resolver.js'
+    );
+  });
+});


### PR DESCRIPTION
This allows an application to call:

```js
setApplication(App.create({ autoboot: false }));
```

And still support legacy style `moduleFor*` tests.

Without this change the following both of the following invocations are required:

```js
setApplication(App.create({ autoboot: false }));
setResolver(resolver);
```