### PR TITLE
Add test for firing file change event twice

### DIFF
--- a/addon-test-support/@ember/test-helpers/dom/fire-event.js
+++ b/addon-test-support/@ember/test-helpers/dom/fire-event.js
@@ -191,6 +191,7 @@ function buildFileEvent(type, element, files = []) {
     });
     Object.defineProperty(element, 'files', {
       value: files,
+      configurable: true,
     });
   }
 

--- a/tests/unit/dom/select-files-test.js
+++ b/tests/unit/dom/select-files-test.js
@@ -1,0 +1,55 @@
+import { module, test } from 'qunit';
+import { triggerEvent, setupContext, teardownContext } from '@ember/test-helpers';
+import { buildInstrumentedElement } from '../../helpers/events';
+import hasEmberVersion from 'ember-test-helpers/has-ember-version';
+
+module('DOM Helper: selectFiles', function(hooks) {
+  if (!hasEmberVersion(2, 4)) {
+    return;
+  }
+
+  let context, element;
+
+  const textFile = new Blob(['Hello World'], { type: 'text/plain' });
+  textFile.name = 'text-file.txt';
+
+  const imageFile = new Blob([], { type: 'text/png' });
+  imageFile.name = 'image-file.png';
+
+  hooks.beforeEach(function() {
+    // used to simulate how `setupRenderingTest` (and soon `setupApplicationTest`)
+    // set context.element to the rootElement
+    context = {
+      element: document.querySelector('#qunit-fixture'),
+    };
+  });
+
+  hooks.afterEach(async function() {
+    if (element) {
+      element.parentNode.removeChild(element);
+    }
+
+    // only teardown if setupContext was called
+    if (context.owner) {
+      await teardownContext(context);
+    }
+    document.getElementById('ember-testing').innerHTML = '';
+  });
+
+  test('it can trigger a file selection event more than once', async function(assert) {
+    element = buildInstrumentedElement('input');
+    element.setAttribute('type', 'file');
+
+    let count = 0;
+
+    element.addEventListener('change', () => {
+      assert.step(`file${++count}`);
+    });
+
+    await setupContext(context);
+    await triggerEvent(element, 'change', [textFile]);
+    await triggerEvent(element, 'change', [imageFile]);
+
+    assert.verifySteps(['change', 'file1', 'change', 'file2']);
+  });
+});

--- a/tests/unit/dom/select-files-test.js
+++ b/tests/unit/dom/select-files-test.js
@@ -40,10 +40,8 @@ module('DOM Helper: selectFiles', function(hooks) {
     element = buildInstrumentedElement('input');
     element.setAttribute('type', 'file');
 
-    let count = 0;
-
     element.addEventListener('change', e => {
-      assert.step(e.target.files[count].name);
+      assert.step(e.target.files[0].name);
     });
 
     await setupContext(context);

--- a/tests/unit/dom/select-files-test.js
+++ b/tests/unit/dom/select-files-test.js
@@ -42,14 +42,14 @@ module('DOM Helper: selectFiles', function(hooks) {
 
     let count = 0;
 
-    element.addEventListener('change', () => {
-      assert.step(`file${++count}`);
+    element.addEventListener('change', e => {
+      assert.step(e.target.files[count].name);
     });
 
     await setupContext(context);
     await triggerEvent(element, 'change', [textFile]);
     await triggerEvent(element, 'change', [imageFile]);
 
-    assert.verifySteps(['change', 'file1', 'change', 'file2']);
+    assert.verifySteps(['change', 'text-file.txt', 'change', 'image-file.png']);
   });
 });


### PR DESCRIPTION
Even though ember-test-helpers doesn't have a `selectFiles` helper (yet?) it does handle firing of events with files. However, it was not possible to select files more than once (not to be confused with selecting multiple files at once).