### PR TITLE
Chore: Remove RSVP "resolve in run-loop" config

### DIFF
--- a/addon-test-support/@ember/test-helpers/setup-context.js
+++ b/addon-test-support/@ember/test-helpers/setup-context.js
@@ -2,7 +2,6 @@ import { run } from '@ember/runloop';
 import { set, setProperties, get, getProperties } from '@ember/object';
 import { guidFor } from '@ember/object/internals';
 import buildOwner from './build-owner';
-import { _setupPromiseListeners } from './ext/rsvp';
 import { _setupAJAXHooks } from './settled';
 import Ember from 'ember';
 import { Promise } from 'rsvp';
@@ -205,7 +204,6 @@ export default function(context, options = {}) {
       };
 
       _setupAJAXHooks();
-      _setupPromiseListeners();
 
       return context;
     });

--- a/addon-test-support/@ember/test-helpers/teardown-context.js
+++ b/addon-test-support/@ember/test-helpers/teardown-context.js
@@ -1,6 +1,5 @@
 import { guidFor } from '@ember/object/internals';
 import { run } from '@ember/runloop';
-import { _teardownPromiseListeners } from './ext/rsvp';
 import { _teardownAJAXHooks } from './settled';
 import { unsetContext, CLEANUP } from './setup-context';
 import { nextTickPromise, runDestroyablesFor } from './-utils';
@@ -25,7 +24,6 @@ export default function teardownContext(context) {
     .then(() => {
       let { owner } = context;
 
-      _teardownPromiseListeners();
       _teardownAJAXHooks();
 
       run(owner, 'destroy');

--- a/addon-test-support/ember-test-helpers/legacy-0-6-x/abstract-test-module.js
+++ b/addon-test-support/ember-test-helpers/legacy-0-6-x/abstract-test-module.js
@@ -1,7 +1,7 @@
 import { run } from '@ember/runloop';
 import { Promise as EmberPromise, resolve } from 'rsvp';
 import { assign, merge as emberMerge } from '@ember/polyfills';
-import { _setupPromiseListeners, _teardownPromiseListeners } from '@ember/test-helpers/ext/rsvp';
+import { _setupPromiseListeners, _teardownPromiseListeners } from './ext/rsvp';
 import { _setupAJAXHooks, _teardownAJAXHooks } from '@ember/test-helpers/settled';
 import { getContext, setContext, unsetContext } from '@ember/test-helpers';
 

--- a/addon-test-support/ember-test-helpers/legacy-0-6-x/ext/rsvp.js
+++ b/addon-test-support/ember-test-helpers/legacy-0-6-x/ext/rsvp.js
@@ -5,8 +5,8 @@ let originalAsync;
 
 /**
   Configures `RSVP` to resolve promises on the run-loop's action queue. This is
-  done by Ember internally and should likely be removed (it was only needed to
-  provide a consistent testing experience for users of Ember < 1.7).
+  done by Ember internally since Ember 1.7 and it is only needed to
+  provide a consistent testing experience for users of Ember < 1.7.
 
   @private
 */
@@ -21,8 +21,7 @@ export function _setupPromiseListeners() {
 }
 
 /**
-  Resets `RSVP`'s `async` to its prior value. This is done by Ember internally
-  and should likely be removed.
+  Resets `RSVP`'s `async` to its prior value.
 
   @private
 */


### PR DESCRIPTION
As mentioned in the recently updated documentation, this is actually not needed. This commit removes it from the RFC232 style testing harness (only leaving it in place for legacy `moduleFor` style tests in order to have as little churn as possible there).