### PR TITLE
Wait for pending AJAX in acceptance tests.

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,10 @@
 module.exports = {
   name: 'ember-test-helpers',
 
+  included() {
+    this.import('vendor/monkey-patches.js', { type: 'test' });
+  },
+
   treeForAddonTestSupport(tree) {
     // intentionally not calling _super here
     // so that can have our `import`'s be

--- a/tests/helpers/module-for-acceptance.js
+++ b/tests/helpers/module-for-acceptance.js
@@ -2,11 +2,22 @@ import { resolve } from 'rsvp';
 import { module } from 'qunit';
 import startApp from '../helpers/start-app';
 import destroyApp from '../helpers/destroy-app';
+import { setResolverRegistry } from './resolver';
+import QUnitTestAdapter from './qunit-test-adapter';
 import Ember from 'ember';
 
 export default function(name, options = {}) {
   module(name, {
     beforeEach() {
+      Ember.Test.adapter = QUnitTestAdapter.create();
+
+      if (options.registry) {
+        setResolverRegistry(options.registry);
+      }
+
+      let testElementContainer = document.querySelector('#ember-testing-container');
+      this.fixtureResetValue = testElementContainer.innerHTML;
+
       Ember.testing = true;
       this.application = startApp();
 
@@ -19,7 +30,11 @@ export default function(name, options = {}) {
       let afterEach = options.afterEach && options.afterEach.apply(this, arguments);
       return resolve(afterEach)
         .then(() => destroyApp(this.application))
-        .finally(() => (Ember.testing = false));
+        .finally(() => {
+          Ember.testing = false;
+
+          document.getElementById('ember-testing-container').innerHTML = this.fixtureResetValue;
+        });
     },
   });
 }

--- a/tests/integration/module-for-acceptance-interop-test.js
+++ b/tests/integration/module-for-acceptance-interop-test.js
@@ -1,0 +1,74 @@
+import { test } from 'qunit';
+import { run } from '@ember/runloop';
+import EmberRouter from '@ember/routing/router';
+import Component from '@ember/component';
+import { settled } from '@ember/test-helpers';
+import hasEmberVersion from '@ember/test-helpers/has-ember-version';
+
+import hbs from 'htmlbars-inline-precompile';
+import ajax from '../helpers/ajax';
+import { fireEvent } from '../helpers/events';
+import Pretender from 'pretender';
+import moduleForAcceptance from '../helpers/module-for-acceptance';
+
+const TestComponent3 = Component.extend({
+  layout: hbs`{{internalValue}}`,
+
+  internalValue: '',
+
+  click() {
+    ajax('/whazzits').then(data => {
+      let value = this.get('internalValue');
+
+      run(this, 'set', 'internalValue', value + data);
+    });
+  },
+});
+
+const Router = EmberRouter.extend({ location: 'none' });
+Router.map(function() {
+  this.route('ajax-request');
+});
+
+moduleForAcceptance('Classic "moduleForAcceptance" | using settled', {
+  registry: {
+    'router:main': Router,
+    'component:x-test-3': TestComponent3,
+    'template:ajax-request': hbs`{{x-test-3 class="special-thing"}}`,
+  },
+
+  beforeEach() {
+    this.server = new Pretender(function() {
+      this.get(
+        '/whazzits',
+        function() {
+          return [200, { 'Content-Type': 'text/plain' }, 'Remote Data!'];
+        },
+        25
+      );
+    });
+  },
+
+  afterEach() {
+    this.server.shutdown();
+  },
+});
+
+// this requires Ember 2.8 or higher due to a refactor that exposed the
+// internal mechanism that tracks pending requests in legacy acceptance tests,
+// in older versions of ember legacy acceptance tests using `settled` from
+// `ember-test-helpers` will **not** wait on pending requests.
+if (hasEmberVersion(2, 8)) {
+  test('Basic acceptance test using instance test helpers', function(assert) {
+    return this.application.testHelpers
+      .visit('/ajax-request')
+      .then(() => {
+        fireEvent(document.querySelector('.special-thing'), 'click');
+        return settled();
+      })
+      .then(() => {
+        let testingElement = document.getElementById('ember-testing');
+        assert.equal(testingElement.textContent, 'Remote Data!');
+      });
+  });
+}

--- a/vendor/monkey-patches.js
+++ b/vendor/monkey-patches.js
@@ -1,0 +1,35 @@
+/* globals require, Ember, jQuery */
+
+(function() {
+  if (typeof jQuery !== 'undefined') {
+    var _Ember;
+    if (typeof Ember !== 'undefined') {
+      _Ember = Ember;
+    } else {
+      _Ember = require('ember').default;
+    }
+
+    var pendingRequests;
+    if (Ember.__loader.registry['ember-testing/test/pending_requests']) {
+      pendingRequests = Ember.__loader.require('ember-testing/test/pending_requests');
+    }
+
+    if (pendingRequests) {
+      // This exists to ensure that the AJAX listeners setup by Ember itself
+      // (which as of 2.17 are not properly torn down) get cleared and released
+      // when the application is destroyed. Without this, any AJAX requests
+      // that happen _between_ when acceptance tests will always share
+      // `pendingRequests`.
+      _Ember.Application.reopen({
+        willDestroy() {
+          jQuery(document).off('ajaxSend', pendingRequests.incrementPendingRequests);
+          jQuery(document).off('ajaxComplete', pendingRequests.decrementPendingRequests);
+
+          pendingRequests.clearPendingRequests();
+
+          this._super.apply(this, arguments);
+        },
+      });
+    }
+  }
+})();

--- a/vendor/monkey-patches.js
+++ b/vendor/monkey-patches.js
@@ -18,7 +18,7 @@
       // This exists to ensure that the AJAX listeners setup by Ember itself
       // (which as of 2.17 are not properly torn down) get cleared and released
       // when the application is destroyed. Without this, any AJAX requests
-      // that happen _between_ when acceptance tests will always share
+      // that happen _between_ acceptance tests will always share
       // `pendingRequests`.
       _Ember.Application.reopen({
         willDestroy() {


### PR DESCRIPTION
Ember internally tracks AJAX requests in the same way that we do here for legacy style "acceptance" tests using the `ember-testing.js` asset provided by emberjs/ember.js itself. When `@ember/test-helpers`'s `settled` utility is used in a legacy acceptance test context any pending AJAX requests are not properly considered during the `isSettled` check below.

This utilizes a local utility method present in Ember since around 2.8.0 to properly consider pending AJAX requests done within legacy acceptance tests.