### PR TITLE
Fix KeyboardEvent#key and allow `triggerKeyEvent` to receive keys instead of keycodes

### DIFF
--- a/addon-test-support/@ember/test-helpers/dom/fire-event.js
+++ b/addon-test-support/@ember/test-helpers/dom/fire-event.js
@@ -128,13 +128,13 @@ function buildKeyboardEvent(type, options = {}) {
     // https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent
     Object.defineProperty(event, 'keyCode', {
       get() {
-        return parseInt(this.key);
+        return parseInt(eventOpts.keyCode);
       },
     });
 
     Object.defineProperty(event, 'which', {
       get() {
-        return parseInt(this.key);
+        return parseInt(eventOpts.which);
       },
     });
 

--- a/addon-test-support/@ember/test-helpers/dom/trigger-key-event.js
+++ b/addon-test-support/@ember/test-helpers/dom/trigger-key-event.js
@@ -96,12 +96,15 @@ function keyCodeFromKey(key) {
 }
 
 /**
-  Triggers a keyboard event on the specified target.
+  Triggers a keyboard event of given type in the target element.
+  It also requires the developer to provide either a string with the [`key`](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key/Key_Values)
+  or the numeric [`keyCode`](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode) of the pressed key.
+  Optionally the user can also provide a POJO with extra modifiers for the event.
 
   @public
   @param {string|Element} target the element or selector to trigger the event on
   @param {'keydown' | 'keyup' | 'keypress'} eventType the type of event to trigger
-  @param {number|string} key the keyCode of the event being triggered
+  @param {number|string} key the `keyCode`(number) or `key`(string) of the event being triggered
   @param {Object} [modifiers] the state of various modifier keys
   @param {boolean} [modifiers.ctrlKey=false] if true the generated event will indicate the control key was pressed during the key event
   @param {boolean} [modifiers.altKey=false] if true the generated event will indicate the alt key was pressed during the key event
@@ -131,7 +134,7 @@ export default function triggerKeyEvent(target, eventType, key, modifiers = DEFA
       );
     }
 
-    if (key === null || key === undefined) {
+    if (typeof key !== 'number' && typeof key !== 'string') {
       throw new Error(`Must provide a \`key\` or \`keyCode\` to \`triggerKeyEvent\``);
     }
     let props;

--- a/tests/unit/dom/trigger-key-event-test.js
+++ b/tests/unit/dom/trigger-key-event-test.js
@@ -58,7 +58,7 @@ module('DOM Helper: triggerKeyEvent', function(hooks) {
 
     assert.rejects(
       triggerKeyEvent(element, 'keypress'),
-      /Must provide a `keyCode` to `triggerKeyEvent`/
+      /Must provide a `key` or `keyCode` to `triggerKeyEvent`/
     );
   });
 
@@ -122,5 +122,111 @@ module('DOM Helper: triggerKeyEvent', function(hooks) {
     await triggerKeyEvent(element, 'keypress', 13, { altKey: true, ctrlKey: true });
 
     assert.verifySteps(['keypress']);
+  });
+
+  test('The value of the `event.key` is properly inferred from the given keycode and modifiers', async function(assert) {
+    element = buildInstrumentedElement('div');
+    async function checkKey(keyCode, key, modifiers) {
+      let handler = e => {
+        assert.equal(e.key, key);
+      };
+      element.addEventListener('keydown', handler);
+      await triggerKeyEvent(element, 'keydown', keyCode, modifiers);
+      element.removeEventListener('keydown', handler);
+    }
+    await checkKey(8, 'Backspace');
+    await checkKey(9, 'Tab');
+    await checkKey(13, 'Enter');
+    await checkKey(16, 'Shift');
+    await checkKey(17, 'Control');
+    await checkKey(18, 'Alt');
+    await checkKey(20, 'CapsLock');
+    await checkKey(27, 'Escape');
+    await checkKey(32, '');
+    await checkKey(37, 'ArrowLeft');
+    await checkKey(38, 'ArrowUp');
+    await checkKey(39, 'ArrowRight');
+    await checkKey(40, 'ArrowDown');
+    await checkKey(91, 'Meta');
+    await checkKey(93, 'Meta');
+    await checkKey(187, '=');
+    await checkKey(189, '-');
+    await checkKey(65, 'a');
+    await checkKey(90, 'z');
+    await checkKey(65, 'A', { shiftKey: true });
+    await checkKey(90, 'Z', { shiftKey: true });
+    assert.verifySteps([
+      'keydown',
+      'keydown',
+      'keydown',
+      'keydown',
+      'keydown',
+      'keydown',
+      'keydown',
+      'keydown',
+      'keydown',
+      'keydown',
+      'keydown',
+      'keydown',
+      'keydown',
+      'keydown',
+      'keydown',
+      'keydown',
+      'keydown',
+      'keydown',
+      'keydown',
+      'keydown',
+      'keydown',
+    ]);
+  });
+
+  test('The value of the `event.keyCode` is properly inferred from the given key', async function(assert) {
+    element = buildInstrumentedElement('div');
+    async function checkKeyCode(key, keyCode) {
+      let handler = e => {
+        assert.equal(e.keyCode, keyCode);
+      };
+      element.addEventListener('keydown', handler);
+      await triggerKeyEvent(element, 'keydown', key);
+      element.removeEventListener('keydown', handler);
+    }
+    await checkKeyCode('Backspace', 8);
+    await checkKeyCode('Tab', 9);
+    await checkKeyCode('Enter', 13);
+    await checkKeyCode('Shift', 16);
+    await checkKeyCode('Control', 17);
+    await checkKeyCode('Alt', 18);
+    await checkKeyCode('CapsLock', 20);
+    await checkKeyCode('Escape', 27);
+    await checkKeyCode('', 32);
+    await checkKeyCode('ArrowLeft', 37);
+    await checkKeyCode('ArrowUp', 38);
+    await checkKeyCode('ArrowRight', 39);
+    await checkKeyCode('ArrowDown', 40);
+    await checkKeyCode('Meta', 91);
+    await checkKeyCode('=', 187);
+    await checkKeyCode('-', 189);
+    await checkKeyCode('a', 65);
+    await checkKeyCode('z', 90);
+    assert.verifySteps([
+      'keydown',
+      'keydown',
+      'keydown',
+      'keydown',
+      'keydown',
+      'keydown',
+      'keydown',
+      'keydown',
+      'keydown',
+      'keydown',
+      'keydown',
+      'keydown',
+      'keydown',
+      'keydown',
+      'keydown',
+      'keydown',
+      'keydown',
+      'keydown',
+    ]);
   });
 });

--- a/tests/unit/dom/trigger-key-event-test.js
+++ b/tests/unit/dom/trigger-key-event-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { triggerKeyEvent, setupContext, teardownContext } from '@ember/test-helpers';
-import { buildInstrumentedElement } from '../../helpers/events';
+import { buildInstrumentedElement, insertElement } from '../../helpers/events';
 import hasEmberVersion from 'ember-test-helpers/has-ember-version';
 
 module('DOM Helper: triggerKeyEvent', function(hooks) {
@@ -125,7 +125,8 @@ module('DOM Helper: triggerKeyEvent', function(hooks) {
   });
 
   test('The value of the `event.key` is properly inferred from the given keycode and modifiers', async function(assert) {
-    element = buildInstrumentedElement('div');
+    element = document.createElement('div');
+    insertElement(element);
     async function checkKey(keyCode, key, modifiers) {
       let handler = e => {
         assert.equal(e.key, key);
@@ -155,33 +156,11 @@ module('DOM Helper: triggerKeyEvent', function(hooks) {
     await checkKey(90, 'z');
     await checkKey(65, 'A', { shiftKey: true });
     await checkKey(90, 'Z', { shiftKey: true });
-    assert.verifySteps([
-      'keydown',
-      'keydown',
-      'keydown',
-      'keydown',
-      'keydown',
-      'keydown',
-      'keydown',
-      'keydown',
-      'keydown',
-      'keydown',
-      'keydown',
-      'keydown',
-      'keydown',
-      'keydown',
-      'keydown',
-      'keydown',
-      'keydown',
-      'keydown',
-      'keydown',
-      'keydown',
-      'keydown',
-    ]);
   });
 
   test('The value of the `event.keyCode` is properly inferred from the given key', async function(assert) {
-    element = buildInstrumentedElement('div');
+    element = document.createElement('div');
+    insertElement(element);
     async function checkKeyCode(key, keyCode) {
       let handler = e => {
         assert.equal(e.keyCode, keyCode);
@@ -208,25 +187,5 @@ module('DOM Helper: triggerKeyEvent', function(hooks) {
     await checkKeyCode('-', 189);
     await checkKeyCode('a', 65);
     await checkKeyCode('z', 90);
-    assert.verifySteps([
-      'keydown',
-      'keydown',
-      'keydown',
-      'keydown',
-      'keydown',
-      'keydown',
-      'keydown',
-      'keydown',
-      'keydown',
-      'keydown',
-      'keydown',
-      'keydown',
-      'keydown',
-      'keydown',
-      'keydown',
-      'keydown',
-      'keydown',
-      'keydown',
-    ]);
   });
 });


### PR DESCRIPTION
Closes #265

Now: `triggerKeyEvent(selector, 'keydown', 9)` and `triggerKeyEvent(selector, 'keydown', 'Tab')` are equivalent.
Also, the generated event in both cases has `e.keyCode === 9` and `e.key === 'Tab'`