### PR TITLE
Ensure view is set by default on generated mouse events

### DIFF
--- a/addon-test-support/@ember/test-helpers/dom/fire-event.js
+++ b/addon-test-support/@ember/test-helpers/dom/fire-event.js
@@ -93,7 +93,7 @@ function buildBasicEvent(type, options = {}) {
 // eslint-disable-next-line require-jsdoc
 function buildMouseEvent(type, options = {}) {
   let event;
-  let eventOpts = assign({}, DEFAULT_EVENT_OPTIONS, options);
+  let eventOpts = assign({ view: window }, DEFAULT_EVENT_OPTIONS, options);
   if (MOUSE_EVENT_CONSTRUCTOR) {
     event = new MouseEvent(type, eventOpts);
   } else {

--- a/tests/unit/dom/click-test.js
+++ b/tests/unit/dom/click-test.js
@@ -103,6 +103,19 @@ module('DOM Helper: click', function(hooks) {
 
       assert.verifySteps(['mousedown 13 17 2', 'mouseup 13 17 2', 'click 13 17 2']);
     });
+
+    test('clicking a div has window set as view by default', async function(assert) {
+      element = buildInstrumentedElement('div', ['view']);
+
+      await setupContext(context);
+      await click(element);
+
+      assert.verifySteps([
+        'mousedown [object Window]',
+        'mouseup [object Window]',
+        'click [object Window]',
+      ]);
+    });
   });
 
   module('focusable element types', function() {


### PR DESCRIPTION
This PR adds `window` as default `view` on generated mouse events.

This fixes #426 