### PR TITLE
Ensure `vendor` is transpiled.

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,4 +17,16 @@ module.exports = {
       registry: this.registry,
     });
   },
+
+  treeForVendor(rawVendorTree) {
+    let babelAddon = this.addons.find(addon => addon.name === 'ember-cli-babel');
+
+    let transpiledVendorTree = babelAddon.transpileTree(rawVendorTree, {
+      'ember-cli-babel': {
+        compileModules: false,
+      },
+    });
+
+    return transpiledVendorTree;
+  },
 };

--- a/vendor/monkey-patches.js
+++ b/vendor/monkey-patches.js
@@ -1,15 +1,15 @@
 /* globals require, Ember, jQuery */
 
-(function() {
+(() => {
   if (typeof jQuery !== 'undefined') {
-    var _Ember;
+    let _Ember;
     if (typeof Ember !== 'undefined') {
       _Ember = Ember;
     } else {
       _Ember = require('ember').default;
     }
 
-    var pendingRequests;
+    let pendingRequests;
     if (Ember.__loader.registry['ember-testing/test/pending_requests']) {
       pendingRequests = Ember.__loader.require('ember-testing/test/pending_requests');
     }
@@ -27,7 +27,7 @@
 
           pendingRequests.clearPendingRequests();
 
-          this._super.apply(this, arguments);
+          this._super(...arguments);
         },
       });
     }


### PR DESCRIPTION
Fixes an issue introduced by #264 on IE11.