### PR TITLE
Change descriptors to allow properties to be enumerated and configured

### DIFF
--- a/addon-test-support/@ember/test-helpers/setup-context.js
+++ b/addon-test-support/@ember/test-helpers/setup-context.js
@@ -168,11 +168,15 @@ export default function(context, options = {}) {
     })
     .then(owner => {
       Object.defineProperty(context, 'owner', {
+        configurable: true,
+        enumerable: true,
         value: owner,
         writable: false,
       });
 
       Object.defineProperty(context, 'set', {
+        configurable: true,
+        enumerable: true,
         value(key, value) {
           let ret = run(function() {
             return set(context, key, value);
@@ -184,6 +188,8 @@ export default function(context, options = {}) {
       });
 
       Object.defineProperty(context, 'setProperties', {
+        configurable: true,
+        enumerable: true,
         value(hash) {
           let ret = run(function() {
             return setProperties(context, hash);
@@ -195,6 +201,8 @@ export default function(context, options = {}) {
       });
 
       Object.defineProperty(context, 'get', {
+        configurable: true,
+        enumerable: true,
         value(key) {
           return get(context, key);
         },
@@ -202,6 +210,8 @@ export default function(context, options = {}) {
       });
 
       Object.defineProperty(context, 'getProperties', {
+        configurable: true,
+        enumerable: true,
         value(...args) {
           return getProperties(context, args);
         },

--- a/addon-test-support/@ember/test-helpers/setup-rendering-context.js
+++ b/addon-test-support/@ember/test-helpers/setup-rendering-context.js
@@ -154,14 +154,26 @@ export default function setupRenderingContext(context) {
       // these methods being placed on the context itself will be deprecated in
       // a future version (no giant rush) to remove some confusion about which
       // is the "right" way to things...
-      Object.defineProperty(context, 'render', { value: render, writable: false });
+      Object.defineProperty(context, 'render', {
+        configurable: true,
+        enumerable: true,
+        value: render,
+        writable: false,
+      });
       Object.defineProperty(context, 'clearRender', {
+        configurable: true,
+        enumerable: true,
         value: clearRender,
         writable: false,
       });
 
       if (global.jQuery) {
-        Object.defineProperty(context, '$', { value: jQuerySelector, writable: false });
+        Object.defineProperty(context, '$', {
+          configurable: true,
+          enumerable: true,
+          value: jQuerySelector,
+          writable: false,
+        });
       }
 
       // When the host app uses `setApplication` (instead of `setResolver`) the event dispatcher has
@@ -194,6 +206,8 @@ export default function setupRenderingContext(context) {
     })
     .then(() => {
       Object.defineProperty(context, 'element', {
+        configurable: true,
+        enumerable: true,
         // ensure the element is based on the wrapping toplevel view
         // Ember still wraps the main application template with a
         // normal tagged view


### PR DESCRIPTION
Test context is shared in Mocha (https://github.com/mochajs/mocha/wiki/Shared-Behaviours), so test specific properties need to be deleted or reconfigured after each test. 
`ember-mocha` currently deletes the properties added. In order to do this it needs them to be `configurable` and `enumerable`.
See https://github.com/emberjs/ember-mocha/issues/205 for more details.