### PR TITLE
auto-dist-tag: Use Node 4 compatible release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ jobs:
     - stage: deploy
       if: tag IS present
       env: NAME=npm-publish # used only to make Travis UI show description
-      install: yarn global add auto-dist-tag
+      install: yarn global add auto-dist-tag@0.1
       script: auto-dist-tag --write
       deploy:
         provider: npm


### PR DESCRIPTION
This should fix https://travis-ci.org/emberjs/ember-test-helpers/jobs/380815111 while we're still targeting Node 4 here.