### PR TITLE
Lock down documentation to 5.3.5 to avoid Node 4 issues.

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@ember/optional-features": "^0.5.1",
-    "documentation": "^5.3.5",
+    "documentation": "5.3.5",
     "ember-cli": "~2.18.0",
     "ember-cli-dependency-checker": "^2.0.0",
     "ember-cli-eslint": "^4.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2326,7 +2326,7 @@ doctrine@^2.1.0:
   dependencies:
     esutils "^2.0.2"
 
-documentation@^5.3.5:
+documentation@5.3.5:
   version "5.3.5"
   resolved "https://registry.yarnpkg.com/documentation/-/documentation-5.3.5.tgz#48f5f30035f17f76f149c3a516e7df6fae0ece6c"
   dependencies:


### PR DESCRIPTION
see https://github.com/documentationjs/documentation/issues/1014