### PR TITLE
Refactor `setupRenderingContext` so that element is stable after setup.

### DIFF
--- a/addon-test-support/@ember/test-helpers/setup-rendering-context.js
+++ b/addon-test-support/@ember/test-helpers/setup-rendering-context.js
@@ -5,6 +5,7 @@ import global from './global';
 import { getContext } from './setup-context';
 import { nextTickPromise } from './-utils';
 import settled from './settled';
+import hbs from 'htmlbars-inline-precompile';
 
 export const RENDERING_CLEANUP = Object.create(null);
 
@@ -57,14 +58,17 @@ export default function(context) {
     let OutletView = owner.factoryFor
       ? owner.factoryFor('view:-outlet')
       : owner._lookupFactory('view:-outlet');
-    let OutletTemplate = owner.lookup('template:-outlet');
     let toplevelView = OutletView.create();
+    let OutletTemplate = owner.lookup('template:-outlet');
+    if (!OutletTemplate) {
+      owner.register('template:-outlet', hbs`{{outlet}}`);
+      OutletTemplate = owner.lookup('template:-outlet');
+    }
 
     // push this into the rendering specific cleanup bucket, to be ran during
     // `teardownRenderingContext` but before the owner itself is destroyed
     RENDERING_CLEANUP[contextGuid].push(() => toplevelView.destroy());
 
-    let hasOutletTemplate = Boolean(OutletTemplate);
     let outletState = {
       render: {
         owner,
@@ -78,95 +82,66 @@ export default function(context) {
 
       outlets: {},
     };
+    toplevelView.setOutletState(outletState);
 
-    let element, hasRendered;
+    // TODO: make this id configurable
+    run(toplevelView, 'appendTo', '#ember-testing');
+
+    // ensure the element is based on the wrapping toplevel view
+    // Ember still wraps the main application template with a
+    // normal tagged view
+    //
+    // In older Ember versions (2.4) the element itself is not stable,
+    // and therefore we cannot update the `this.element` until after the
+    // rendering is completed
+    context.element = document.querySelector('#ember-testing > .ember-view');
+
     let templateId = 0;
-
-    if (hasOutletTemplate) {
-      run(() => {
-        toplevelView.setOutletState(outletState);
-      });
-    }
 
     context.render = function render(template) {
       if (!template) {
         throw new Error('you must pass a template to `render()`');
       }
 
-      // ensure context.element is reset until after rendering has completed
-      element = undefined;
+      return nextTickPromise().then(() => {
+        templateId += 1;
+        let templateFullName = `template:-undertest-${templateId}`;
+        owner.register(templateFullName, template);
+        let stateToRender = {
+          owner,
+          into: undefined,
+          outlet: 'main',
+          name: 'index',
+          controller: context,
+          ViewClass: undefined,
+          template: owner.lookup(templateFullName),
+          outlets: {},
+        };
 
-      return nextTickPromise()
-        .then(() => {
-          templateId += 1;
-          let templateFullName = `template:-undertest-${templateId}`;
-          owner.register(templateFullName, template);
-          let stateToRender = {
-            owner,
-            into: undefined,
-            outlet: 'main',
-            name: 'index',
-            controller: context,
-            ViewClass: undefined,
-            template: owner.lookup(templateFullName),
-            outlets: {},
-          };
+        stateToRender.name = 'index';
+        outletState.outlets.main = { render: stateToRender, outlets: {} };
 
-          if (hasOutletTemplate) {
-            stateToRender.name = 'index';
-            outletState.outlets.main = { render: stateToRender, outlets: {} };
-          } else {
-            stateToRender.name = 'application';
-            outletState = { render: stateToRender, outlets: {} };
-          }
+        toplevelView.setOutletState(outletState);
 
-          toplevelView.setOutletState(outletState);
-          if (!hasRendered) {
-            // TODO: make this id configurable
-            run(toplevelView, 'appendTo', '#ember-testing');
-            hasRendered = true;
-          }
-
-          // using next here because the actual rendering does not happen until
-          // the renderer detects it is dirty (which happens on backburner's end
-          // hook), see the following implementation details:
-          //
-          // * [view:outlet](https://github.com/emberjs/ember.js/blob/f94a4b6aef5b41b96ef2e481f35e07608df01440/packages/ember-glimmer/lib/views/outlet.js#L129-L145) manually dirties its own tag upon `setOutletState`
-          // * [backburner's custom end hook](https://github.com/emberjs/ember.js/blob/f94a4b6aef5b41b96ef2e481f35e07608df01440/packages/ember-glimmer/lib/renderer.js#L145-L159) detects that the current revision of the root is no longer the latest, and triggers a new rendering transaction
-          return nextTickPromise();
-        })
-        .then(() => {
-          // ensure the element is based on the wrapping toplevel view
-          // Ember still wraps the main application template with a
-          // normal tagged view
-          //
-          // In older Ember versions (2.4) the element itself is not stable,
-          // and therefore we cannot update the `this.element` until after the
-          // rendering is completed
-          element = document.querySelector('#ember-testing > .ember-view');
-
-          return settled();
-        });
+        // using next here because the actual rendering does not happen until
+        // the renderer detects it is dirty (which happens on backburner's end
+        // hook), see the following implementation details:
+        //
+        // * [view:outlet](https://github.com/emberjs/ember.js/blob/f94a4b6aef5b41b96ef2e481f35e07608df01440/packages/ember-glimmer/lib/views/outlet.js#L129-L145) manually dirties its own tag upon `setOutletState`
+        // * [backburner's custom end hook](https://github.com/emberjs/ember.js/blob/f94a4b6aef5b41b96ef2e481f35e07608df01440/packages/ember-glimmer/lib/renderer.js#L145-L159) detects that the current revision of the root is no longer the latest, and triggers a new rendering transaction
+        return settled();
+      });
     };
-
-    Object.defineProperty(context, 'element', {
-      enumerable: true,
-      configurable: true,
-      get() {
-        return element;
-      },
-    });
 
     if (global.jQuery) {
       context.$ = function $(selector) {
         // emulates Ember internal behavor of `this.$` in a component
         // https://github.com/emberjs/ember.js/blob/v2.5.1/packages/ember-views/lib/views/states/has_element.js#L18
-        return selector ? global.jQuery(selector, element) : global.jQuery(element);
+        return selector ? global.jQuery(selector, context.element) : global.jQuery(context.element);
       };
     }
 
     context.clearRender = function clearRender() {
-      element = undefined;
       return nextTickPromise().then(() => {
         toplevelView.setOutletState({
           render: {
@@ -176,7 +151,7 @@ export default function(context) {
             name: 'application',
             controller: context,
             ViewClass: undefined,
-            template: undefined,
+            template: OutletTemplate,
           },
           outlets: {},
         });

--- a/index.js
+++ b/index.js
@@ -5,6 +5,8 @@ module.exports = {
   name: 'ember-test-helpers',
 
   included() {
+    this._super.included.apply(this, arguments);
+
     this.import('vendor/monkey-patches.js', { type: 'test' });
   },
 

--- a/package.json
+++ b/package.json
@@ -32,14 +32,14 @@
   },
   "dependencies": {
     "broccoli-funnel": "^2.0.1",
-    "ember-cli-babel": "^6.10.0"
+    "ember-cli-babel": "^6.10.0",
+    "ember-cli-htmlbars-inline-precompile": "^1.0.0"
   },
   "devDependencies": {
     "ember-cli": "^2.17.1",
     "ember-cli-dependency-checker": "^2.0.0",
     "ember-cli-eslint": "^4.2.1",
     "ember-cli-htmlbars": "^2.0.1",
-    "ember-cli-htmlbars-inline-precompile": "^1.0.0",
     "ember-cli-inject-live-reload": "^1.4.1",
     "ember-cli-pretender": "^1.0.1",
     "ember-cli-shims": "^1.2.0",

--- a/tests/integration/setup-rendering-context-test.js
+++ b/tests/integration/setup-rendering-context-test.js
@@ -1,0 +1,92 @@
+import Ember from 'ember';
+import { module, test } from 'qunit';
+import Component from '@ember/component';
+import {
+  setupContext,
+  setupRenderingContext,
+  teardownContext,
+  teardownRenderingContext,
+  waitFor,
+  render,
+} from '@ember/test-helpers';
+
+import hasEmberVersion from 'ember-test-helpers/has-ember-version';
+import { setResolverRegistry } from '../helpers/resolver';
+import hbs from 'htmlbars-inline-precompile';
+import { defer } from 'rsvp';
+
+const PromiseWrapperTemplate = hbs`
+{{~#if settled~}}
+  {{fulfillmentValue}}
+{{~else~}}
+  <div class="loading">Please wait</div>
+{{~/if}}
+`;
+
+const PromiseWrapper = Component.extend({
+  init() {
+    this._super(...arguments);
+
+    this.promise
+      .then(value => this.set('fulfillmentValue', value))
+      .finally(() => this.set('settled', true));
+  },
+});
+
+module('setupRenderingContext "real world"', function(hooks) {
+  if (!hasEmberVersion(2, 4)) {
+    return;
+  }
+  hooks.beforeEach(async function() {
+    setResolverRegistry({
+      'component:promise-wrapper': PromiseWrapper,
+      'template:components/promise-wrapper': PromiseWrapperTemplate,
+    });
+
+    await setupContext(this);
+    await setupRenderingContext(this);
+
+    this._waiter = () => {
+      return !this.isWaiterPending;
+    };
+
+    // In Ember < 2.8 `registerWaiter` expected to be bound to
+    // `Ember.Test` 😭
+    //
+    // Once we have dropped support for < 2.8 we should swap this to
+    // use:
+    //
+    // import { registerWaiter } from '@ember/test';
+    Ember.Test.registerWaiter(this._waiter);
+  });
+
+  hooks.afterEach(async function() {
+    Ember.Test.unregisterWaiter(this._waiter);
+    await teardownRenderingContext(this);
+    await teardownContext(this);
+  });
+
+  test('can check element while waiting for settled state', async function(assert) {
+    let deferred = defer();
+    this.set('promise', deferred.promise);
+
+    // force the waiter to pause, emulating a pending AJAX or fetch request
+    this.isWaiterPending = true;
+
+    // Does not use `await` intentionally
+    let renderPromise = render(hbs`{{promise-wrapper promise=promise }}`);
+
+    await waitFor('.loading');
+
+    assert.equal(this.element.textContent, 'Please wait', 'has pending content');
+
+    deferred.resolve('Yippie!');
+
+    // release the waiter, so `settled` from `render` will complete
+    this.isWaiterPending = false;
+
+    await renderPromise;
+
+    assert.equal(this.element.textContent, 'Yippie!', 'has fulfillment value');
+  });
+});

--- a/tests/unit/setup-rendering-context-test.js
+++ b/tests/unit/setup-rendering-context-test.js
@@ -66,18 +66,20 @@ module('setupRenderingContext', function(hooks) {
     });
 
     test('render does not run sync', async function(assert) {
-      assert.equal(this.element, undefined, 'precond - this.element is not set before this.render');
+      assert.ok(this.element, 'precond - this.element is present (but empty) before this.render');
 
       let renderPromise = this.render(hbs`<p>Hello!</p>`);
 
-      assert.equal(this.element, undefined, 'precond - this.element is not set sync');
+      assert.equal(this.element.textContent, '', 'precond - this.element is not updated sync');
 
       await renderPromise;
+
       assert.equal(this.element.textContent, 'Hello!');
     });
 
     test('clearRender can be used to clear the previously rendered template', async function(assert) {
       let testingRootElement = document.getElementById('ember-testing');
+      let originalElement = this.element;
 
       await this.render(hbs`<p>Hello!</p>`);
 
@@ -85,9 +87,10 @@ module('setupRenderingContext', function(hooks) {
       assert.equal(testingRootElement.textContent, 'Hello!', 'has rendered content');
 
       await this.clearRender();
-      assert.equal(this.element, undefined, 'this.element is reset');
 
-      assert.equal(testingRootElement.textContent, '', 'content is cleared');
+      assert.equal(this.element.textContent, '', 'has rendered content');
+      assert.equal(testingRootElement.textContent, '', 'has rendered content');
+      assert.strictEqual(this.element, originalElement, 'this.element is stable');
     });
 
     (hasjQuery() ? test : skip)('this.$ is exposed when jQuery is present', async function(assert) {
@@ -322,6 +325,7 @@ module('setupRenderingContext', function(hooks) {
 
     test('imported clearRender can be used instead of this.clearRender', async function(assert) {
       let testingRootElement = document.getElementById('ember-testing');
+      let originalElement = this.element;
 
       await this.render(hbs`<p>Hello!</p>`);
 
@@ -329,9 +333,10 @@ module('setupRenderingContext', function(hooks) {
       assert.equal(testingRootElement.textContent, 'Hello!', 'has rendered content');
 
       await clearRender();
-      assert.equal(this.element, undefined, 'this.element is reset');
 
-      assert.equal(testingRootElement.textContent, '', 'content is cleared');
+      assert.equal(this.element.textContent, '', 'has rendered content');
+      assert.equal(testingRootElement.textContent, '', 'has rendered content');
+      assert.strictEqual(this.element, originalElement, 'this.element is stable');
     });
   }
 


### PR DESCRIPTION
Previously (with `moduleForComponent`) eager rendering was avoided because it was not clear that rendering was _actually_ desired (and therefore the extra work would be wasted in cases that were not testing rendering).  Unlike `moduleForComponent` we can be certain that `setupRenderingContext` is only used in actual rendering contexts (its in the name :P ), so we do not need to be concerned with the performance.

This change is a compatible change (unless someone was _relying_ on the fact that `this.element` was undefined, which seems super weird) that ensures `this.element` is set immediately upon `setupRenderingContext` being called (instead of lazily when the first `render` is done). At that point `this.element` is essentially an empty element (roughly akin to having only `{{outlet}}` in an `application` template without an `index` template).

This unlocks the ability to test pending promises during rendering (via things like `waitUntil`).

Fixes #281