### PR TITLE
Add doubleClick helper

### DIFF
--- a/API.md
+++ b/API.md
@@ -4,6 +4,7 @@
 
 -   [DOM Interaction Helpers](#dom-interaction-helpers)
     -   [click](#click)
+    -   [doubleClick](#doubleclick)
     -   [tap](#tap)
     -   [focus](#focus)
     -   [blur](#blur)
@@ -79,6 +80,45 @@ to continue to emulate how actual browsers handle clicking a given element.
 **Parameters**
 
 -   `target` **([string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String) \| [Element](https://developer.mozilla.org/docs/Web/API/Element))** the element or selector to click on
+
+Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;void>** resolves when settled
+
+### doubleClick
+
+Double-clicks on the specified target.
+
+Sends a number of events intending to simulate a "real" user double-clicking on an
+element.
+
+For non-focusable elements the following events are triggered (in order):
+
+-   `mousedown`
+-   `mouseup`
+-   `click`
+-   `mousedown`
+-   `mouseup`
+-   `click`
+-   `dblclick`
+
+For focusable (e.g. form control) elements the following events are triggered
+(in order):
+
+-   `mousedown`
+-   `focus`
+-   `focusin`
+-   `mouseup`
+-   `click`
+-   `mousedown`
+-   `mouseup`
+-   `click`
+-   `dblclick`
+
+The exact listing of events that are triggered may change over time as needed
+to continue to emulate how actual browsers handle double-clicking a given element.
+
+**Parameters**
+
+-   `target` **([string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String) \| [Element](https://developer.mozilla.org/docs/Web/API/Element))** the element or selector to double-click on
 
 Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;void>** resolves when settled
 

--- a/addon-test-support/@ember/test-helpers/dom/double-click.js
+++ b/addon-test-support/@ember/test-helpers/dom/double-click.js
@@ -1,0 +1,77 @@
+import getElement from './-get-element';
+import fireEvent from './fire-event';
+import { __focus__ } from './focus';
+import settled from '../settled';
+import isFocusable from './-is-focusable';
+import { nextTickPromise } from '../-utils';
+
+/**
+  @private
+  @param {Element} element the element to double-click on
+*/
+export function __doubleClick__(element) {
+  fireEvent(element, 'mousedown');
+
+  if (isFocusable(element)) {
+    __focus__(element);
+  }
+
+  fireEvent(element, 'mouseup');
+  fireEvent(element, 'click');
+  fireEvent(element, 'mousedown');
+  fireEvent(element, 'mouseup');
+  fireEvent(element, 'click');
+  fireEvent(element, 'dblclick');
+}
+
+/**
+  Double-clicks on the specified target.
+
+  Sends a number of events intending to simulate a "real" user clicking on an
+  element.
+
+  For non-focusable elements the following events are triggered (in order):
+
+  - `mousedown`
+  - `mouseup`
+  - `click`
+  - `mousedown`
+  - `mouseup`
+  - `click`
+  - `dblclick`
+
+  For focusable (e.g. form control) elements the following events are triggered
+  (in order):
+
+  - `mousedown`
+  - `focus`
+  - `focusin`
+  - `mouseup`
+  - `click`
+  - `mousedown`
+  - `mouseup`
+  - `click`
+  - `dblclick`
+
+  The exact listing of events that are triggered may change over time as needed
+  to continue to emulate how actual browsers handle clicking a given element.
+
+  @public
+  @param {string|Element} target the element or selector to double-click on
+  @return {Promise<void>} resolves when settled
+*/
+export default function doubleClick(target) {
+  return nextTickPromise().then(() => {
+    if (!target) {
+      throw new Error('Must pass an element or selector to `doubleClick`.');
+    }
+
+    let element = getElement(target);
+    if (!element) {
+      throw new Error(`Element not found when calling \`doubleClick('${target}')\`.`);
+    }
+
+    __doubleClick__(element);
+    return settled();
+  });
+}

--- a/addon-test-support/@ember/test-helpers/index.js
+++ b/addon-test-support/@ember/test-helpers/index.js
@@ -24,6 +24,7 @@ export { default as validateErrorHandler } from './validate-error-handler';
 
 // DOM Helpers
 export { default as click } from './dom/click';
+export { default as doubleClick } from './dom/double-click';
 export { default as tap } from './dom/tap';
 export { default as focus } from './dom/focus';
 export { default as blur } from './dom/blur';

--- a/documentation.yml
+++ b/documentation.yml
@@ -2,6 +2,7 @@ toc:
   - name: DOM Interaction Helpers
     children:
       - click
+      - doubleClick
       - tap
       - focus
       - blur


### PR DESCRIPTION
This PR adds a `doubleClick` helper to simulate double-clicks, similar to the `click` helper. I'm not sure that it was necessary but I duplicated all the `click` tests.

Here's a little JSBin I threw together to make sure I got the event ordering correct: http://jsbin.com/pulapatapo/1/edit?html,console,output

The order for a focusable element is

```
mousedown
focus
focusin
mouseup
click
mousedown
mouseup
click
dblclick
```

which essentially amounts to two simulated clicks followed by a `dblclick` event.