### PR TITLE
Assert `settled()` only takes an object as first argument

### DIFF
--- a/addon-test-support/@ember/test-helpers/settled.js
+++ b/addon-test-support/@ember/test-helpers/settled.js
@@ -202,8 +202,10 @@ export default function settled() {
   let options = arguments[0];
 
   if (arguments.length > 0) {
-    assert(`The 'settled' (formerly 'wait') testing helper only accepts an object. You passed ${options}`,
-      typeof options === 'object' && options !== null);
+    assert(
+      `The 'settled' (formerly 'wait') testing helper only accepts an object.  You passed ${options}`,
+      typeof options === 'object' && options !== null
+    );
   }
 
   return waitUntil(() => isSettled(options), { timeout: Infinity });

--- a/addon-test-support/@ember/test-helpers/settled.js
+++ b/addon-test-support/@ember/test-helpers/settled.js
@@ -203,7 +203,7 @@ export default function settled() {
 
   if (options) {
     assert(
-      `The 'settled' (formerly 'wait') testing helper only accepts an object. You passed ${options}`,
+      `The 'settled' (formerly 'wait') testing helper only accepts an object if passed arguments. You passed ${options}`,
       typeof options === 'object'
     );
   }

--- a/addon-test-support/@ember/test-helpers/settled.js
+++ b/addon-test-support/@ember/test-helpers/settled.js
@@ -201,10 +201,10 @@ export function isSettled() {
 export default function settled() {
   let options = arguments[0];
 
-  if (arguments.length > 0) {
+  if (options) {
     assert(
       `The 'settled' (formerly 'wait') testing helper only accepts an object. You passed ${options}`,
-      typeof options === 'object' && options !== null
+      typeof options === 'object'
     );
   }
 

--- a/addon-test-support/@ember/test-helpers/settled.js
+++ b/addon-test-support/@ember/test-helpers/settled.js
@@ -201,8 +201,10 @@ export function isSettled() {
 export default function settled() {
   let options = arguments[0];
 
-  assert(`The 'settled' (formerly 'wait') testing helper only accepts 'undefined' or an object. You passed ${options}`,
-    typeof options === 'undefined' || typeof options === 'object' && options !== null);
+  if (arguments.length > 0) {
+    assert(`The 'settled' (formerly 'wait') testing helper only accepts an object. You passed ${options}`,
+      typeof options === 'object' && options !== null);
+  }
 
   return waitUntil(() => isSettled(options), { timeout: Infinity });
 }

--- a/addon-test-support/@ember/test-helpers/settled.js
+++ b/addon-test-support/@ember/test-helpers/settled.js
@@ -1,3 +1,4 @@
+import { assert } from '@ember/debug';
 import { run } from '@ember/runloop';
 
 import jQuery from 'jquery';
@@ -199,6 +200,9 @@ export function isSettled() {
 */
 export default function settled() {
   let options = arguments[0];
+
+  assert(`The 'settled' (formerly 'wait') testing helper only accepts 'undefined' or an object. You passed ${options}`,
+    typeof options === 'undefined' || typeof options === 'object' && options !== null);
 
   return waitUntil(() => isSettled(options), { timeout: Infinity });
 }

--- a/addon-test-support/@ember/test-helpers/settled.js
+++ b/addon-test-support/@ember/test-helpers/settled.js
@@ -203,7 +203,7 @@ export default function settled() {
 
   if (arguments.length > 0) {
     assert(
-      `The 'settled' (formerly 'wait') testing helper only accepts an object.  You passed ${options}`,
+      `The 'settled' (formerly 'wait') testing helper only accepts an object. You passed ${options}`,
       typeof options === 'object' && options !== null
     );
   }

--- a/addon-test-support/@ember/test-helpers/setup-application-context.js
+++ b/addon-test-support/@ember/test-helpers/setup-application-context.js
@@ -26,9 +26,7 @@ export function visit() {
         context.element = document.querySelector('#ember-testing');
       }
     })
-    .then(() => {
-      return settled();
-    });
+    .then(settled);
 }
 
 /**

--- a/addon-test-support/@ember/test-helpers/setup-application-context.js
+++ b/addon-test-support/@ember/test-helpers/setup-application-context.js
@@ -26,7 +26,9 @@ export function visit() {
         context.element = document.querySelector('#ember-testing');
       }
     })
-    .then(settled);
+    .then(() => {
+      return settled();
+    });
 }
 
 /**

--- a/tests/integration/settled-test.js
+++ b/tests/integration/settled-test.js
@@ -164,7 +164,7 @@ module('settled real-world scenarios', function(hooks) {
     } catch (e) {
       assert.equal(
         e.message,
-        `Assertion Failed: The 'settled' (formerly 'wait') testing helper only accepts an object. You passed 3000`
+        `Assertion Failed: The 'settled' (formerly 'wait') testing helper only accepts an object if passed arguments. You passed 3000`
       );
     }
   });

--- a/tests/integration/settled-test.js
+++ b/tests/integration/settled-test.js
@@ -154,6 +154,21 @@ module('settled real-world scenarios', function(hooks) {
     assert.equal(this.element.textContent, 'async value');
   });
 
+  test('raises assertion if pass in timer', async function(assert) {
+    this.owner.register('component:x-test-1', TestComponent1);
+
+    await this.render(hbs`{{x-test-1}}`);
+
+    try {
+      await settled(3000);
+    } catch (e) {
+      assert.equal(
+        e.message,
+        `Assertion Failed: The 'settled' (formerly 'wait') testing helper only accepts 'undefined' or an object. You passed 3000`
+      );
+    }
+  });
+
   test('it works when async exists in an event/action', async function(assert) {
     this.owner.register('component:x-test-2', TestComponent2);
 

--- a/tests/integration/settled-test.js
+++ b/tests/integration/settled-test.js
@@ -164,7 +164,7 @@ module('settled real-world scenarios', function(hooks) {
     } catch (e) {
       assert.equal(
         e.message,
-        `Assertion Failed: The 'settled' (formerly 'wait') testing helper only accepts 'undefined' or an object. You passed 3000`
+        `Assertion Failed: The 'settled' (formerly 'wait') testing helper only accepts an object. You passed 3000`
       );
     }
   });


### PR DESCRIPTION
Fixes #283 