### PR TITLE
[In progress] Create visible() test helper

### DIFF
--- a/API.md
+++ b/API.md
@@ -25,6 +25,7 @@
 -   [Wait Helpers](#wait-helpers)
     -   [waitFor](#waitfor)
     -   [waitUntil](#waituntil)
+    -   [visible](#visible)
     -   [settled](#settled)
     -   [isSettled](#issettled)
     -   [getSettledState](#getsettledstate)
@@ -356,6 +357,22 @@ while _not_ settled (e.g. "loading" or "pending" states).
     -   `options.timeoutMessage` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the message to use in the reject on timeout (optional, default `'waitUntil timed out'`)
 
 Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)** resolves with the callback value when it returns a truthy value
+
+### visible
+
+Used to wait until a given element is graphically visibile within a parent container. This is accomplished by utilizing an [Intersection Observer](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API).
+
+**Parameters**
+
+-   `target` **([string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String) \| [Element](https://developer.mozilla.org/docs/Web/API/Element))** the selector to wait for
+-   `options` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)?** the options to be used (optional, default `{}`)
+    -   `options.timeout` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)?** the time to wait (in ms) for the element to appear (optional, default `1000`)
+    -   `options.threshold` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)?** the percentage (between 0 and 1) of the object that must be visible. Equivalent to the threshold option of the [Intersection Observer](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API). (optional, default `1.0`)
+    -   `options.root` **([string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String) \| [Element](https://developer.mozilla.org/docs/Web/API/Element))?** the container element to check if the target is visible within. Equivalent to the root option of the [Intersection Observer](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API). (optional, default is the test container element)
+    -   `options.rootMargin` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** a CSS margin that will be added to the container element before comparison to the target element. Equivalent to the rootmargin option of the [Intersection Observer](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API). (optional, default `0px 0px 0px 0px`)
+    -   `options.timeoutMessage` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** the error message when the helper times out (optional, default `'visible timed out'`)
+
+Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;void>** resolves when the target element is visible
 
 ### settled
 

--- a/addon-test-support/@ember/test-helpers/dom/visible.js
+++ b/addon-test-support/@ember/test-helpers/dom/visible.js
@@ -1,0 +1,56 @@
+import { Promise } from 'rsvp';
+import { futureTick } from '../-utils';
+import { getRootElement } from './get-root-element';
+import getElement from './-get-element';
+
+
+/**
+  Wait for element to be visible inside of given root element (defaults to testing container)
+
+  @public
+  @param {string|Element} target the selector or element for the element that visibility will be calculated on
+  @param {Object} [options] options used to override defaults
+  @param {number} [options.timeout=1000] the maximum amount of time to wait
+  @param {string|Element} [options.root='test container'] the selector for the element whose bounding box will be intersected with the target element. Defaults to the value of getRootElement()
+  @param {number} [options.threshold=1.0] the percentage of visibility required for this helper to resolve
+  @param {string} [options.rootMargin='0px 0px 0px 0px'] offsets to be added to the sides of the root element bounding box before calculating intersection
+  @param {string} [options.timeoutMessage='visible timed out'] the message to use in the reject on timeout
+
+  @returns {Promise} resolves with the callback value when it returns a truthy value
+*/
+export default function visible(target, options = {}) {
+  let root = 'rootSelector' in options ? options.root : getRootElement();
+  let threshold = 'threshold' in options ? options.threshold : 1.0;
+  let rootMargin = 'rootMargin' in options ? options.rootMargin : '0px 0px 0px 0px';
+  let timeout = 'timeout' in options ? options.timeout : 1000;
+  let timeoutMessage = 'timeoutMessage' in options ? options.timeoutMessage : 'visible timed out';
+
+  root = typeof(root) == "string" ? getElement(root) : root;
+  if(!root) throw new Error('Provided root element does not exist');
+
+  target = typeof(target) == "string" ? getElement(target) : target;
+  if(!target) throw new Error('Provided target element does not exist');
+
+  // creating this error eagerly so it has the proper invocation stack
+  let waitTimedOut = new Error(timeoutMessage);
+
+  return new Promise(function(resolve, reject) {
+    function observerCallback (entries, observer) {
+      if(entries[0].intersectionRatio >= threshold) {
+        observer.disconnect();
+        resolve(target);
+      }
+    };
+
+    var intersectionObserver = new IntersectionObserver(observerCallback,
+      {'root': root, 'threshold': threshold, 'rootMargin': rootMargin});
+    intersectionObserver.observe(target);
+
+    futureTick(function() {
+      intersectionObserver.disconnect();
+      reject(waitTimedOut);
+    }, timeout);
+  });
+}
+
+

--- a/addon-test-support/@ember/test-helpers/index.js
+++ b/addon-test-support/@ember/test-helpers/index.js
@@ -35,3 +35,4 @@ export { default as waitFor } from './dom/wait-for';
 export { default as getRootElement } from './dom/get-root-element';
 export { default as find } from './dom/find';
 export { default as findAll } from './dom/find-all';
+export { default as visible } from './dom/visible';

--- a/documentation.yml
+++ b/documentation.yml
@@ -31,6 +31,7 @@ toc:
     children:
       - waitFor
       - waitUntil
+      - visible
       - settled
       - isSettled
       - getSettledState


### PR DESCRIPTION
From [this](https://github.com/GoogleChrome/puppeteer/issues/2629) discussion on the puppeteer github, I found out about the intersection observer API and thought it would be a good fit for ember tests. I've completed the helper and manually tested it on a project of my own, but I still need to add automated tests that cover more scenarios.