### PR TITLE
Remove usage of Ember.Handlebars.SafeString.

### DIFF
--- a/tests/unit/legacy-0-6-x/test-module-for-component-test.js
+++ b/tests/unit/legacy-0-6-x/test-module-for-component-test.js
@@ -17,6 +17,7 @@ import qunitModuleFor from '../../helpers/qunit-module-for';
 import hasjQuery from '../../helpers/has-jquery';
 import hbs from 'htmlbars-inline-precompile';
 import { fireEvent, focus, blur } from '../../helpers/events';
+import { htmlSafe } from '@ember/string';
 
 var Service = EmberService || EmberObject;
 
@@ -34,7 +35,7 @@ var PrettyColor = Component.extend({
   classNames: ['pretty-color'],
   attributeBindings: ['style'],
   style: computed('name', function() {
-    return new Ember.Handlebars.SafeString('color: ' + this.get('name') + ';');
+    return htmlSafe('color: ' + this.get('name') + ';');
   }),
 
   click() {


### PR DESCRIPTION
It has been long deprecated, and is removed in Ember 3.0 (current canary builds).