### PR TITLE
Allow empty string to fillIn

### DIFF
--- a/addon-test-support/@ember/test-helpers/dom/fill-in.js
+++ b/addon-test-support/@ember/test-helpers/dom/fill-in.js
@@ -30,7 +30,7 @@ export default function fillIn(target, text) {
       throw new Error('`fillIn` is only usable on form controls or contenteditable elements.');
     }
 
-    if (!text) {
+    if (typeof text === 'undefined' || text === null) {
       throw new Error('Must provide `text` when calling `fillIn`.');
     }
 

--- a/tests/unit/dom/fill-in-test.js
+++ b/tests/unit/dom/fill-in-test.js
@@ -146,4 +146,15 @@ module('DOM Helper: fillIn', function(hooks) {
     assert.strictEqual(document.activeElement, element, 'activeElement updated');
     assert.equal(element.value, 'foo');
   });
+
+  test('filling an input via selector with empty string', async function(assert) {
+    element = buildInstrumentedElement('input');
+
+    await setupContext(context);
+    await fillIn(`#${element.id}`, '');
+
+    assert.verifySteps(clickSteps);
+    assert.strictEqual(document.activeElement, element, 'activeElement updated');
+    assert.equal(element.value, '');
+  });
 });


### PR DESCRIPTION
For cases where you want to clear out an input and such.