### PR TITLE
Expose `isSettled` utility function.

### DIFF
--- a/addon-test-support/@ember/test-helpers/index.js
+++ b/addon-test-support/@ember/test-helpers/index.js
@@ -11,5 +11,5 @@ export {
 export { default as teardownContext } from './teardown-context';
 export { default as setupRenderingContext, render, clearRender } from './setup-rendering-context';
 export { default as teardownRenderingContext } from './teardown-rendering-context';
-export { default as settled } from './settled';
+export { default as settled, isSettled } from './settled';
 export { default as validateErrorHandler } from './validate-error-handler';


### PR DESCRIPTION
This is a simple refactoring of the existing `settled` helper that exposes an `isSettled()` function which can be used generally to confirm that there are is no pending async.

One example use case is for `ember-qunit` (and also `ember-mocha`) to implement something like:

```js
import { isSettled } from '@ember/test-helpers';

QUnit.testDone(function(results) {
  if (!isSettled) {
    throw new Error(`${results.name} leaks async`);
  }
});
```