### PR TITLE
#351 Adding context for find and findAll helpers

### DIFF
--- a/addon-test-support/@ember/test-helpers/dom/-get-element.js
+++ b/addon-test-support/@ember/test-helpers/dom/-get-element.js
@@ -1,13 +1,14 @@
-import getRootElement from './get-root-element';
+import getContextElement from './get-context-element';
 
 /**
   Used internally by the DOM interaction helpers to find one element.
 
   @private
   @param {string|Element} target the element or selector to retrieve
+  @param {string|Element} [context] the context element or selector
   @returns {Element} the target or selector
 */
-export default function getElement(target) {
+export default function getElement(target, context) {
   if (
     target.nodeType === Node.ELEMENT_NODE ||
     target.nodeType === Node.DOCUMENT_NODE ||
@@ -15,7 +16,7 @@ export default function getElement(target) {
   ) {
     return target;
   } else if (typeof target === 'string') {
-    let rootElement = getRootElement();
+    let rootElement = getContextElement(context);
 
     return rootElement.querySelector(target);
   } else {

--- a/addon-test-support/@ember/test-helpers/dom/-get-elements.js
+++ b/addon-test-support/@ember/test-helpers/dom/-get-elements.js
@@ -1,15 +1,16 @@
-import getRootElement from './get-root-element';
+import getContextElement from './get-context-element';
 
 /**
   Used internally by the DOM interaction helpers to find multiple elements.
 
   @private
   @param {string} target the selector to retrieve
+  @param {string|Element} [context] the context element or selector
   @returns {NodeList} the matched elements
 */
-export default function getElements(target) {
+export default function getElements(target, context) {
   if (typeof target === 'string') {
-    let rootElement = getRootElement();
+    let rootElement = getContextElement(context);
 
     return rootElement.querySelectorAll(target);
   } else {

--- a/addon-test-support/@ember/test-helpers/dom/find-all.js
+++ b/addon-test-support/@ember/test-helpers/dom/find-all.js
@@ -7,12 +7,13 @@ import toArray from './-to-array';
 
   @public
   @param {string} selector the selector to search for
+  @param {string|Element} [context] the context element or selector
   @return {Array} array of matched elements
 */
-export default function find(selector) {
+export default function find(selector, context) {
   if (!selector) {
     throw new Error('Must pass a selector to `findAll`.');
   }
 
-  return toArray(getElements(selector));
+  return toArray(getElements(selector, context));
 }

--- a/addon-test-support/@ember/test-helpers/dom/find.js
+++ b/addon-test-support/@ember/test-helpers/dom/find.js
@@ -6,12 +6,13 @@ import getElement from './-get-element';
 
   @public
   @param {string} selector the selector to search for
+  @param {string|Element} [context] the context element or selector
   @return {Element} matched element or null
 */
-export default function find(selector) {
+export default function find(selector, context) {
   if (!selector) {
     throw new Error('Must pass a selector to `find`.');
   }
 
-  return getElement(selector);
+  return getElement(selector, context);
 }

--- a/addon-test-support/@ember/test-helpers/dom/get-context-element.js
+++ b/addon-test-support/@ember/test-helpers/dom/get-context-element.js
@@ -1,0 +1,19 @@
+import getRootElement from './get-root-element';
+
+/**
+ Used internally by the DOM interaction helpers to get the appropriate context element based on the context the user passes into the helper.
+
+ @private
+ @param {string|Element} context the context element or selector
+ @returns {Element} the appropriate context element
+ */
+export default function getContextElement(context) {
+  if (context) {
+    if (typeof context === 'string') {
+      return getRootElement().querySelector(context);
+    } else if (context instanceof Element) {
+      return context;
+    }
+  }
+  return getRootElement();
+}

--- a/addon-test-support/@ember/test-helpers/dom/get-context-element.js
+++ b/addon-test-support/@ember/test-helpers/dom/get-context-element.js
@@ -4,7 +4,7 @@ import getRootElement from './get-root-element';
  Used internally by the DOM interaction helpers to get the appropriate context element based on the context the user passes into the helper.
 
  @private
- @param {string|Element} context the context element or selector
+ @param {string|Element} [context] the context element or selector
  @returns {Element} the appropriate context element
  */
 export default function getContextElement(context) {

--- a/tests/unit/dom/find-all-test.js
+++ b/tests/unit/dom/find-all-test.js
@@ -7,23 +7,38 @@ module('DOM Helper: findAll', function(hooks) {
     return;
   }
 
-  let context, element1, element2;
+  let context, element1, element2, child1, child2, child3, child4;
+  const createDiv = () => document.createElement('div'),
+    setupElements = index => {
+      let parent = createDiv(),
+        children = [createDiv(), createDiv()];
+      parent.setAttribute('id', `elt-${index}`);
+      children.forEach(child => {
+        child.classList.add('my-class');
+        parent.appendChild(child);
+      });
+      return [parent, ...children];
+    },
+    checkResult = (assert, result, elements) => {
+      assert.ok(result instanceof Array);
+      assert.equal(result.length, elements.length);
+      elements.forEach((element, index) => {
+        assert.equal(result[index], element);
+      });
+    };
 
   hooks.beforeEach(function() {
     context = {};
-    element1 = document.createElement('div');
-    element1.classList.add('elt');
-    element2 = document.createElement('div');
-    element2.classList.add('elt');
+    [element1, child1, child2] = setupElements(1);
+    [element2, child3, child4] = setupElements(2);
   });
 
   hooks.afterEach(async function() {
-    if (element1.parentNode) {
-      element1.parentNode.removeChild(element1);
-    }
-    if (element2.parentNode) {
-      element2.parentNode.removeChild(element2);
-    }
+    [element1, element2].forEach(element => {
+      if (element.parentNode) {
+        element.parentNode.removeChild(element);
+      }
+    });
     if (context.owner) {
       await teardownContext(context);
     }
@@ -38,11 +53,14 @@ module('DOM Helper: findAll', function(hooks) {
     fixture.appendChild(element1);
     fixture.appendChild(element2);
 
-    let result = findAll('.elt');
-    assert.ok(result instanceof Array);
-    assert.equal(result.length, 2);
-    assert.equal(result[0], element1);
-    assert.equal(result[1], element2);
+    let result = findAll('.my-class');
+    checkResult(assert, result, [child1, child2, child3, child4]);
+
+    result = findAll('.my-class', '#elt-2');
+    checkResult(assert, result, [child3, child4]);
+
+    result = findAll('.my-class', element2);
+    checkResult(assert, result, [child3, child4]);
   });
 
   test('does not match outside test container', async function(assert) {
@@ -52,10 +70,8 @@ module('DOM Helper: findAll', function(hooks) {
     fixture.appendChild(element1);
     fixture.parentNode.appendChild(element2);
 
-    let result = findAll('.elt');
-    assert.ok(result instanceof Array);
-    assert.equal(result.length, 1);
-    assert.equal(result[0], element1);
+    let result = findAll('.my-class');
+    checkResult(assert, result, [child1, child2]);
   });
 
   test('throws without context set', function(assert) {

--- a/tests/unit/dom/find-test.js
+++ b/tests/unit/dom/find-test.js
@@ -7,18 +7,30 @@ module('DOM Helper: find', function(hooks) {
     return;
   }
 
-  let context, element;
+  let context, element1, element2, child1, child2;
+  const createDiv = () => document.createElement('div'),
+    setupElements = index => {
+      let parent = createDiv(),
+        child = createDiv();
+      parent.setAttribute('id', `elt-${index}`);
+      child.classList.add('my-class');
+      parent.appendChild(child);
+      return [parent, child];
+    };
 
   hooks.beforeEach(function() {
     context = {};
-    element = document.createElement('div');
-    element.setAttribute('id', 'elt');
+    [element1, child1] = setupElements(1);
+    [element2, child2] = setupElements(2);
   });
 
   hooks.afterEach(async function() {
-    if (element.parentNode) {
-      element.parentNode.removeChild(element);
-    }
+    [element1, element2].forEach(element => {
+      if (element.parentNode) {
+        element.parentNode.removeChild(element);
+      }
+    });
+
     if (context.owner) {
       await teardownContext(context);
     }
@@ -30,18 +42,22 @@ module('DOM Helper: find', function(hooks) {
     await setupContext(context);
 
     let fixture = document.querySelector('#ember-testing');
-    fixture.appendChild(element);
+    fixture.appendChild(element1);
+    fixture.appendChild(element2);
 
-    assert.equal(find('#elt'), element);
+    assert.equal(find('#elt-1'), element1);
+    assert.equal(find('.my-class'), child1);
+    assert.equal(find('.my-class', '#elt-2'), child2);
+    assert.equal(find('.my-class', element2), child2);
   });
 
   test('does not match outside test container', async function(assert) {
     await setupContext(context);
 
     let fixture = document.querySelector('#ember-testing');
-    fixture.parentNode.appendChild(element);
+    fixture.parentNode.appendChild(element1);
 
-    assert.notOk(find('#elt'));
+    assert.notOk(find('#elt-1'));
   });
 
   test('throws without context set', function(assert) {


### PR DESCRIPTION
I added an optional context param to both the find and findAll helpers.  This was a helpful feature in ember-native-dom-helpers, allowing one to write very clean and readable test loops.  I also tightened up the test code a bit for both helpers.