### PR TITLE
Update buildMouseEvent to use MouseEvent constructor if it is present

### DIFF
--- a/addon-test-support/@ember/test-helpers/dom/fire-event.js
+++ b/addon-test-support/@ember/test-helpers/dom/fire-event.js
@@ -84,27 +84,39 @@ function buildBasicEvent(type, options = {}) {
 // eslint-disable-next-line require-jsdoc
 function buildMouseEvent(type, options = {}) {
   let event;
+  let eventOpts = merge(merge({}, DEFAULT_EVENT_OPTIONS), options);
   try {
-    event = document.createEvent('MouseEvents');
-    let eventOpts = merge(merge({}, DEFAULT_EVENT_OPTIONS), options);
-    event.initMouseEvent(
-      type,
-      eventOpts.bubbles,
-      eventOpts.cancelable,
-      window,
-      eventOpts.detail,
-      eventOpts.screenX,
-      eventOpts.screenY,
-      eventOpts.clientX,
-      eventOpts.clientY,
-      eventOpts.ctrlKey,
-      eventOpts.altKey,
-      eventOpts.shiftKey,
-      eventOpts.metaKey,
-      eventOpts.button,
-      eventOpts.relatedTarget
-    );
+    event = new MouseEvent(type, eventOpts);
   } catch (e) {
+    // left intentionally blank
+  }
+
+  if (!event) {
+    try {
+      event = document.createEvent('MouseEvents');
+      event.initMouseEvent(
+        type,
+        eventOpts.bubbles,
+        eventOpts.cancelable,
+        window,
+        eventOpts.detail,
+        eventOpts.screenX,
+        eventOpts.screenY,
+        eventOpts.clientX,
+        eventOpts.clientY,
+        eventOpts.ctrlKey,
+        eventOpts.altKey,
+        eventOpts.shiftKey,
+        eventOpts.metaKey,
+        eventOpts.button,
+        eventOpts.relatedTarget
+      );
+    } catch (e) {
+      // left intentionally blank
+    }
+  }
+
+  if (!event) {
     event = buildBasicEvent(type, options);
   }
   return event;

--- a/addon-test-support/@ember/test-helpers/dom/fire-event.js
+++ b/addon-test-support/@ember/test-helpers/dom/fire-event.js
@@ -1,5 +1,15 @@
 import { merge } from '@ember/polyfills';
 
+// eslint-disable-next-line require-jsdoc
+function checkMouseEventExistence() {
+  try {
+    new MouseEvent('test');
+    return true;
+  } catch (e) {
+    return false;
+  }
+}
+const MOUSE_EVENT_EXISTS = checkMouseEventExistence();
 const DEFAULT_EVENT_OPTIONS = { bubbles: true, cancelable: true };
 export const KEYBOARD_EVENT_TYPES = Object.freeze(['keydown', 'keypress', 'keyup']);
 const MOUSE_EVENT_TYPES = [
@@ -85,13 +95,9 @@ function buildBasicEvent(type, options = {}) {
 function buildMouseEvent(type, options = {}) {
   let event;
   let eventOpts = merge(merge({}, DEFAULT_EVENT_OPTIONS), options);
-  try {
+  if (MOUSE_EVENT_EXISTS) {
     event = new MouseEvent(type, eventOpts);
-  } catch (e) {
-    // left intentionally blank
-  }
-
-  if (!event) {
+  } else {
     try {
       event = document.createEvent('MouseEvents');
       event.initMouseEvent(
@@ -112,13 +118,10 @@ function buildMouseEvent(type, options = {}) {
         eventOpts.relatedTarget
       );
     } catch (e) {
-      // left intentionally blank
+      event = buildBasicEvent(type, options);
     }
   }
 
-  if (!event) {
-    event = buildBasicEvent(type, options);
-  }
   return event;
 }
 

--- a/addon-test-support/@ember/test-helpers/dom/fire-event.js
+++ b/addon-test-support/@ember/test-helpers/dom/fire-event.js
@@ -1,15 +1,14 @@
 import { merge } from '@ember/polyfills';
 
 // eslint-disable-next-line require-jsdoc
-function checkMouseEventExistence() {
+const MOUSE_EVENT_CONSTRUCTOR = (() => {
   try {
     new MouseEvent('test');
     return true;
   } catch (e) {
     return false;
   }
-}
-const MOUSE_EVENT_EXISTS = checkMouseEventExistence();
+})();
 const DEFAULT_EVENT_OPTIONS = { bubbles: true, cancelable: true };
 export const KEYBOARD_EVENT_TYPES = Object.freeze(['keydown', 'keypress', 'keyup']);
 const MOUSE_EVENT_TYPES = [
@@ -95,7 +94,7 @@ function buildBasicEvent(type, options = {}) {
 function buildMouseEvent(type, options = {}) {
   let event;
   let eventOpts = merge(merge({}, DEFAULT_EVENT_OPTIONS), options);
-  if (MOUSE_EVENT_EXISTS) {
+  if (MOUSE_EVENT_CONSTRUCTOR) {
     event = new MouseEvent(type, eventOpts);
   } else {
     try {


### PR DESCRIPTION
Closes #266 by using the `MouseEvent` constructor in `buildMouseEvent` if it is present. Otherwise, it falls back to the existing `initMouseEvent` function for compatibility with IE 9/10