### PR TITLE
Allow for custom error message in waitUntil helper

### DIFF
--- a/addon-test-support/@ember/test-helpers/wait-until.js
+++ b/addon-test-support/@ember/test-helpers/wait-until.js
@@ -14,6 +14,7 @@ const MAX_TIMEOUT = 10;
   @param {Function} callback the callback to use for testing when waiting should stop
   @param {Object} [options] options used to override defaults
   @param {number} [options.timeout=1000] the maximum amount of time to wait
+  @param {string} [options.timeoutMessage='waitUntil timed out'] the message to use in the reject on timeout
   @returns {Promise} resolves with the callback value when it returns a truthy value
 */
 export default function waitUntil(callback, options = {}) {

--- a/addon-test-support/@ember/test-helpers/wait-until.js
+++ b/addon-test-support/@ember/test-helpers/wait-until.js
@@ -18,9 +18,10 @@ const MAX_TIMEOUT = 10;
 */
 export default function waitUntil(callback, options = {}) {
   let timeout = 'timeout' in options ? options.timeout : 1000;
+  let errorMsg = 'errorMessage' in options ? options.errorMessage : 'waitUntil timed out';
 
   // creating this error eagerly so it has the proper invocation stack
-  let waitUntilTimedOut = new Error('waitUntil timed out');
+  let waitUntilTimedOut = new Error(errorMsg);
 
   return new Promise(function(resolve, reject) {
     let time = 0;

--- a/addon-test-support/@ember/test-helpers/wait-until.js
+++ b/addon-test-support/@ember/test-helpers/wait-until.js
@@ -18,10 +18,10 @@ const MAX_TIMEOUT = 10;
 */
 export default function waitUntil(callback, options = {}) {
   let timeout = 'timeout' in options ? options.timeout : 1000;
-  let errorMsg = 'errorMessage' in options ? options.errorMessage : 'waitUntil timed out';
+  let timeoutMessage = 'timeoutMessage' in options ? options.timeoutMessage : 'waitUntil timed out';
 
   // creating this error eagerly so it has the proper invocation stack
-  let waitUntilTimedOut = new Error(errorMsg);
+  let waitUntilTimedOut = new Error(timeoutMessage);
 
   return new Promise(function(resolve, reject) {
     let time = 0;

--- a/tests/unit/wait-until-test.js
+++ b/tests/unit/wait-until-test.js
@@ -42,7 +42,7 @@ module('DOM helper: waitUntil', function() {
     assert.step('before invocation');
     let waiter = waitUntil(() => {}, {
       timeout: 20,
-      errorMessage: 'Oh no, a nasty error occurred',
+      timeoutMessage: 'Oh no, a nasty error occurred',
     });
     assert.step('after invocation');
 

--- a/tests/unit/wait-until-test.js
+++ b/tests/unit/wait-until-test.js
@@ -38,6 +38,30 @@ module('DOM helper: waitUntil', function() {
       });
   });
 
+  test('waits until timeout expires with custom error message', function(assert) {
+    assert.step('before invocation');
+    let waiter = waitUntil(() => {}, {
+      timeout: 20,
+      errorMessage: 'Oh no, a nasty error occurred',
+    });
+    assert.step('after invocation');
+
+    setTimeout(() => assert.step('waiting'), 10);
+
+    return waiter
+      .catch(reason => {
+        assert.step(`catch handler: ${reason.message}`);
+      })
+      .finally(() => {
+        assert.verifySteps([
+          'before invocation',
+          'after invocation',
+          'waiting',
+          'catch handler: Oh no, a nasty error occurred',
+        ]);
+      });
+  });
+
   test('rejects when callback throws', function(assert) {
     return waitUntil(() => {
       throw new Error('error goes here');


### PR DESCRIPTION
We have need to distinguish between different waitUntil timeouts. To do this, it would be nice to be able to pass a custom error message to waitUntil which it will use upon promise reject. This small PR does that. 