### PR TITLE
Ensure `vendor` tree is transpiled when developing addon.

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -8,6 +8,9 @@ module.exports = function(defaults) {
     eslint: {
       testGenerator: 'qunit',
     },
+    trees: {
+      vendor: null,
+    },
   };
 
   if (defaults.project.findAddonByName('ember-native-dom-event-dispatcher')) {


### PR DESCRIPTION
By default ember-cli updates a number of the "app trees" to be from `tests/dummy` when developing an addon locally. We do this for `app`, `styles`, `templates`, `public`, and `tests` trees (handled inside `lib/broccoli/ember-addon.js`).

Unfortunately, we do **not** forward the apps `vendor` tree to `tests/dummy/`. This means that our addon's `treeForVendor` is called, but then subsequently _clobbered_ by the "apps" `vendor` tree (which is _literally the same tree_, but untranspiled).

IMHO, this should be fixed in ember-cli upstream. I can't imagine anyone relying on this behavior intentionally...