### PR TITLE
make getApplication public

### DIFF
--- a/API.md
+++ b/API.md
@@ -41,6 +41,7 @@
     -   [setupRenderingContext](#setuprenderingcontext)
     -   [teardownRenderingContext](#teardownrenderingcontext)
     -   [setApplication](#setapplication)
+    -   [getApplication](#getapplication)
     -   [setupApplicationContext](#setupapplicationcontext)
     -   [teardownApplicationContext](#teardownapplicationcontext)
     -   [validateErrorHandler](#validateerrorhandler)
@@ -511,6 +512,12 @@ Responsible for:
 -   `context` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** the context to setup
 
 Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;void>** resolves when settled
+
+### getApplication
+
+Retrieves the application instance stored by setApplication.
+
+-   Used by `setupContext`.
 
 ### setApplication
 

--- a/addon-test-support/@ember/test-helpers/index.js
+++ b/addon-test-support/@ember/test-helpers/index.js
@@ -1,5 +1,5 @@
 export { setResolver, getResolver } from './resolver';
-export { setApplication } from './application';
+export { getApplication, setApplication } from './application';
 export {
   default as setupContext,
   getContext,

--- a/tests/unit/application-test.js
+++ b/tests/unit/application-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { application, resolver } from '../helpers/resolver';
-import { setApplication, setResolver, getResolver } from '@ember/test-helpers';
+import { getApplication, setApplication, setResolver, getResolver } from '@ember/test-helpers';
 
 module('application', function(hooks) {
   hooks.beforeEach(function() {
@@ -26,6 +26,7 @@ module('application', function(hooks) {
       actualResolver.isResolverFromTestHelpers,
       'should not have used resolver created in tests/helpers/resolver.js'
     );
+    assert.deepEqual(getApplication().constructor, application.constructor);
   });
 
   test('calling setApplication when a resolver is set does not clobber existing resolver', function(assert) {


### PR DESCRIPTION
One use case I have is I would like to call `setApplication(Application.create({ autoboot: false, custom: 'bar' });` or something similar.  However, this may be a bit dangerous because this sets the application for the rest of the test run.  In order to ensure further calls to get the application instance aren't this Application instance, I need to reset it with the old application instance using `this.oldAppInstance = getApplication()` before setting.

Lmk what you think!

Ref #335 