### PR TITLE
Fix order dependence in tests.

### DIFF
--- a/addon-test-support/@ember/test-helpers/teardown-context.js
+++ b/addon-test-support/@ember/test-helpers/teardown-context.js
@@ -1,6 +1,7 @@
 import { run, next } from '@ember/runloop';
 import { _teardownPromiseListeners } from './ext/rsvp';
 import { _teardownAJAXHooks } from './settled';
+import { unsetContext } from './setup-context';
 import { Promise } from 'rsvp';
 import Ember from 'ember';
 
@@ -16,6 +17,7 @@ export default function(context) {
       run(owner, 'destroy');
       Ember.testing = false;
 
+      unsetContext();
       resolve(context);
     });
   });

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -3,6 +3,10 @@ import { registerDeprecationHandler } from '@ember/debug';
 import AbstractTestLoader from 'ember-cli-test-loader/test-support/index';
 import Ember from 'ember';
 
+if (QUnit.config.seed) {
+  QUnit.config.reorder = false;
+}
+
 let moduleLoadFailures = [];
 
 QUnit.done(function() {

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -8,10 +8,15 @@ if (QUnit.config.seed) {
 }
 
 let moduleLoadFailures = [];
+let cleanupFailures = [];
 
 QUnit.done(function() {
   if (moduleLoadFailures.length) {
     throw new Error('\n' + moduleLoadFailures.join('\n'));
+  }
+
+  if (cleanupFailures.length) {
+    throw new Error('\n' + cleanupFailures.join('\n'));
   }
 });
 
@@ -46,11 +51,14 @@ QUnit.testStart(function() {
 QUnit.testDone(function({ module, name }) {
   // this is used to ensure that no tests accidentally leak `Ember.testing` state
   if (Ember.testing) {
-    throw new Error(
-      `Ember.testing should be reset after test has completed. ${module}: ${
-        name
-      } did not reset Ember.testing`
-    );
+    let message = `Ember.testing should be reset after test has completed. ${module}: ${
+      name
+    } did not reset Ember.testing`;
+    cleanupFailures.push(message);
+
+    // eslint-disable-next-line
+    console.error(message);
+    Ember.testing = false;
   }
 
   // this is used to ensure that the testing container is always reset properly
@@ -58,11 +66,14 @@ QUnit.testDone(function({ module, name }) {
   let actual = testElementContainer.innerHTML;
   let expected = `<div id="ember-testing"></div>`;
   if (actual !== expected) {
-    throw new Error(
-      `Expected #ember-testing-container to be reset after ${module}: ${name}, but was \`${
-        actual
-      }\``
-    );
+    let message = `Expected #ember-testing-container to be reset after ${module}: ${
+      name
+    }, but was \`${actual}\``;
+    cleanupFailures.push(message);
+
+    // eslint-disable-next-line
+    console.error(message);
+    testElementContainer.innerHTML = expected;
   }
 });
 

--- a/tests/unit/legacy-0-6-x/test-module-for-acceptance-test.js
+++ b/tests/unit/legacy-0-6-x/test-module-for-acceptance-test.js
@@ -21,7 +21,7 @@ moduleForAcceptance('TestModuleForAcceptance | Lifecycle', {
 
   beforeSetup(assert) {
     assert.expect(6);
-    assert.strictEqual(getContext(), undefined);
+    assert.ok(getContext() === undefined, 'precond - getContext() was reset');
 
     setResolverRegistry({
       'router:main': EmberRouter.extend({ location: 'none' }),

--- a/tests/unit/legacy-0-6-x/test-module-for-component-test.js
+++ b/tests/unit/legacy-0-6-x/test-module-for-component-test.js
@@ -334,6 +334,7 @@ test('deprecation is not raised', function(assert) {
 module('moduleForComponent: can be invoked with the component name and description', {
   beforeEach(assert) {
     var done = assert.async();
+    setupRegistry();
     testModule = new TestModuleForComponent('pretty-color', 'PrettyColor', {
       unit: true,
     });

--- a/tests/unit/legacy-0-6-x/test-module-test.js
+++ b/tests/unit/legacy-0-6-x/test-module-test.js
@@ -161,7 +161,7 @@ test("subject's created in a test are destroyed", function(assert) {
 });
 
 moduleFor('component:x-foo', 'component:x-foo -- without needs or `integration: true`', {
-  beforeSetup: setupRegistry(),
+  beforeSetup: () => setupRegistry(),
 });
 
 test('knows nothing about our non-subject component', function(assert) {
@@ -170,7 +170,7 @@ test('knows nothing about our non-subject component', function(assert) {
 });
 
 moduleFor('component:x-foo', 'component:x-foo -- when needing another component', {
-  beforeSetup: setupRegistry(),
+  beforeSetup: () => setupRegistry(),
   needs: ['component:not-the-subject'],
 });
 
@@ -337,6 +337,7 @@ var contexts, testModule;
 QUnit.module('context can be provided to TestModule', {
   beforeEach() {
     contexts = [this];
+    setupRegistry();
     testModule = new TestModule('component:x-foo', 'Foo', {
       setup() {
         contexts.push(this);
@@ -383,7 +384,9 @@ test('`toString` returns the test subject', function(assert) {
   );
 });
 
-moduleFor('component:x-foo', 'ember-testing resets to empty value');
+moduleFor('component:x-foo', 'ember-testing resets to empty value', {
+  beforeSetup: setupRegistry,
+});
 
 test('sets ember-testing content to "foobar"', function(assert) {
   assert.expect(0);
@@ -401,7 +404,7 @@ test('sets ember-testing content to "<div>foobar</div>"', function(assert) {
   assert.expect(1);
   document.getElementById('ember-testing').innerHTML = '<div>foobar</div>';
 
-  testModule = new TestModule('component:x-foo', 'Foo');
+  testModule = new TestModule('component:x-foo', 'Foo', { beforeSetup: setupRegistry });
   testModule.setContext(this);
   return testModule
     .setup(...arguments)

--- a/tests/unit/setup-context-test.js
+++ b/tests/unit/setup-context-test.js
@@ -23,7 +23,7 @@ module('setupContext', function(hooks) {
     return;
   }
 
-  hooks.before(function() {
+  hooks.beforeEach(function() {
     setResolverRegistry({
       'service:foo': Service.extend({ isFoo: true }),
     });
@@ -35,9 +35,7 @@ module('setupContext', function(hooks) {
       await teardownContext(context);
       context = undefined;
     }
-  });
 
-  hooks.after(function() {
     setApplication(application);
     setResolver(resolver);
   });

--- a/tests/unit/teardown-context-test.js
+++ b/tests/unit/teardown-context-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import Service from '@ember/service';
-import { setupContext, teardownContext } from 'ember-test-helpers';
+import { getContext, setupContext, teardownContext } from 'ember-test-helpers';
 import { setResolverRegistry } from '../helpers/resolver';
 import hasEmberVersion from 'ember-test-helpers/has-ember-version';
 import Ember from 'ember';
@@ -39,5 +39,13 @@ module('teardownContext', function(hooks) {
     await teardownContext(context);
 
     assert.notOk(Ember.testing, 'Ember.testing is falsey after teardown');
+  });
+
+  test('it unsets the context', async function(assert) {
+    assert.strictEqual(getContext(), context, 'precond');
+
+    await teardownContext(context);
+
+    assert.strictEqual(getContext(), undefined, 'context is unset');
   });
 });

--- a/tests/unit/teardown-context-test.js
+++ b/tests/unit/teardown-context-test.js
@@ -10,14 +10,11 @@ module('teardownContext', function(hooks) {
     return;
   }
 
-  hooks.before(function() {
+  let context;
+  hooks.beforeEach(function() {
     setResolverRegistry({
       'service:foo': Service.extend({ isFoo: true }),
     });
-  });
-
-  let context;
-  hooks.beforeEach(function() {
     context = {};
     return setupContext(context);
   });


### PR DESCRIPTION
* Refactor cleanup assertions to use global failure after test run.
* Avoid `before` and `after` when randomizing test order.
* Ensure `setupRegistry` is called _before_ it is needed each time.
* Simplify precondition assertion in test-module-for-acceptance tests.
* Make randomized seed testing easier.
* Ensure `unsetContext()` is called during teardown.