### PR TITLE
Tests: Make valid-jsdoc an error (instead of warning)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -51,7 +51,7 @@ module.exports = {
     {
       files: ['addon-test-support/**/*.js'],
       rules: {
-        'valid-jsdoc': 'warn',
+        'valid-jsdoc': 'error',
       }
     },
   ]

--- a/addon-test-support/@ember/test-helpers/dom/fire-event.js
+++ b/addon-test-support/@ember/test-helpers/dom/fire-event.js
@@ -23,6 +23,7 @@ const FILE_SELECTION_EVENT_TYPES = ['change'];
   @param {Element} element the element to dispatch the event to
   @param {string} eventType the type of event
   @param {Object} [options] additional properties to be set on the event
+  @returns {Event} the event that was dispatched
 */
 export default function fireEvent(element, eventType, options = {}) {
   if (!element) {


### PR DESCRIPTION
Now that the documentation is updated, this makes it an error...