### PR TITLE
Implement `validateErrorHandler` utility.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ A quick summary of the exports from the `ember-test-helpers` module:
 * `teardownRenderingContext` - Cleans up any work done in a rendering test.
 * `settled` - Returns a promise which will resolve when all async from AJAX, test waiters, and 
   scheduled timers have completed.
+* `validateErrorHandler` - Used to ensure that the `Ember.onerror` error handler properly re-throws any errors during testing.
 
 ## Collaborating
 

--- a/addon-test-support/@ember/test-helpers/index.js
+++ b/addon-test-support/@ember/test-helpers/index.js
@@ -12,3 +12,4 @@ export { default as teardownContext } from './teardown-context';
 export { default as setupRenderingContext, render, clearRender } from './setup-rendering-context';
 export { default as teardownRenderingContext } from './teardown-rendering-context';
 export { default as settled } from './settled';
+export { default as validateErrorHandler } from './validate-error-handler';

--- a/addon-test-support/@ember/test-helpers/validate-error-handler.js
+++ b/addon-test-support/@ember/test-helpers/validate-error-handler.js
@@ -1,0 +1,28 @@
+import Ember from 'ember';
+const VALID = Object.freeze({ isValid: true, message: null });
+const INVALID = Object.freeze({
+  isValid: false,
+  message: 'error handler should have re-thrown the provided error',
+});
+
+export default function(callback = Ember.onerror) {
+  if (callback === undefined || callback === null) {
+    return VALID;
+  }
+
+  let error = new Error('Error handler validation error!');
+
+  let originalEmberTesting = Ember.testing;
+  Ember.testing = true;
+  try {
+    callback(error);
+  } catch (e) {
+    if (e === error) {
+      return VALID;
+    }
+  } finally {
+    Ember.testing = originalEmberTesting;
+  }
+
+  return INVALID;
+}

--- a/tests/unit/validate-error-handler-test.js
+++ b/tests/unit/validate-error-handler-test.js
@@ -1,0 +1,96 @@
+import { module, test } from 'qunit';
+import Ember from 'ember';
+
+import { validateErrorHandler } from '@ember/test-helpers';
+
+module('validateErrorHandler', function(hooks) {
+  hooks.beforeEach(function(assert) {
+    assert.valid = result => {
+      assert.deepEqual(result, {
+        isValid: true,
+        message: null,
+      });
+    };
+
+    assert.invalid = result => {
+      assert.deepEqual(result, {
+        isValid: false,
+        message: 'error handler should have re-thrown the provided error',
+      });
+    };
+  });
+
+  module('with a passed in callback', function() {
+    test('invokes the provided callback', function(assert) {
+      assert.expect(1);
+
+      validateErrorHandler(function() {
+        assert.ok(true, 'error handler was invoked');
+      });
+    });
+
+    test('considers handler missing to be a valid handler', function(assert) {
+      let result = validateErrorHandler(null);
+
+      assert.valid(result);
+    });
+
+    test('when the provided function does _not_ rethrow it is invalid', function(assert) {
+      let result = validateErrorHandler(function() {});
+
+      assert.invalid(result);
+    });
+
+    test('when the provided function does rethrow it is valid', function(assert) {
+      let result = validateErrorHandler(function(error) {
+        throw error;
+      });
+
+      assert.valid(result);
+    });
+  });
+
+  module('without a passed in callback', function(hooks) {
+    hooks.beforeEach(function() {
+      this.originalOnerror = Ember.onerror;
+    });
+
+    hooks.afterEach(function() {
+      Ember.onerror = this.originalOnerror;
+    });
+
+    test('invokes the provided callback', function(assert) {
+      assert.expect(1);
+
+      Ember.onerror = function() {
+        assert.ok(true, 'error handler was invoked');
+      };
+
+      validateErrorHandler();
+    });
+
+    test('considers handler missing to be a valid handler', function(assert) {
+      Ember.onerror = undefined;
+      let result = validateErrorHandler();
+
+      assert.valid(result);
+    });
+
+    test('when the provided function does _not_ rethrow it is invalid', function(assert) {
+      Ember.onerror = function() {};
+      let result = validateErrorHandler();
+
+      assert.invalid(result);
+    });
+
+    test('when the provided function does rethrow it is valid', function(assert) {
+      Ember.onerror = function(error) {
+        throw error;
+      };
+
+      let result = validateErrorHandler();
+
+      assert.valid(result);
+    });
+  });
+});


### PR DESCRIPTION
Ensures that `Ember.onerror` is setup that properly re-throws when testing.

This is intended to be used by test framework hosts (or other libraries) to ensure that `Ember.onerror` is properly configured. Without a check like this, `Ember.onerror` could _easily_ swallow all errors and make it _seem_ like everything is just fine (and have green tests) when in reality everything is on fire...

Example implementation for `ember-qunit`:

```js
import { validateErrorHandler } from '@ember/test-helpers';

test('Ember.onerror is functioning properly', function(assert) {
  let result = validateErrorHandler();
  assert.ok(result.isValid, result.message);
});
```


Additional reading:

* more detailed writeup in https://github.com/emberjs/ember.js/pull/15871
* [ember-test-friendly-error-handler](https://github.com/rwjblue/ember-test-friendly-error-handler) addon makes it very simple to implement a test friendly `Ember.onerror`