### PR TITLE
Use `nextTick` and `nextTickPromise` throughout codebase.

### DIFF
--- a/addon-test-support/@ember/test-helpers/-utils.js
+++ b/addon-test-support/@ember/test-helpers/-utils.js
@@ -1,6 +1,7 @@
 import { Promise } from 'rsvp';
 
 export const nextTick = setTimeout;
+export const futureTick = setTimeout;
 
 export function nextTickPromise() {
   return new Promise(resolve => {

--- a/addon-test-support/@ember/test-helpers/settled.js
+++ b/addon-test-support/@ember/test-helpers/settled.js
@@ -4,10 +4,7 @@ import { Promise as EmberPromise } from 'rsvp';
 import jQuery from 'jquery';
 
 import Ember from 'ember';
-import global from './global';
-
-// TODO: refactor to use `nextTick` from #258
-const SET_TIMEOUT = global.setTimeout;
+import { nextTick, futureTick } from './-utils';
 
 // Ember internally tracks AJAX requests in the same way that we do here for
 // legacy style "acceptance" tests using the `ember-testing.js` asset provided
@@ -49,7 +46,7 @@ function decrementAjaxPendingRequests(_, xhr) {
   // counter will decrement. In the specific case of AJAX, this means that any
   // promises chained off of `$.ajax` will properly have their `.then` called
   // _before_ this is decremented (and testing continues)
-  SET_TIMEOUT(() => {
+  nextTick(() => {
     for (let i = 0; i < requests.length; i++) {
       if (xhr === requests[i]) {
         requests.splice(i, 1);
@@ -146,7 +143,7 @@ export default function settled(options) {
         timeout = MAX_TIMEOUT;
       }
 
-      global.setTimeout(function() {
+      futureTick(function() {
         let settled = isSettled(options);
         if (settled) {
           // Synchronously resolve the promise

--- a/addon-test-support/@ember/test-helpers/setup-context.js
+++ b/addon-test-support/@ember/test-helpers/setup-context.js
@@ -1,4 +1,4 @@
-import { run, next } from '@ember/runloop';
+import { run } from '@ember/runloop';
 import { set, setProperties, get, getProperties } from '@ember/object';
 import buildOwner from './build-owner';
 import { _setupPromiseListeners } from './ext/rsvp';
@@ -9,6 +9,7 @@ import { assert } from '@ember/debug';
 import global from './global';
 import { getResolver } from './resolver';
 import { getApplication } from './application';
+import { nextTickPromise } from './-utils';
 
 let __test_context__;
 
@@ -61,10 +62,7 @@ export default function(context, options = {}) {
   Ember.testing = true;
   setContext(context);
 
-  return new Promise(resolve => {
-    // ensure "real" async and not "fake" RSVP based async
-    next(resolve);
-  })
+  return nextTickPromise()
     .then(() => {
       let { resolver } = options;
       let buildOwnerOptions;

--- a/addon-test-support/@ember/test-helpers/setup-rendering-context.js
+++ b/addon-test-support/@ember/test-helpers/setup-rendering-context.js
@@ -1,9 +1,10 @@
 import { guidFor } from '@ember/object/internals';
-import { run, next } from '@ember/runloop';
-import { Promise } from 'rsvp';
+import { run } from '@ember/runloop';
 import Ember from 'ember';
 import global from './global';
 import { getContext } from './setup-context';
+import { nextTickPromise } from './-utils';
+import settled from './settled';
 
 export const RENDERING_CLEANUP = Object.create(null);
 
@@ -48,156 +49,147 @@ export default function(context) {
     },
   ];
 
-  return new Promise(resolve => {
-    // ensure "real" async and not "fake" RSVP based async
-    next(() => {
-      let { owner } = context;
+  return nextTickPromise().then(() => {
+    let { owner } = context;
 
-      // When the host app uses `setApplication` (instead of `setResolver`) the event dispatcher has
-      // already been setup via `applicationInstance.boot()` in `./build-owner`. If using
-      // `setResolver` (instead of `setApplication`) a "mock owner" is created by extending
-      // `Ember._ContainerProxyMixin` and `Ember._RegistryProxyMixin` in this scenario we need to
-      // manually start the event dispatcher.
-      if (owner._emberTestHelpersMockOwner) {
-        let dispatcher = owner.lookup('event_dispatcher:main') || Ember.EventDispatcher.create();
-        dispatcher.setup({}, '#ember-testing');
-      }
+    // When the host app uses `setApplication` (instead of `setResolver`) the event dispatcher has
+    // already been setup via `applicationInstance.boot()` in `./build-owner`. If using
+    // `setResolver` (instead of `setApplication`) a "mock owner" is created by extending
+    // `Ember._ContainerProxyMixin` and `Ember._RegistryProxyMixin` in this scenario we need to
+    // manually start the event dispatcher.
+    if (owner._emberTestHelpersMockOwner) {
+      let dispatcher = owner.lookup('event_dispatcher:main') || Ember.EventDispatcher.create();
+      dispatcher.setup({}, '#ember-testing');
+    }
 
-      let OutletView = owner.factoryFor
-        ? owner.factoryFor('view:-outlet')
-        : owner._lookupFactory('view:-outlet');
-      let OutletTemplate = owner.lookup('template:-outlet');
-      let toplevelView = OutletView.create();
-      RENDERING_CLEANUP[guid].push(() => toplevelView.destroy());
+    let OutletView = owner.factoryFor
+      ? owner.factoryFor('view:-outlet')
+      : owner._lookupFactory('view:-outlet');
+    let OutletTemplate = owner.lookup('template:-outlet');
+    let toplevelView = OutletView.create();
+    RENDERING_CLEANUP[guid].push(() => toplevelView.destroy());
 
-      let hasOutletTemplate = Boolean(OutletTemplate);
-      let outletState = {
-        render: {
-          owner,
-          into: undefined,
-          outlet: 'main',
-          name: 'application',
-          controller: context,
-          ViewClass: undefined,
-          template: OutletTemplate,
-        },
+    let hasOutletTemplate = Boolean(OutletTemplate);
+    let outletState = {
+      render: {
+        owner,
+        into: undefined,
+        outlet: 'main',
+        name: 'application',
+        controller: context,
+        ViewClass: undefined,
+        template: OutletTemplate,
+      },
 
-        outlets: {},
-      };
+      outlets: {},
+    };
 
-      let element, hasRendered;
-      let templateId = 0;
+    let element, hasRendered;
+    let templateId = 0;
 
-      if (hasOutletTemplate) {
-        run(() => {
-          toplevelView.setOutletState(outletState);
-        });
-      }
-
-      context.render = function render(template) {
-        if (!template) {
-          throw new Error('you must pass a template to `render()`');
-        }
-
-        // ensure context.element is reset until after rendering has completed
-        element = undefined;
-
-        return new Promise(function asyncRender(resolve) {
-          // manually enter async land, so that rendering itself is always async (even though
-          // Ember <= 2.18 do not require async rendering)
-          next(function asyncRenderSetup() {
-            templateId += 1;
-            let templateFullName = `template:-undertest-${templateId}`;
-            owner.register(templateFullName, template);
-            let stateToRender = {
-              owner,
-              into: undefined,
-              outlet: 'main',
-              name: 'index',
-              controller: context,
-              ViewClass: undefined,
-              template: owner.lookup(templateFullName),
-              outlets: {},
-            };
-
-            if (hasOutletTemplate) {
-              stateToRender.name = 'index';
-              outletState.outlets.main = { render: stateToRender, outlets: {} };
-            } else {
-              stateToRender.name = 'application';
-              outletState = { render: stateToRender, outlets: {} };
-            }
-
-            toplevelView.setOutletState(outletState);
-            if (!hasRendered) {
-              // TODO: make this id configurable
-              run(toplevelView, 'appendTo', '#ember-testing');
-              hasRendered = true;
-            }
-
-            // using next here because the actual rendering does not happen until
-            // the renderer detects it is dirty (which happens on backburner's end
-            // hook), see the following implementation details:
-            //
-            // * [view:outlet](https://github.com/emberjs/ember.js/blob/f94a4b6aef5b41b96ef2e481f35e07608df01440/packages/ember-glimmer/lib/views/outlet.js#L129-L145) manually dirties its own tag upon `setOutletState`
-            // * [backburner's custom end hook](https://github.com/emberjs/ember.js/blob/f94a4b6aef5b41b96ef2e481f35e07608df01440/packages/ember-glimmer/lib/renderer.js#L145-L159) detects that the current revision of the root is no longer the latest, and triggers a new rendering transaction
-            next(function asyncUpdateElementAfterRender() {
-              // ensure the element is based on the wrapping toplevel view
-              // Ember still wraps the main application template with a
-              // normal tagged view
-              //
-              // In older Ember versions (2.4) the element itself is not stable,
-              // and therefore we cannot update the `this.element` until after the
-              // rendering is completed
-              element = document.querySelector('#ember-testing > .ember-view');
-
-              resolve();
-            });
-          });
-        });
-      };
-
-      Object.defineProperty(context, 'element', {
-        enumerable: true,
-        configurable: true,
-        get() {
-          return element;
-        },
+    if (hasOutletTemplate) {
+      run(() => {
+        toplevelView.setOutletState(outletState);
       });
+    }
 
-      if (global.jQuery) {
-        context.$ = function $(selector) {
-          // emulates Ember internal behavor of `this.$` in a component
-          // https://github.com/emberjs/ember.js/blob/v2.5.1/packages/ember-views/lib/views/states/has_element.js#L18
-          return selector ? global.jQuery(selector, element) : global.jQuery(element);
-        };
+    context.render = function render(template) {
+      if (!template) {
+        throw new Error('you must pass a template to `render()`');
       }
 
-      context.clearRender = function clearRender() {
-        return new Promise(function async_clearRender(resolve) {
-          element = undefined;
+      // ensure context.element is reset until after rendering has completed
+      element = undefined;
 
-          next(function async_clearRender() {
-            toplevelView.setOutletState({
-              render: {
-                owner,
-                into: undefined,
-                outlet: 'main',
-                name: 'application',
-                controller: context,
-                ViewClass: undefined,
-                template: undefined,
-              },
-              outlets: {},
-            });
+      return nextTickPromise()
+        .then(() => {
+          templateId += 1;
+          let templateFullName = `template:-undertest-${templateId}`;
+          owner.register(templateFullName, template);
+          let stateToRender = {
+            owner,
+            into: undefined,
+            outlet: 'main',
+            name: 'index',
+            controller: context,
+            ViewClass: undefined,
+            template: owner.lookup(templateFullName),
+            outlets: {},
+          };
 
-            // RE: next usage, see detailed comment above
-            next(resolve);
-          });
+          if (hasOutletTemplate) {
+            stateToRender.name = 'index';
+            outletState.outlets.main = { render: stateToRender, outlets: {} };
+          } else {
+            stateToRender.name = 'application';
+            outletState = { render: stateToRender, outlets: {} };
+          }
+
+          toplevelView.setOutletState(outletState);
+          if (!hasRendered) {
+            // TODO: make this id configurable
+            run(toplevelView, 'appendTo', '#ember-testing');
+            hasRendered = true;
+          }
+
+          // using next here because the actual rendering does not happen until
+          // the renderer detects it is dirty (which happens on backburner's end
+          // hook), see the following implementation details:
+          //
+          // * [view:outlet](https://github.com/emberjs/ember.js/blob/f94a4b6aef5b41b96ef2e481f35e07608df01440/packages/ember-glimmer/lib/views/outlet.js#L129-L145) manually dirties its own tag upon `setOutletState`
+          // * [backburner's custom end hook](https://github.com/emberjs/ember.js/blob/f94a4b6aef5b41b96ef2e481f35e07608df01440/packages/ember-glimmer/lib/renderer.js#L145-L159) detects that the current revision of the root is no longer the latest, and triggers a new rendering transaction
+          return nextTickPromise();
+        })
+        .then(() => {
+          // ensure the element is based on the wrapping toplevel view
+          // Ember still wraps the main application template with a
+          // normal tagged view
+          //
+          // In older Ember versions (2.4) the element itself is not stable,
+          // and therefore we cannot update the `this.element` until after the
+          // rendering is completed
+          element = document.querySelector('#ember-testing > .ember-view');
+
+          return settled();
         });
-      };
+    };
 
-      resolve(context);
+    Object.defineProperty(context, 'element', {
+      enumerable: true,
+      configurable: true,
+      get() {
+        return element;
+      },
     });
+
+    if (global.jQuery) {
+      context.$ = function $(selector) {
+        // emulates Ember internal behavor of `this.$` in a component
+        // https://github.com/emberjs/ember.js/blob/v2.5.1/packages/ember-views/lib/views/states/has_element.js#L18
+        return selector ? global.jQuery(selector, element) : global.jQuery(element);
+      };
+    }
+
+    context.clearRender = function clearRender() {
+      element = undefined;
+      return nextTickPromise().then(() => {
+        toplevelView.setOutletState({
+          render: {
+            owner,
+            into: undefined,
+            outlet: 'main',
+            name: 'application',
+            controller: context,
+            ViewClass: undefined,
+            template: undefined,
+          },
+          outlets: {},
+        });
+
+        return settled();
+      });
+    };
+
+    return context;
   });
 }

--- a/addon-test-support/@ember/test-helpers/teardown-context.js
+++ b/addon-test-support/@ember/test-helpers/teardown-context.js
@@ -1,24 +1,23 @@
-import { run, next } from '@ember/runloop';
+import { run } from '@ember/runloop';
 import { _teardownPromiseListeners } from './ext/rsvp';
 import { _teardownAJAXHooks } from './settled';
 import { unsetContext } from './setup-context';
-import { Promise } from 'rsvp';
+import { nextTickPromise } from './-utils';
+import settled from './settled';
 import Ember from 'ember';
 
 export default function(context) {
-  return new Promise(resolve => {
-    // ensure "real" async and not "fake" RSVP based async
-    next(() => {
-      let { owner } = context;
+  return nextTickPromise().then(() => {
+    let { owner } = context;
 
-      _teardownPromiseListeners();
-      _teardownAJAXHooks();
+    _teardownPromiseListeners();
+    _teardownAJAXHooks();
 
-      run(owner, 'destroy');
-      Ember.testing = false;
+    run(owner, 'destroy');
+    Ember.testing = false;
 
-      unsetContext();
-      resolve(context);
-    });
+    unsetContext();
+
+    return settled();
   });
 }

--- a/addon-test-support/@ember/test-helpers/teardown-rendering-context.js
+++ b/addon-test-support/@ember/test-helpers/teardown-rendering-context.js
@@ -1,21 +1,20 @@
 import { guidFor } from '@ember/object/internals';
-import { run, next } from '@ember/runloop';
-import { Promise } from 'rsvp';
+import { run } from '@ember/runloop';
 import { RENDERING_CLEANUP } from './setup-rendering-context';
+import { nextTickPromise } from './-utils';
+import settled from './settled';
 
 export default function(context) {
-  return new Promise(resolve => {
-    // ensure "real" async and not "fake" RSVP based async
-    next(() => {
-      let guid = guidFor(context);
-      let destroyables = RENDERING_CLEANUP[guid];
+  return nextTickPromise().then(() => {
+    let guid = guidFor(context);
+    let destroyables = RENDERING_CLEANUP[guid];
 
-      for (let i = 0; i < destroyables.length; i++) {
-        run(destroyables[i]);
-      }
+    for (let i = 0; i < destroyables.length; i++) {
+      run(destroyables[i]);
+    }
 
-      delete RENDERING_CLEANUP[guid];
-      resolve(context);
-    });
+    delete RENDERING_CLEANUP[guid];
+
+    return settled();
   });
 }


### PR DESCRIPTION
Updates `setupContext` and `setupRenderingContext` to use `nextTickPromise` (simplifying the code nicely).

Also adds `settled()` calls after `render`, `clearRender`, `teardownContext`, and `teardownRenderingContext` to ensure that all run-loop business has been completed before returning.

Fixes https://github.com/emberjs/ember-test-helpers/issues/268.