### PR TITLE
[FEATURE] Add ancestor for find and findAll

### DIFF
--- a/addon-test-support/@ember/test-helpers/dom/-get-element.js
+++ b/addon-test-support/@ember/test-helpers/dom/-get-element.js
@@ -5,9 +5,10 @@ import getRootElement from './get-root-element';
 
   @private
   @param {string|Element} target the element or selector to retrieve
+  @param {Element} [ancestor] optional root element
   @returns {Element} the target or selector
 */
-export default function getElement(target) {
+export default function getElement(target, ancestor) {
   if (
     target.nodeType === Node.ELEMENT_NODE ||
     target.nodeType === Node.DOCUMENT_NODE ||
@@ -15,7 +16,11 @@ export default function getElement(target) {
   ) {
     return target;
   } else if (typeof target === 'string') {
-    let rootElement = getRootElement();
+    let rootElement = ancestor;
+
+    if (!(ancestor instanceof HTMLElement)) {
+      rootElement = getRootElement();
+    }
 
     return rootElement.querySelector(target);
   } else {

--- a/addon-test-support/@ember/test-helpers/dom/-get-elements.js
+++ b/addon-test-support/@ember/test-helpers/dom/-get-elements.js
@@ -5,11 +5,16 @@ import getRootElement from './get-root-element';
 
   @private
   @param {string} target the selector to retrieve
+  @param {Element} [ancestor] optional root element
   @returns {NodeList} the matched elements
 */
-export default function getElements(target) {
+export default function getElements(target, ancestor) {
   if (typeof target === 'string') {
-    let rootElement = getRootElement();
+    let rootElement = ancestor;
+
+    if (!(ancestor instanceof HTMLElement)) {
+      rootElement = getRootElement();
+    }
 
     return rootElement.querySelectorAll(target);
   } else {

--- a/addon-test-support/@ember/test-helpers/dom/find-all.js
+++ b/addon-test-support/@ember/test-helpers/dom/find-all.js
@@ -7,12 +7,13 @@ import toArray from './-to-array';
 
   @public
   @param {string} selector the selector to search for
+  @param {Element} ancestor optional root element
   @return {Array} array of matched elements
 */
-export default function find(selector) {
+export default function find(selector, ancestor) {
   if (!selector) {
     throw new Error('Must pass a selector to `findAll`.');
   }
 
-  return toArray(getElements(selector));
+  return toArray(getElements(selector, ancestor));
 }

--- a/addon-test-support/@ember/test-helpers/dom/find.js
+++ b/addon-test-support/@ember/test-helpers/dom/find.js
@@ -6,12 +6,13 @@ import getElement from './-get-element';
 
   @public
   @param {string} selector the selector to search for
+  @param {Element} ancestor optional root element
   @return {Element} matched element or null
 */
-export default function find(selector) {
+export default function find(selector, ancestor) {
   if (!selector) {
     throw new Error('Must pass a selector to `find`.');
   }
 
-  return getElement(selector);
+  return getElement(selector, ancestor);
 }

--- a/tests/unit/dom/find-all-test.js
+++ b/tests/unit/dom/find-all-test.js
@@ -58,6 +58,30 @@ module('DOM Helper: findAll', function(hooks) {
     assert.equal(result[0], element1);
   });
 
+  test('works if an ancestor is passed', async function(assert) {
+    await setupContext(context);
+    let selector = 'my-unique-class';
+    let resultCount = 3;
+
+    let fixture = document.querySelector('#ember-testing');
+    element1.classList.add(selector);
+    fixture.appendChild(element1);
+    element2.classList.add(selector);
+    fixture.appendChild(element2);
+    let ancestor = document.createElement('span');
+    for (let i = 0; i < resultCount; i++) {
+      let validResult = document.createElement('div');
+      validResult.classList.add(selector);
+      ancestor.appendChild(validResult);
+    }
+    fixture.appendChild(ancestor);
+
+    let resultElements = findAll(`.${selector}`, ancestor);
+    assert.equal(resultElements.length, resultCount);
+    assert.notOk(resultElements.includes(element1));
+    assert.notOk(resultElements.includes(element2));
+  });
+
   test('throws without context set', function(assert) {
     assert.throws(() => {
       findAll('#foo');

--- a/tests/unit/dom/find-test.js
+++ b/tests/unit/dom/find-test.js
@@ -44,6 +44,22 @@ module('DOM Helper: find', function(hooks) {
     assert.notOk(find('#elt'));
   });
 
+  test('works if an ancestor is passed', async function(assert) {
+    await setupContext(context);
+    let selector = 'my-unique-class';
+
+    let fixture = document.querySelector('#ember-testing');
+    element.classList.add(selector);
+    fixture.appendChild(element);
+    let ancestor = document.createElement('span');
+    let validResult = document.createElement('div');
+    validResult.classList.add(selector);
+    ancestor.appendChild(validResult);
+    fixture.appendChild(ancestor);
+
+    assert.equal(find(`.${selector}`, ancestor), validResult);
+  });
+
   test('throws without context set', function(assert) {
     assert.throws(() => {
       find('#foo');


### PR DESCRIPTION
In ember-native-dom-helpers, find and findAll had an optional second
argument, a _context_ element for querySelector or querySelectorAll.

Given _context_ and _root element_ have already some meaning in
ember-test-helpers, I chose to call it _ancestor_ to prevent
misunderstoods.