### PR TITLE
Fix getRootElement failing when Application.rootElement is an element

### DIFF
--- a/addon-test-support/@ember/test-helpers/dom/get-root-element.js
+++ b/addon-test-support/@ember/test-helpers/dom/get-root-element.js
@@ -14,16 +14,24 @@ export default function getRootElement() {
     throw new Error('Must setup rendering context before attempting to interact with elements.');
   }
 
-  let rootElementSelector;
+  let rootElement;
   // When the host app uses `setApplication` (instead of `setResolver`) the owner has
-  // a `rootElement` set on it with the element id to be used
+  // a `rootElement` set on it with the element or id to be used
   if (owner && owner._emberTestHelpersMockOwner === undefined) {
-    rootElementSelector = owner.rootElement;
+    rootElement = owner.rootElement;
   } else {
-    rootElementSelector = '#ember-testing';
+    rootElement = '#ember-testing';
   }
 
-  let rootElement = document.querySelector(rootElementSelector);
-
-  return rootElement;
+  if (
+    rootElement.nodeType === Node.ELEMENT_NODE ||
+    rootElement.nodeType === Node.DOCUMENT_NODE ||
+    rootElement instanceof Window
+  ) {
+    return rootElement;
+  } else if (typeof rootElement === 'string') {
+    return document.querySelector(rootElement);
+  } else {
+    throw new Error('Application.rootElement must be an element or a selector string');
+  }
 }

--- a/tests/unit/dom/get-root-element-test.js
+++ b/tests/unit/dom/get-root-element-test.js
@@ -33,4 +33,39 @@ module('DOM Helper: getRootElement', function(hooks) {
       getRootElement();
     }, /Must setup rendering context before attempting to interact with elements/);
   });
+
+  test('works when Application.rootElement is a string', async function(assert) {
+    await setupContext(context);
+
+    const existingRoot = getRootElement();
+    const newRoot = document.createElement('div');
+    newRoot.setAttribute('id', 'custom-root');
+    existingRoot.appendChild(newRoot);
+    context.owner.rootElement = '#custom-root';
+
+    const fixture = document.querySelector('#custom-root');
+    assert.equal(getRootElement(), fixture);
+  });
+
+  test('works when Application.rootElement is an element', async function(assert) {
+    await setupContext(context);
+
+    const existingRoot = getRootElement();
+    const newRoot = document.createElement('div');
+    newRoot.setAttribute('id', 'custom-root-2');
+    existingRoot.appendChild(newRoot);
+    context.owner.rootElement = newRoot;
+
+    const fixture = document.querySelector('#custom-root-2');
+    assert.equal(getRootElement(), fixture);
+  });
+
+  test('throws when Application.rootElement is neither string nor element', async function(assert) {
+    await setupContext(context);
+
+    context.owner.rootElement = { bad: 'value' };
+    assert.throws(() => {
+      getRootElement();
+    }, /Application.rootElement must be an element or a selector string/);
+  });
 });


### PR DESCRIPTION
Fixes #403 

I used the same element detection logic that -get-element.js uses.