### PR TITLE
Make sure initializers can modify the DOM

### DIFF
--- a/addon-test-support/@ember/test-helpers/setup-context.js
+++ b/addon-test-support/@ember/test-helpers/setup-context.js
@@ -135,17 +135,23 @@ export default function(context, options = {}) {
   let contextGuid = guidFor(context);
   CLEANUP[contextGuid] = [];
 
-  let testElementContainer = document.getElementById('ember-testing-container');
-  let fixtureResetValue = testElementContainer.innerHTML;
-
-  // push this into the final cleanup bucket, to be ran _after_ the owner
-  // is destroyed and settled (e.g. flushed run loops, etc)
-  CLEANUP[contextGuid].push(() => {
-    testElementContainer.innerHTML = fixtureResetValue;
-  });
-
   return nextTickPromise()
     .then(() => {
+      let application = getApplication();
+      if (application) {
+        return application.boot();
+      }
+    })
+    .then(() => {
+      let testElementContainer = document.getElementById('ember-testing-container');
+      let fixtureResetValue = testElementContainer.innerHTML;
+
+      // push this into the final cleanup bucket, to be ran _after_ the owner
+      // is destroyed and settled (e.g. flushed run loops, etc)
+      CLEANUP[contextGuid].push(() => {
+        testElementContainer.innerHTML = fixtureResetValue;
+      });
+
       let { resolver } = options;
 
       // This handles precendence, specifying a specific option of


### PR DESCRIPTION
The initializers were running after the snapshot of the root element was taken, meaning that if an initializer modified the contents of the root element, that modification would not persist beyond the first test. So we boot the app a little earlier to make sure initializers can safely modify the DOM.