### PR TITLE
Add some specific documentation for uploading files

### DIFF
--- a/API.md
+++ b/API.md
@@ -170,6 +170,20 @@ Triggers an event on the specified target.
 -   `eventType` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the type of event to trigger
 -   `options` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** additional properties to be set on the event
 
+**Examples**
+
+_Using triggerEvent to Upload a file
+When using triggerEvent to upload a file the `eventType` must be `change` and  you must pass an
+array of [Blob](https://developer.mozilla.org/en-US/docs/Web/API/Blob) as `options`._
+
+```javascript
+triggerEvent(
+  'input.fileUpload',
+  'change',
+  [new Blob(['Ember Rules!'])]
+);
+```
+
 Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;void>** resolves when the application is settled
 
 ### triggerKeyEvent

--- a/addon-test-support/@ember/test-helpers/dom/trigger-event.js
+++ b/addon-test-support/@ember/test-helpers/dom/trigger-event.js
@@ -4,14 +4,25 @@ import settled from '../settled';
 import { nextTickPromise } from '../-utils';
 
 /**
-  Triggers an event on the specified target.
-
-  @public
-  @param {string|Element} target the element or selector to trigger the event on
-  @param {string} eventType the type of event to trigger
-  @param {Object} options additional properties to be set on the event
-  @return {Promise<void>} resolves when the application is settled
-*/
+ * Triggers an event on the specified target.
+ *
+ * @public
+ * @param {string|Element} target the element or selector to trigger the event on
+ * @param {string} eventType the type of event to trigger
+ * @param {Object} options additional properties to be set on the event
+ * @return {Promise<void>} resolves when the application is settled
+ *
+ * @example
+ * <caption>Using triggerEvent to Upload a file
+ * When using triggerEvent to upload a file the `eventType` must be `change` and  you must pass an
+ * array of [Blob](https://developer.mozilla.org/en-US/docs/Web/API/Blob) as `options`.</caption>
+ *
+ * triggerEvent(
+ *   'input.fileUpload',
+ *   'change',
+ *   [new Blob(['Ember Rules!'])]
+ * );
+ */
 export default function triggerEvent(target, eventType, options) {
   return nextTickPromise().then(() => {
     if (!target) {


### PR DESCRIPTION
Uploading files with an event is a specific code path and the task can
be tough to figure out without an example.

I couldn't think of a better way to document this, but it seemed necessary to me.  I've been using a construct like:

```
inputElement.triggerHandler({
 type: 'change',
 target: {
  files: {
   0: file,
   length: 1,
   item() { return file; }
  }
 }
});
```

So when converting from jQuery helpers to this addon it was difficult to see how to make file uploads work. Turns out some really nice work is done in `fire-event.js` - just needed to be documented.