### PR TITLE
Use "real" rootElement for DOM interaction helpers.

### DIFF
--- a/addon-test-support/@ember/test-helpers/dom/-get-element.js
+++ b/addon-test-support/@ember/test-helpers/dom/-get-element.js
@@ -9,7 +9,11 @@ import { getContext } from '../setup-context';
   @returns {Element} the target or selector
 */
 export default function getElement(target) {
-  if (target instanceof Window || target instanceof Document || target instanceof Element) {
+  if (
+    target.nodeType === Node.ELEMENT_NODE ||
+    target.nodeType === Node.DOCUMENT_NODE ||
+    target instanceof Window
+  ) {
     return target;
   } else if (typeof target === 'string') {
     let context = getContext();

--- a/addon-test-support/@ember/test-helpers/dom/-get-element.js
+++ b/addon-test-support/@ember/test-helpers/dom/-get-element.js
@@ -1,4 +1,4 @@
-import { getContext } from '../setup-context';
+import getRootElement from './get-root-element';
 
 /**
   Used internally by the DOM interaction helpers to find the element to trigger
@@ -16,11 +16,7 @@ export default function getElement(target) {
   ) {
     return target;
   } else if (typeof target === 'string') {
-    let context = getContext();
-    let rootElement = context && context.element;
-    if (!rootElement) {
-      throw new Error(`Must setup rendering context before attempting to interact with elements.`);
-    }
+    let rootElement = getRootElement();
 
     return rootElement.querySelector(target);
   } else {

--- a/addon-test-support/@ember/test-helpers/dom/get-root-element.js
+++ b/addon-test-support/@ember/test-helpers/dom/get-root-element.js
@@ -1,0 +1,27 @@
+import { getContext } from '../setup-context';
+
+/**
+  @private
+  @returns {Element} the root element
+*/
+export default function getRootElement() {
+  let context = getContext();
+  let owner = context && context.owner;
+
+  if (!owner) {
+    throw new Error('Must setup rendering context before attempting to interact with elements.');
+  }
+
+  let rootElementSelector;
+  // When the host app uses `setApplication` (instead of `setResolver`) the owner has
+  // a `rootElement` set on it with the element id to be used
+  if (owner && owner._emberTestHelpersMockOwner === undefined) {
+    rootElementSelector = owner.rootElement;
+  } else {
+    rootElementSelector = '#ember-testing';
+  }
+
+  let rootElement = document.querySelector(rootElementSelector);
+
+  return rootElement;
+}

--- a/addon-test-support/@ember/test-helpers/dom/wait-for.js
+++ b/addon-test-support/@ember/test-helpers/dom/wait-for.js
@@ -1,5 +1,5 @@
 import waitUntil from '../wait-until';
-import { getContext } from '../setup-context';
+import getRootElement from './get-root-element';
 import getElement from './-get-element';
 import { nextTickPromise } from '../-utils';
 
@@ -37,8 +37,7 @@ export default function waitFor(selector, { timeout = 1000, count = null } = {})
     let callback;
     if (count !== null) {
       callback = () => {
-        let context = getContext();
-        let rootElement = context && context.element;
+        let rootElement = getRootElement();
         let elements = rootElement.querySelectorAll(selector);
         if (elements.length === count) {
           return toArray(elements);

--- a/addon-test-support/@ember/test-helpers/setup-rendering-context.js
+++ b/addon-test-support/@ember/test-helpers/setup-rendering-context.js
@@ -111,8 +111,15 @@ export default function setupRenderingContext(context) {
     };
     toplevelView.setOutletState(outletState);
 
-    // TODO: make this id configurable
-    run(toplevelView, 'appendTo', '#ember-testing');
+    let rootElement;
+    // When the host app uses `setApplication` (instead of `setResolver`) the owner has
+    // a `rootElement` set on it with the element id to be used
+    if (owner._emberTestHelpersMockOwner) {
+      rootElement = '#ember-testing';
+    } else {
+      rootElement = owner.rootElement;
+    }
+    run(toplevelView, 'appendTo', rootElement);
 
     // ensure the element is based on the wrapping toplevel view
     // Ember still wraps the main application template with a

--- a/addon-test-support/@ember/test-helpers/setup-rendering-context.js
+++ b/addon-test-support/@ember/test-helpers/setup-rendering-context.js
@@ -6,6 +6,7 @@ import { getContext } from './setup-context';
 import { nextTickPromise } from './-utils';
 import settled from './settled';
 import hbs from 'htmlbars-inline-precompile';
+import getRootElement from './dom/get-root-element';
 
 export const RENDERING_CLEANUP = Object.create(null);
 
@@ -111,15 +112,7 @@ export default function setupRenderingContext(context) {
     };
     toplevelView.setOutletState(outletState);
 
-    let rootElement;
-    // When the host app uses `setApplication` (instead of `setResolver`) the owner has
-    // a `rootElement` set on it with the element id to be used
-    if (owner._emberTestHelpersMockOwner) {
-      rootElement = '#ember-testing';
-    } else {
-      rootElement = owner.rootElement;
-    }
-    run(toplevelView, 'appendTo', rootElement);
+    run(toplevelView, 'appendTo', getRootElement());
 
     // ensure the element is based on the wrapping toplevel view
     // Ember still wraps the main application template with a

--- a/tests/helpers/events.js
+++ b/tests/helpers/events.js
@@ -177,7 +177,7 @@ export function buildInstrumentedElement(elementType) {
     });
   });
 
-  let fixture = document.querySelector('#qunit-fixture');
+  let fixture = document.querySelector('#ember-testing');
   fixture.appendChild(element);
 
   return element;

--- a/tests/integration/settled-test.js
+++ b/tests/integration/settled-test.js
@@ -28,7 +28,7 @@ const TestComponent1 = Component.extend({
 });
 
 const TestComponent2 = Component.extend({
-  layout: hbs`{{internalValue}}`,
+  layout: hbs`<div class="test-component">{{internalValue}}</div>`,
 
   internalValue: 'initial value',
 
@@ -38,7 +38,7 @@ const TestComponent2 = Component.extend({
 });
 
 const TestComponent3 = Component.extend({
-  layout: hbs`{{internalValue}}`,
+  layout: hbs`<div class="test-component">{{internalValue}}</div>`,
 
   internalValue: '',
 
@@ -52,7 +52,7 @@ const TestComponent3 = Component.extend({
 });
 
 const TestComponent4 = Component.extend({
-  layout: hbs`{{internalValue}}`,
+  layout: hbs`<div class="test-component">{{internalValue}}</div>`,
 
   internalValue: '',
 
@@ -161,7 +161,7 @@ module('settled real-world scenarios', function(hooks) {
 
     assert.equal(this.element.textContent, 'initial value');
 
-    await click('div');
+    await click('.test-component');
 
     assert.equal(this.element.textContent, 'async value');
   });
@@ -171,7 +171,7 @@ module('settled real-world scenarios', function(hooks) {
 
     await this.render(hbs`{{x-test-3}}`);
 
-    await click('div');
+    await click('.test-component');
 
     assert.equal(this.element.textContent, 'Remote Data!');
   });
@@ -181,7 +181,7 @@ module('settled real-world scenarios', function(hooks) {
 
     await this.render(hbs`{{x-test-4}}`);
 
-    await click('div');
+    await click('.test-component');
 
     assert.equal(this.element.textContent, 'Local Data!Remote Data!Remote Data!');
   });

--- a/tests/unit/dom/blur-test.js
+++ b/tests/unit/dom/blur-test.js
@@ -2,6 +2,7 @@ import { module, test } from 'qunit';
 import { focus, blur, setupContext, teardownContext } from '@ember/test-helpers';
 import { buildInstrumentedElement } from '../../helpers/events';
 import { isIE11, isEdge } from '../../helpers/browser-detect';
+import hasEmberVersion from 'ember-test-helpers/has-ember-version';
 
 let focusSteps = ['focus', 'focusin'];
 let blurSteps = ['blur', 'focusout'];
@@ -14,6 +15,10 @@ if (isIE11) {
 }
 
 module('DOM Helper: blur', function(hooks) {
+  if (!hasEmberVersion(2, 4)) {
+    return;
+  }
+
   let context, elementWithFocus;
 
   hooks.beforeEach(async function(assert) {

--- a/tests/unit/dom/click-test.js
+++ b/tests/unit/dom/click-test.js
@@ -2,8 +2,13 @@ import { module, test } from 'qunit';
 import { click, setupContext, teardownContext } from '@ember/test-helpers';
 import { buildInstrumentedElement } from '../../helpers/events';
 import { isIE11 } from '../../helpers/browser-detect';
+import hasEmberVersion from 'ember-test-helpers/has-ember-version';
 
 module('DOM Helper: click', function(hooks) {
+  if (!hasEmberVersion(2, 4)) {
+    return;
+  }
+
   let context, element;
 
   hooks.beforeEach(function() {

--- a/tests/unit/dom/click-test.js
+++ b/tests/unit/dom/click-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { click, setContext, unsetContext } from '@ember/test-helpers';
+import { click, setupContext, teardownContext } from '@ember/test-helpers';
 import { buildInstrumentedElement } from '../../helpers/events';
 import { isIE11 } from '../../helpers/browser-detect';
 
@@ -7,25 +7,25 @@ module('DOM Helper: click', function(hooks) {
   let context, element;
 
   hooks.beforeEach(function() {
-    // used to simulate how `setupRenderingTest` (and soon `setupApplicationTest`)
-    // set context.element to the rootElement
-    context = {
-      element: document.querySelector('#qunit-fixture'),
-    };
+    context = {};
   });
 
-  hooks.afterEach(function() {
+  hooks.afterEach(async function() {
     if (element) {
       element.parentNode.removeChild(element);
     }
-    unsetContext();
+    if (context.owner) {
+      await teardownContext(context);
+    }
+
+    document.getElementById('ember-testing').innerHTML = '';
   });
 
   module('non-focusable element types', function() {
     test('clicking a div via selector with context set', async function(assert) {
       element = buildInstrumentedElement('div');
 
-      setContext(context);
+      await setupContext(context);
       await click(`#${element.id}`);
 
       assert.verifySteps(['mousedown', 'mouseup', 'click']);
@@ -34,7 +34,7 @@ module('DOM Helper: click', function(hooks) {
     test('clicking a div via element with context set', async function(assert) {
       element = buildInstrumentedElement('div');
 
-      setContext(context);
+      await setupContext(context);
       await click(element);
 
       assert.verifySteps(['mousedown', 'mouseup', 'click']);
@@ -63,8 +63,9 @@ module('DOM Helper: click', function(hooks) {
     test('rejects if selector is not found', async function(assert) {
       element = buildInstrumentedElement('div');
 
+      await setupContext(context);
+
       assert.rejects(() => {
-        setContext(context);
         return click(`#foo-bar-baz-not-here-ever-bye-bye`);
       }, /Element not found when calling `click\('#foo-bar-baz-not-here-ever-bye-bye'\)`/);
     });
@@ -88,7 +89,7 @@ module('DOM Helper: click', function(hooks) {
     test('clicking a input via selector with context set', async function(assert) {
       element = buildInstrumentedElement('input');
 
-      setContext(context);
+      await setupContext(context);
       await click(`#${element.id}`);
 
       assert.verifySteps(clickSteps);
@@ -98,7 +99,7 @@ module('DOM Helper: click', function(hooks) {
     test('clicking a input via element with context set', async function(assert) {
       element = buildInstrumentedElement('input');
 
-      setContext(context);
+      await setupContext(context);
       await click(element);
 
       assert.verifySteps(clickSteps);

--- a/tests/unit/dom/fill-in-test.js
+++ b/tests/unit/dom/fill-in-test.js
@@ -2,6 +2,7 @@ import { module, test } from 'qunit';
 import { fillIn, setupContext, teardownContext } from '@ember/test-helpers';
 import { buildInstrumentedElement } from '../../helpers/events';
 import { isIE11 } from '../../helpers/browser-detect';
+import hasEmberVersion from 'ember-test-helpers/has-ember-version';
 
 let clickSteps = ['focus', 'focusin', 'input', 'change'];
 
@@ -10,6 +11,10 @@ if (isIE11) {
 }
 
 module('DOM Helper: fillIn', function(hooks) {
+  if (!hasEmberVersion(2, 4)) {
+    return;
+  }
+
   let context, element;
 
   hooks.beforeEach(function() {

--- a/tests/unit/dom/fill-in-test.js
+++ b/tests/unit/dom/fill-in-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { fillIn, setContext, unsetContext } from '@ember/test-helpers';
+import { fillIn, setupContext, teardownContext } from '@ember/test-helpers';
 import { buildInstrumentedElement } from '../../helpers/events';
 import { isIE11 } from '../../helpers/browser-detect';
 
@@ -13,24 +13,24 @@ module('DOM Helper: fillIn', function(hooks) {
   let context, element;
 
   hooks.beforeEach(function() {
-    // used to simulate how `setupRenderingTest` (and soon `setupApplicationTest`)
-    // set context.element to the rootElement
-    context = {
-      element: document.querySelector('#qunit-fixture'),
-    };
+    context = {};
   });
 
-  hooks.afterEach(function() {
+  hooks.afterEach(async function() {
     if (element) {
       element.parentNode.removeChild(element);
     }
-    unsetContext();
+    if (context.owner) {
+      await teardownContext(context);
+    }
+
+    document.getElementById('ember-testing').innerHTML = '';
   });
 
   test('filling in a non-fillable element', async function(assert) {
     element = buildInstrumentedElement('div');
 
-    setContext(context);
+    await setupContext(context);
     assert.rejects(() => {
       return fillIn(`#${element.id}`, 'foo');
     }, /`fillIn` is only usable on form controls or contenteditable elements/);
@@ -39,8 +39,9 @@ module('DOM Helper: fillIn', function(hooks) {
   test('rejects if selector is not found', async function(assert) {
     element = buildInstrumentedElement('div');
 
+    await setupContext(context);
+
     assert.rejects(() => {
-      setContext(context);
       return fillIn(`#foo-bar-baz-not-here-ever-bye-bye`, 'foo');
     }, /Element not found when calling `fillIn\('#foo-bar-baz-not-here-ever-bye-bye'\)`/);
   });
@@ -78,7 +79,7 @@ module('DOM Helper: fillIn', function(hooks) {
   test('filling a textarea via selector with context set', async function(assert) {
     element = buildInstrumentedElement('textarea');
 
-    setContext(context);
+    await setupContext(context);
     await fillIn(`#${element.id}`, 'foo');
 
     assert.verifySteps(clickSteps);
@@ -89,7 +90,7 @@ module('DOM Helper: fillIn', function(hooks) {
   test('filling an input via element with context set', async function(assert) {
     element = buildInstrumentedElement('textarea');
 
-    setContext(context);
+    await setupContext(context);
     await fillIn(element, 'foo');
 
     assert.verifySteps(clickSteps);
@@ -100,7 +101,7 @@ module('DOM Helper: fillIn', function(hooks) {
   test('filling an input via selector with context set', async function(assert) {
     element = buildInstrumentedElement('input');
 
-    setContext(context);
+    await setupContext(context);
     await fillIn(`#${element.id}`, 'foo');
 
     assert.verifySteps(clickSteps);
@@ -111,7 +112,7 @@ module('DOM Helper: fillIn', function(hooks) {
   test('filling an input via element with context set', async function(assert) {
     element = buildInstrumentedElement('input');
 
-    setContext(context);
+    await setupContext(context);
     await fillIn(element, 'foo');
 
     assert.verifySteps(clickSteps);
@@ -123,7 +124,7 @@ module('DOM Helper: fillIn', function(hooks) {
     element = buildInstrumentedElement('div');
     element.setAttribute('contenteditable', '');
 
-    setContext(context);
+    await setupContext(context);
     await fillIn(element, 'foo');
 
     assert.verifySteps(clickSteps);

--- a/tests/unit/dom/focus-test.js
+++ b/tests/unit/dom/focus-test.js
@@ -2,6 +2,7 @@ import { module, test } from 'qunit';
 import { focus, setupContext, teardownContext } from '@ember/test-helpers';
 import { buildInstrumentedElement } from '../../helpers/events';
 import { isIE11 } from '../../helpers/browser-detect';
+import hasEmberVersion from 'ember-test-helpers/has-ember-version';
 
 let focusSteps = ['focus', 'focusin'];
 
@@ -10,6 +11,10 @@ if (isIE11) {
 }
 
 module('DOM Helper: focus', function(hooks) {
+  if (!hasEmberVersion(2, 4)) {
+    return;
+  }
+
   let context, element;
 
   hooks.beforeEach(function() {

--- a/tests/unit/dom/tap-test.js
+++ b/tests/unit/dom/tap-test.js
@@ -2,8 +2,13 @@ import { module, test } from 'qunit';
 import { tap, setupContext, teardownContext } from '@ember/test-helpers';
 import { buildInstrumentedElement } from '../../helpers/events';
 import { isIE11 } from '../../helpers/browser-detect';
+import hasEmberVersion from 'ember-test-helpers/has-ember-version';
 
 module('DOM Helper: tap', function(hooks) {
+  if (!hasEmberVersion(2, 4)) {
+    return;
+  }
+
   let context, element;
 
   hooks.beforeEach(function() {

--- a/tests/unit/dom/tap-test.js
+++ b/tests/unit/dom/tap-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { tap, setContext, unsetContext } from '@ember/test-helpers';
+import { tap, setupContext, teardownContext } from '@ember/test-helpers';
 import { buildInstrumentedElement } from '../../helpers/events';
 import { isIE11 } from '../../helpers/browser-detect';
 
@@ -14,18 +14,22 @@ module('DOM Helper: tap', function(hooks) {
     };
   });
 
-  hooks.afterEach(function() {
+  hooks.afterEach(async function() {
     if (element) {
       element.parentNode.removeChild(element);
     }
-    unsetContext();
+    // only teardown if setupContext was called
+    if (context.owner) {
+      await teardownContext(context);
+    }
+    document.getElementById('ember-testing').innerHTML = '';
   });
 
   module('non-focusable element types', function() {
     test('taping a div via selector with context set', async function(assert) {
       element = buildInstrumentedElement('div');
 
-      setContext(context);
+      await setupContext(context);
       await tap(`#${element.id}`);
 
       assert.verifySteps(['touchstart', 'touchend', 'mousedown', 'mouseup', 'click']);
@@ -34,7 +38,7 @@ module('DOM Helper: tap', function(hooks) {
     test('tapping a div via element with context set', async function(assert) {
       element = buildInstrumentedElement('div');
 
-      setContext(context);
+      await setupContext(context);
       await tap(element);
 
       assert.verifySteps(['touchstart', 'touchend', 'mousedown', 'mouseup', 'click']);
@@ -63,8 +67,9 @@ module('DOM Helper: tap', function(hooks) {
     test('rejects if selector is not found', async function(assert) {
       element = buildInstrumentedElement('div');
 
+      await setupContext(context);
+
       assert.rejects(() => {
-        setContext(context);
         return tap(`#foo-bar-baz-not-here-ever-bye-bye`);
       }, /Element not found when calling `tap\('#foo-bar-baz-not-here-ever-bye-bye'\)`/);
     });
@@ -87,7 +92,7 @@ module('DOM Helper: tap', function(hooks) {
     test('tapping a input via selector with context set', async function(assert) {
       element = buildInstrumentedElement('input');
 
-      setContext(context);
+      await setupContext(context);
       await tap(`#${element.id}`);
 
       assert.verifySteps(tapSteps);
@@ -97,7 +102,7 @@ module('DOM Helper: tap', function(hooks) {
     test('tapping a input via element with context set', async function(assert) {
       element = buildInstrumentedElement('input');
 
-      setContext(context);
+      await setupContext(context);
       await tap(element);
 
       assert.verifySteps(tapSteps);

--- a/tests/unit/dom/trigger-event-test.js
+++ b/tests/unit/dom/trigger-event-test.js
@@ -1,8 +1,13 @@
 import { module, test } from 'qunit';
 import { triggerEvent, setupContext, teardownContext } from '@ember/test-helpers';
 import { buildInstrumentedElement } from '../../helpers/events';
+import hasEmberVersion from 'ember-test-helpers/has-ember-version';
 
 module('DOM Helper: triggerEvent', function(hooks) {
+  if (!hasEmberVersion(2, 4)) {
+    return;
+  }
+
   let context, element;
 
   hooks.beforeEach(function() {

--- a/tests/unit/dom/trigger-event-test.js
+++ b/tests/unit/dom/trigger-event-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { triggerEvent, setContext, unsetContext } from '@ember/test-helpers';
+import { triggerEvent, setupContext, teardownContext } from '@ember/test-helpers';
 import { buildInstrumentedElement } from '../../helpers/events';
 
 module('DOM Helper: triggerEvent', function(hooks) {
@@ -13,11 +13,16 @@ module('DOM Helper: triggerEvent', function(hooks) {
     };
   });
 
-  hooks.afterEach(function() {
+  hooks.afterEach(async function() {
     if (element) {
       element.parentNode.removeChild(element);
     }
-    unsetContext();
+
+    // only teardown if setupContext was called
+    if (context.owner) {
+      await teardownContext(context);
+    }
+    document.getElementById('ember-testing').innerHTML = '';
   });
 
   test('can trigger arbitrary event types', async function(assert) {
@@ -27,7 +32,7 @@ module('DOM Helper: triggerEvent', function(hooks) {
       assert.ok(e instanceof Event, `fliberty listener receives a native event`);
     });
 
-    setContext(context);
+    await setupContext(context);
     await triggerEvent(`#${element.id}`, 'fliberty');
 
     assert.verifySteps(['fliberty']);
@@ -36,7 +41,7 @@ module('DOM Helper: triggerEvent', function(hooks) {
   test('triggering event via selector with context set fires the given event type', async function(assert) {
     element = buildInstrumentedElement('div');
 
-    setContext(context);
+    await setupContext(context);
     await triggerEvent(`#${element.id}`, 'mouseenter');
 
     assert.verifySteps(['mouseenter']);
@@ -45,7 +50,7 @@ module('DOM Helper: triggerEvent', function(hooks) {
   test('triggering event via element with context set fires the given event type', async function(assert) {
     element = buildInstrumentedElement('div');
 
-    setContext(context);
+    await setupContext(context);
     await triggerEvent(element, 'mouseenter');
 
     assert.verifySteps(['mouseenter']);
@@ -82,8 +87,9 @@ module('DOM Helper: triggerEvent', function(hooks) {
   test('rejects if selector is not found', async function(assert) {
     element = buildInstrumentedElement('div');
 
+    await setupContext(context);
+
     assert.rejects(() => {
-      setContext(context);
       return triggerEvent(`#foo-bar-baz-not-here-ever-bye-bye`, 'mouseenter');
     }, /Element not found when calling `triggerEvent\('#foo-bar-baz-not-here-ever-bye-bye'/);
   });
@@ -91,14 +97,15 @@ module('DOM Helper: triggerEvent', function(hooks) {
   test('rejects if event type is not passed', async function(assert) {
     element = buildInstrumentedElement('div');
 
+    await setupContext(context);
+
     assert.rejects(() => {
-      setContext(context);
       return triggerEvent(element);
     }, /Must provide an `eventType` to `triggerEvent`/);
   });
 
   test('events properly bubble upwards', async function(assert) {
-    setContext(context);
+    await setupContext(context);
     element = buildInstrumentedElement('div');
     element.innerHTML = `
       <div id="outer">

--- a/tests/unit/dom/trigger-key-event-test.js
+++ b/tests/unit/dom/trigger-key-event-test.js
@@ -1,8 +1,13 @@
 import { module, test } from 'qunit';
 import { triggerKeyEvent, setupContext, teardownContext } from '@ember/test-helpers';
 import { buildInstrumentedElement } from '../../helpers/events';
+import hasEmberVersion from 'ember-test-helpers/has-ember-version';
 
 module('DOM Helper: triggerKeyEvent', function(hooks) {
+  if (!hasEmberVersion(2, 4)) {
+    return;
+  }
+
   let context, element;
 
   hooks.beforeEach(function() {

--- a/tests/unit/dom/wait-for-test.js
+++ b/tests/unit/dom/wait-for-test.js
@@ -1,7 +1,12 @@
 import { module, test } from 'qunit';
 import { waitFor, setupContext, teardownContext } from '@ember/test-helpers';
+import hasEmberVersion from 'ember-test-helpers/has-ember-version';
 
 module('DOM Helper: waitFor', function(hooks) {
+  if (!hasEmberVersion(2, 4)) {
+    return;
+  }
+
   let context, rootElement;
 
   hooks.beforeEach(function() {

--- a/tests/unit/dom/wait-for-test.js
+++ b/tests/unit/dom/wait-for-test.js
@@ -1,20 +1,20 @@
 import { module, test } from 'qunit';
-import { waitFor, setContext, unsetContext } from '@ember/test-helpers';
+import { waitFor, setupContext, teardownContext } from '@ember/test-helpers';
 
 module('DOM Helper: waitFor', function(hooks) {
   let context, rootElement;
 
   hooks.beforeEach(function() {
-    // used to simulate how `setupRenderingTest` (and soon `setupApplicationTest`)
-    // set context.element to the rootElement
-    rootElement = document.querySelector('#qunit-fixture');
-    context = {
-      element: rootElement,
-    };
+    context = {};
+    rootElement = document.getElementById('ember-testing');
   });
 
-  hooks.afterEach(function() {
-    unsetContext();
+  hooks.afterEach(async function() {
+    // only teardown if setupContext was called
+    if (context.owner) {
+      await teardownContext(context);
+    }
+    document.getElementById('ember-testing').innerHTML = '';
   });
 
   test('wait for selector without context set', async function(assert) {
@@ -24,7 +24,7 @@ module('DOM Helper: waitFor', function(hooks) {
   });
 
   test('wait for selector', async function(assert) {
-    setContext(context);
+    await setupContext(context);
 
     let waitPromise = waitFor('.something');
 
@@ -38,7 +38,7 @@ module('DOM Helper: waitFor', function(hooks) {
   });
 
   test('wait for count of selector', async function(assert) {
-    setContext(context);
+    await setupContext(context);
 
     let waitPromise = waitFor('.something', { count: 2 });
 
@@ -61,7 +61,7 @@ module('DOM Helper: waitFor', function(hooks) {
   test('wait for selector with timeout', async function(assert) {
     assert.expect(2);
 
-    setContext(context);
+    await setupContext(context);
 
     let start = Date.now();
     try {


### PR DESCRIPTION
Extracts a `getRootElement` utility function (used by `getElement` and `waitFor`).  The utility is private for now, but may be made public in the future (needs more docs at the least).

The basic gist is that `getRootElement` should search relative to the `rootElement` of the application (when `setApplication` was used), and _not_ scoped to the first `.ember-view` _inside_ that element. This ensures that elements added to the `rootElement` (e.g. via `ember-wormhole` / `liquid-wormhole`) can also be interacted with.

Also updates `setupRenderingContext` to use the applications designated `rootElement` (as opposed to _always_ using `#ember-testing`). This brings `setupRenderingContext` in line with `setupApplicationContext`, and now properly uses the specified `rootElement`.

Prior to this, when using `setApplication(...)` with a different `rootElement` set than `#ember-testing` the event dispatcher would be setup to listen on a different element than the one that is actually being rendered into...