### PR TITLE
Split cleanup into two buckets.

### DIFF
--- a/addon-test-support/@ember/test-helpers/-utils.js
+++ b/addon-test-support/@ember/test-helpers/-utils.js
@@ -8,3 +8,17 @@ export function nextTickPromise() {
     nextTick(resolve);
   });
 }
+
+export function runDestroyablesFor(bucket, key) {
+  let destroyables = bucket[key];
+
+  if (!destroyables) {
+    return;
+  }
+
+  for (let i = 0; i < destroyables.length; i++) {
+    destroyables[i]();
+  }
+
+  delete bucket[key];
+}

--- a/addon-test-support/@ember/test-helpers/setup-context.js
+++ b/addon-test-support/@ember/test-helpers/setup-context.js
@@ -1,5 +1,6 @@
 import { run } from '@ember/runloop';
 import { set, setProperties, get, getProperties } from '@ember/object';
+import { guidFor } from '@ember/object/internals';
 import buildOwner from './build-owner';
 import { _setupPromiseListeners } from './ext/rsvp';
 import { _setupAJAXHooks } from './settled';
@@ -49,6 +50,8 @@ export function resumeTest() {
   return context.resumeTest();
 }
 
+export const CLEANUP = Object.create(null);
+
 /*
  * Responsible for:
  *
@@ -61,6 +64,9 @@ export function resumeTest() {
 export default function(context, options = {}) {
   Ember.testing = true;
   setContext(context);
+
+  let contextGuid = guidFor(context);
+  CLEANUP[contextGuid] = [];
 
   return nextTickPromise()
     .then(() => {

--- a/addon-test-support/@ember/test-helpers/teardown-context.js
+++ b/addon-test-support/@ember/test-helpers/teardown-context.js
@@ -1,23 +1,32 @@
+import { guidFor } from '@ember/object/internals';
 import { run } from '@ember/runloop';
 import { _teardownPromiseListeners } from './ext/rsvp';
 import { _teardownAJAXHooks } from './settled';
-import { unsetContext } from './setup-context';
-import { nextTickPromise } from './-utils';
+import { unsetContext, CLEANUP } from './setup-context';
+import { nextTickPromise, runDestroyablesFor } from './-utils';
 import settled from './settled';
 import Ember from 'ember';
 
 export default function(context) {
-  return nextTickPromise().then(() => {
-    let { owner } = context;
+  return nextTickPromise()
+    .then(() => {
+      let { owner } = context;
 
-    _teardownPromiseListeners();
-    _teardownAJAXHooks();
+      _teardownPromiseListeners();
+      _teardownAJAXHooks();
 
-    run(owner, 'destroy');
-    Ember.testing = false;
+      run(owner, 'destroy');
+      Ember.testing = false;
 
-    unsetContext();
+      unsetContext();
 
-    return settled();
-  });
+      return settled();
+    })
+    .finally(() => {
+      let contextGuid = guidFor(context);
+
+      runDestroyablesFor(CLEANUP, contextGuid);
+
+      return settled();
+    });
 }

--- a/addon-test-support/@ember/test-helpers/teardown-rendering-context.js
+++ b/addon-test-support/@ember/test-helpers/teardown-rendering-context.js
@@ -1,19 +1,13 @@
 import { guidFor } from '@ember/object/internals';
-import { run } from '@ember/runloop';
 import { RENDERING_CLEANUP } from './setup-rendering-context';
-import { nextTickPromise } from './-utils';
+import { nextTickPromise, runDestroyablesFor } from './-utils';
 import settled from './settled';
 
 export default function(context) {
   return nextTickPromise().then(() => {
-    let guid = guidFor(context);
-    let destroyables = RENDERING_CLEANUP[guid];
+    let contextGuid = guidFor(context);
 
-    for (let i = 0; i < destroyables.length; i++) {
-      run(destroyables[i]);
-    }
-
-    delete RENDERING_CLEANUP[guid];
+    runDestroyablesFor(RENDERING_CLEANUP, contextGuid);
 
     return settled();
   });

--- a/tests/unit/teardown-rendering-context-test.js
+++ b/tests/unit/teardown-rendering-context-test.js
@@ -32,6 +32,7 @@ module('setupRenderingContext', function(hooks) {
     assert.ok(document.contains(beforeTeardownEl), 'precond - ember-testing element is in DOM');
 
     await teardownRenderingContext(this);
+    await teardownContext(this);
 
     let afterTeardownEl = document.getElementById('ember-testing');
 


### PR DESCRIPTION
The following are the two cleanup buckets:

* `RENDERING_CLEANUP` is done when `teardownRenderingContext` is done (which should **always** be before `teardownContext` is ran).
* `CLEANUP` is done _after_ everything else is destroyed and settled.

---

This refactor fixes the vast majority of issues on IE11. Prior to these changes we were resetting the DOM test fixtures to their original values _before_ we had properly cleaned up the DOM. This meant that when the DOM cleanup actually does run, the various nodes being removed by glimmer's internal cleanup system are not actually present in DOM.  Apparently, Chrome / FireFox / Safari / Edge are all fine with this situation (and silently allow `node.removeChild(someThingNotInNode)` without an error), but IE11 did properly (IMHO) error that `someThingNotInNode` was not found.