### PR TITLE
Add ember-beta to allowed failures.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ env:
 matrix:
   fast_finish: true
   allow_failures:
+    - env: EMBER_TRY_SCENARIO=ember-beta
     - env: EMBER_TRY_SCENARIO=ember-canary
 
 before_install:


### PR DESCRIPTION
https://github.com/emberjs/ember-test-helpers/issues/249 is created to track reverting this PR.