### PR TITLE
Clobber `self.find` when running rendering or application tests.

### DIFF
--- a/addon-test-support/@ember/test-helpers/setup-rendering-context.js
+++ b/addon-test-support/@ember/test-helpers/setup-rendering-context.js
@@ -149,6 +149,12 @@ export default function setupRenderingContext(context) {
 
   return nextTickPromise()
     .then(() => {
+      let originalFind = global.find;
+      RENDERING_CLEANUP[contextGuid].push(() => {
+        global.find = originalFind;
+      });
+      delete global.find;
+
       let { owner } = context;
 
       // these methods being placed on the context itself will be deprecated in

--- a/addon-test-support/@ember/test-helpers/teardown-application-context.js
+++ b/addon-test-support/@ember/test-helpers/teardown-application-context.js
@@ -1,4 +1,7 @@
 import settled from './settled';
+import { guidFor } from '@ember/object/internals';
+import { APPLICATION_CLEANUP } from './setup-application-context';
+import { nextTickPromise, runDestroyablesFor } from './-utils';
 
 /**
   Used by test framework addons to tear down the provided context after testing is completed.
@@ -7,6 +10,12 @@ import settled from './settled';
   @param {Object} context the context to setup
   @returns {Promise<void>} resolves when settled
 */
-export default function() {
-  return settled();
+export default function(context) {
+  return nextTickPromise().then(() => {
+    let contextGuid = guidFor(context);
+
+    runDestroyablesFor(APPLICATION_CLEANUP, contextGuid);
+
+    return settled();
+  });
 }

--- a/tests/integration/module-for-acceptance-interop-test.js
+++ b/tests/integration/module-for-acceptance-interop-test.js
@@ -4,6 +4,7 @@ import EmberRouter from '@ember/routing/router';
 import Component from '@ember/component';
 import { click } from '@ember/test-helpers';
 import hasEmberVersion from '@ember/test-helpers/has-ember-version';
+import hasjQuery from '../helpers/has-jquery';
 
 import hbs from 'htmlbars-inline-precompile';
 import ajax from '../helpers/ajax';
@@ -34,6 +35,7 @@ moduleForAcceptance('Classic "moduleForAcceptance" | using settled', {
     'router:main': Router,
     'component:x-test-3': TestComponent3,
     'template:ajax-request': hbs`{{x-test-3 class="special-thing"}}`,
+    'template:index': hbs`<div class="foo">I'm a div!</div>`,
   },
 
   beforeEach() {
@@ -71,5 +73,18 @@ if (hasEmberVersion(2, 8)) {
         let testingElement = document.getElementById('ember-testing');
         assert.equal(testingElement.textContent, 'Remote Data!');
       });
+  });
+}
+
+if (hasjQuery()) {
+  test('has access to `find`', function(assert) {
+    // eslint-disable-next-line no-undef
+    visit('/');
+
+    // eslint-disable-next-line no-undef
+    andThen(() => {
+      let element = find('.foo');
+      assert.equal(element.textContent, "I'm a div!");
+    });
   });
 }

--- a/tests/unit/setup-application-context-test.js
+++ b/tests/unit/setup-application-context-test.js
@@ -127,4 +127,8 @@ module('setupApplicationContext', function(hooks) {
   test('bubbles up errors', function(assert) {
     assert.rejects(visit('/widgets'), /Model hook error from \/widgets/);
   });
+
+  test('window.find is not present', function(assert) {
+    assert.strictEqual(self.find, undefined, 'global find is not present');
+  });
 });

--- a/tests/unit/setup-rendering-context-test.js
+++ b/tests/unit/setup-rendering-context-test.js
@@ -366,6 +366,10 @@ module('setupRenderingContext', function(hooks) {
       assert.equal(testingRootElement.textContent, '', 'has rendered content');
       assert.strictEqual(this.element, originalElement, 'this.element is stable');
     });
+
+    test('window.find is not present', function(assert) {
+      assert.strictEqual(self.find, undefined, 'global find is not present');
+    });
   }
 
   module('with only application set', function(hooks) {

--- a/tests/unit/teardown-rendering-context-test.js
+++ b/tests/unit/teardown-rendering-context-test.js
@@ -13,6 +13,7 @@ module('setupRenderingContext', function(hooks) {
   }
 
   hooks.beforeEach(async function() {
+    this.originalFind = self.find;
     await setupContext(this);
     await setupRenderingContext(this);
   });
@@ -53,5 +54,11 @@ module('setupRenderingContext', function(hooks) {
       document.body.contains(beforeTeardownEl),
       'previous ember-testing element is no longer in DOM'
     );
+  });
+
+  test('resets self.find after teardown', async function(assert) {
+    await teardownRenderingContext(this);
+
+    assert.strictEqual(self.find, this.originalFind);
   });
 });


### PR DESCRIPTION
Forgetting to import `find`, and then calling the global `find` function has become a very common pain point as folks migrate from the older system (where `find` was always globally clobbered to be our own special version) and the new system where you must import it.

This fixes many WAT's...