### PR TITLE
Standarise the `fireEvent` method interface

### DIFF
--- a/API.md
+++ b/API.md
@@ -87,7 +87,7 @@ Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/
 
 Double-clicks on the specified target.
 
-Sends a number of events intending to simulate a "real" user double-clicking on an
+Sends a number of events intending to simulate a "real" user clicking on an
 element.
 
 For non-focusable elements the following events are triggered (in order):
@@ -114,7 +114,7 @@ For focusable (e.g. form control) elements the following events are triggered
 -   `dblclick`
 
 The exact listing of events that are triggered may change over time as needed
-to continue to emulate how actual browsers handle double-clicking a given element.
+to continue to emulate how actual browsers handle clicking a given element.
 
 **Parameters**
 
@@ -204,11 +204,40 @@ Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/
 
 Triggers an event on the specified target.
 
+For HTML `input` element of type 'file', if you wish to trigger `change`
+event, the options param can be passed as:
+  1\. an array of `File` objects.
+  2\. an object with key `files` which contains an array of `File` objects.
+
 **Parameters**
 
 -   `target` **([string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String) \| [Element](https://developer.mozilla.org/docs/Web/API/Element))** the element or selector to trigger the event on
 -   `eventType` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the type of event to trigger
 -   `options` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** additional properties to be set on the event
+
+**Examples**
+
+_Usage_
+
+```javascript
+import { setupRenderingTest } from 'ember-qunit';
+import { render, triggerEvent } from '@ember/test-helpers';
+
+module('awesome-sauce', function(hooks) {
+  setupRenderingTest(hooks);
+    test('does something awesome', async function(assert) {
+    await render(hbs`{{awesome-sauce}}`);
+
+    // passing an array of files
+    let file = new File(['text file'], 'text.txt', { type: 'text/plain' });
+    await triggerEvent('input:file', 'change', [file]);
+
+    // passing an object that with 'files' as a key
+    let file = new File(['text file'], 'text.txt', { type: 'text/plain' });
+    await triggerEvent('input:file', 'change', { files: [file] });
+  });
+});
+```
 
 Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;void>** resolves when the application is settled
 
@@ -337,7 +366,7 @@ interim DOM states (e.g. loading states, pending promises, etc).
 -   `options` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)?** the options to be used (optional, default `{}`)
     -   `options.timeout` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** the time to wait (in ms) for a match (optional, default `1000`)
     -   `options.count` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** the number of elements that should match the provided selector (null means one or more) (optional, default `null`)
-    -   `options.timeoutMessage`   (optional, default `'waitFor timed out'`)
+    -   `options.timeoutMessage`  
 
 Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;([Element](https://developer.mozilla.org/docs/Web/API/Element) \| [Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[Element](https://developer.mozilla.org/docs/Web/API/Element)>)>** resolves when the element(s) appear on the page
 

--- a/addon-test-support/@ember/test-helpers/dom/fire-event.js
+++ b/addon-test-support/@ember/test-helpers/dom/fire-event.js
@@ -180,8 +180,9 @@ function buildKeyboardEvent(type, options = {}) {
 }
 
 // eslint-disable-next-line require-jsdoc
-function buildFileEvent(type, element, files = []) {
+function buildFileEvent(type, element, options = {}) {
   let event = buildBasicEvent(type);
+  let files = Array.isArray(options) ? options : options.files || [];
 
   if (files.length > 0) {
     Object.defineProperty(files, 'item', {

--- a/addon-test-support/@ember/test-helpers/dom/trigger-event.js
+++ b/addon-test-support/@ember/test-helpers/dom/trigger-event.js
@@ -4,14 +4,39 @@ import settled from '../settled';
 import { nextTickPromise } from '../-utils';
 
 /**
-  Triggers an event on the specified target.
-
-  @public
-  @param {string|Element} target the element or selector to trigger the event on
-  @param {string} eventType the type of event to trigger
-  @param {Object} options additional properties to be set on the event
-  @return {Promise<void>} resolves when the application is settled
-*/
+ * Triggers an event on the specified target.
+ *
+ * For HTML `input` element of type 'file', if you wish to trigger `change`
+ * event, the options param can be passed as:
+ *   1. an array of `File` objects.
+ *   2. an object with key `files` which contains an array of `File` objects.
+ *
+ * @public
+ * @param {string|Element} target the element or selector to trigger the event on
+ * @param {string} eventType the type of event to trigger
+ * @param {Object} options additional properties to be set on the event
+ * @return {Promise<void>} resolves when the application is settled
+ *
+ * @example <caption>Usage</caption>
+ *
+ * import { setupRenderingTest } from 'ember-qunit';
+ * import { render, triggerEvent } from '@ember/test-helpers';
+ *
+ * module('awesome-sauce', function(hooks) {
+ *   setupRenderingTest(hooks);
+ *     test('does something awesome', async function(assert) {
+ *     await render(hbs`{{awesome-sauce}}`);
+ *
+ *     // passing an array of files
+ *     let file = new File(['text file'], 'text.txt', { type: 'text/plain' });
+ *     await triggerEvent('input:file', 'change', [file]);
+ *
+ *     // passing an object that with 'files' as a key
+ *     let file = new File(['text file'], 'text.txt', { type: 'text/plain' });
+ *     await triggerEvent('input:file', 'change', { files: [file] });
+ *   });
+ * });
+ */
 export default function triggerEvent(target, eventType, options) {
   return nextTickPromise().then(() => {
     if (!target) {

--- a/tests/unit/dom/select-files-test.js
+++ b/tests/unit/dom/select-files-test.js
@@ -50,4 +50,18 @@ module('DOM Helper: selectFiles', function(hooks) {
 
     assert.verifySteps(['change', 'text-file.txt', 'change', 'image-file.png']);
   });
+
+  test('it can trigger a file selection event with files passed in options object', async function(assert) {
+    element = buildInstrumentedElement('input');
+    element.setAttribute('type', 'file');
+
+    element.addEventListener('change', e => {
+      assert.step(e.target.files[0].name);
+    });
+
+    await setupContext(context);
+    await triggerEvent(element, 'change', { files: [textFile] });
+
+    assert.verifySteps(['change', 'text-file.txt']);
+  });
 });


### PR DESCRIPTION
## Why?

When using `triggerEvent` to fire a `change` event on `<input> element with type="file"`, [those lines](https://github.com/emberjs/ember-test-helpers/blob/8a3614657064efaf13dfe667fe4cfdc14f15f509/addon-test-support/@ember/test-helpers/dom/fire-event.js#L57-L58) call the `buildFileEvent` which forwards `options` with its same structure.

Though, `buildFileEvent` [accepts an array](https://github.com/emberjs/ember-test-helpers/blob/8a3614657064efaf13dfe667fe4cfdc14f15f509/addon-test-support/@ember/test-helpers/dom/fire-event.js#L183): `files = []`, the documentation doesn't clarify this difference.

I think it will be more natural not to break the interface here by introducing an array argument.

## Sample code

```js
let file = new File(['my-content'],'image.png', {
  type: 'image/png',
});
triggerEvent(selector, 'change', [file]); // will work
triggerEvent(selector, 'change',{ files: file }); // will not propagate the value to the event handler
```

## Questions

1. Should we start writing a test for this file? It think it is a sensitive one to skip tests on.

## Alternatives

We could also live with elaborating on this difference in the `API.md`, to avoid breaking changes.

----

cc: kudos to @mattdonnelly for pointing this out, and subsequently saving my day. 