### PR TITLE
Include selector in waitFor()'s default timeout message

### DIFF
--- a/addon-test-support/@ember/test-helpers/dom/wait-for.js
+++ b/addon-test-support/@ember/test-helpers/dom/wait-for.js
@@ -15,10 +15,7 @@ import { nextTickPromise } from '../-utils';
   @param {number} [options.count=null] the number of elements that should match the provided selector (null means one or more)
   @return {Promise<Element|Element[]>} resolves when the element(s) appear on the page
 */
-export default function waitFor(
-  selector,
-  { timeout = 1000, count = null, timeoutMessage } = {}
-) {
+export default function waitFor(selector, { timeout = 1000, count = null, timeoutMessage } = {}) {
   return nextTickPromise().then(() => {
     if (!selector) {
       throw new Error('Must pass a selector to `waitFor`.');

--- a/addon-test-support/@ember/test-helpers/dom/wait-for.js
+++ b/addon-test-support/@ember/test-helpers/dom/wait-for.js
@@ -17,11 +17,14 @@ import { nextTickPromise } from '../-utils';
 */
 export default function waitFor(
   selector,
-  { timeout = 1000, count = null, timeoutMessage = 'waitFor timed out' } = {}
+  { timeout = 1000, count = null, timeoutMessage } = {}
 ) {
   return nextTickPromise().then(() => {
     if (!selector) {
       throw new Error('Must pass a selector to `waitFor`.');
+    }
+    if (!timeoutMessage) {
+      timeoutMessage = `waitFor timed out waiting for selector "${selector}"`;
     }
 
     let callback;

--- a/tests/unit/dom/wait-for-test.js
+++ b/tests/unit/dom/wait-for-test.js
@@ -75,7 +75,7 @@ module('DOM Helper: waitFor', function(hooks) {
     } catch (error) {
       let end = Date.now();
       assert.ok(end - start >= 100, 'timed out after correct time');
-      assert.equal(error.message, 'waitFor timed out');
+      assert.equal(error.message, 'waitFor timed out waiting for selector ".something"');
     }
   });
 


### PR DESCRIPTION
Reduces ambiguity if a timeout occurs in a test with multiple waitFor()s