### PR TITLE
Ensure templates are precompiled properly on ember-cli < 2.12.

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,19 @@
 module.exports = {
   name: 'ember-test-helpers',
 
+  init() {
+    this._super.init && this._super.init.apply(this, arguments);
+
+    // ensure `this.options` is setup properly, this is required by
+    // ember-cli-htmlbars-inline-precompile so that it properly registers
+    // itself with _our_ instance of ember-cli-babel and not the host
+    // applications instance
+    //
+    // newer versions of ember-cli (2.12+) define `this.options` for us,
+    // however older versions (e.g. 2.8) do not...
+    this.options = this.options || {};
+  },
+
   included() {
     this._super.included.apply(this, arguments);
 


### PR DESCRIPTION
When `this.options` is not set on the addon instance, ember-cli-htmlbars-inline-precompile will **not** install the babel plugin on the correct babel instance. This fixes that issue for older ember-cli versions by _always_ ensuring that `this.options` is defined.