### PR TITLE
Import type definitions from `@types/ember__test-helpers`

### DIFF
--- a/addon-test-support/@ember/test-helpers/-utils.ts
+++ b/addon-test-support/@ember/test-helpers/-utils.ts
@@ -78,7 +78,7 @@ export const futureTick = setTimeout;
  @private
  @returns {Promise<void>} Promise which can not be forced to be ran synchronously
 */
-export function nextTickPromise() {
+export function nextTickPromise(): RSVP.Promise<void> {
   // Ember 3.4 removed the auto-run assertion, in 3.4+ we can (and should) avoid the "psuedo promisey" run loop configuration
   // for our `nextTickPromise` implementation. This allows us to have real microtask based next tick timing...
   if (hasEmberVersion(3,4)) {

--- a/addon-test-support/@ember/test-helpers/application.ts
+++ b/addon-test-support/@ember/test-helpers/application.ts
@@ -1,6 +1,8 @@
+import Application from '@ember/application';
+
 import { getResolver, setResolver } from './resolver';
 
-var __application__;
+var __application__: Application;
 
 /**
   Stores the provided application instance so that tests being ran will be aware of the application under test.
@@ -11,11 +13,11 @@ var __application__;
   @public
   @param {Ember.Application} application the application that will be tested
 */
-export function setApplication(application) {
+export function setApplication(application: Application): void {
   __application__ = application;
 
   if (!getResolver()) {
-    let Resolver = application.Resolver;
+    let Resolver = (application as any).Resolver;
     let resolver = Resolver.create({ namespace: application });
 
     setResolver(resolver);
@@ -28,6 +30,6 @@ export function setApplication(application) {
   @public
   @returns {Ember.Application} the previously stored application instance under test
 */
-export function getApplication() {
+export function getApplication(): Application {
   return __application__;
 }

--- a/addon-test-support/@ember/test-helpers/dom/-target.ts
+++ b/addon-test-support/@ember/test-helpers/dom/-target.ts
@@ -1,0 +1,3 @@
+type Target = string | Element;
+
+export default Target;

--- a/addon-test-support/@ember/test-helpers/dom/blur.ts
+++ b/addon-test-support/@ember/test-helpers/dom/blur.ts
@@ -43,7 +43,7 @@ export function __blur__(element) {
   @param {string|Element} [target=document.activeElement] the element or selector to unfocus
   @return {Promise<void>} resolves when settled
 */
-export default function blur(target: Target = document.activeElement!) {
+export default function blur(target: Target = document.activeElement!): Promise<void> {
   return nextTickPromise().then(() => {
     let element = getElement(target);
     if (!element) {

--- a/addon-test-support/@ember/test-helpers/dom/blur.ts
+++ b/addon-test-support/@ember/test-helpers/dom/blur.ts
@@ -3,6 +3,7 @@ import fireEvent from './fire-event';
 import settled from '../settled';
 import isFocusable from './-is-focusable';
 import { nextTickPromise } from '../-utils';
+import Target from './-target';
 
 /**
   @private
@@ -42,7 +43,7 @@ export function __blur__(element) {
   @param {string|Element} [target=document.activeElement] the element or selector to unfocus
   @return {Promise<void>} resolves when settled
 */
-export default function blur(target = document.activeElement) {
+export default function blur(target: Target = document.activeElement!) {
   return nextTickPromise().then(() => {
     let element = getElement(target);
     if (!element) {

--- a/addon-test-support/@ember/test-helpers/dom/click.ts
+++ b/addon-test-support/@ember/test-helpers/dom/click.ts
@@ -54,7 +54,7 @@ export function __click__(element, options) {
   @param {Object} options the options to be merged into the mouse events
   @return {Promise<void>} resolves when settled
 */
-export default function click(target: Target, options = {}) {
+export default function click(target: Target, options: object = {}): Promise<void> {
   return nextTickPromise().then(() => {
     if (!target) {
       throw new Error('Must pass an element or selector to `click`.');

--- a/addon-test-support/@ember/test-helpers/dom/click.ts
+++ b/addon-test-support/@ember/test-helpers/dom/click.ts
@@ -5,6 +5,7 @@ import settled from '../settled';
 import isFocusable from './-is-focusable';
 import { nextTickPromise } from '../-utils';
 import isFormControl from './-is-form-control';
+import Target from './-target';
 
 /**
   @private
@@ -46,14 +47,14 @@ export function __click__(element, options) {
   The exact listing of events that are triggered may change over time as needed
   to continue to emulate how actual browsers handle clicking a given element.
 
-  Use the `options` hash to change the parameters of the MouseEvents. 
+  Use the `options` hash to change the parameters of the MouseEvents.
 
   @public
   @param {string|Element} target the element or selector to click on
   @param {Object} options the options to be merged into the mouse events
   @return {Promise<void>} resolves when settled
 */
-export default function click(target, options = {}) {
+export default function click(target: Target, options = {}) {
   return nextTickPromise().then(() => {
     if (!target) {
       throw new Error('Must pass an element or selector to `click`.');

--- a/addon-test-support/@ember/test-helpers/dom/double-click.ts
+++ b/addon-test-support/@ember/test-helpers/dom/double-click.ts
@@ -65,7 +65,7 @@ export function __doubleClick__(element, options) {
   @param {Object} options the options to be merged into the mouse events
   @return {Promise<void>} resolves when settled
 */
-export default function doubleClick(target: Target, options = {}) {
+export default function doubleClick(target: Target, options: object = {}): Promise<void> {
   return nextTickPromise().then(() => {
     if (!target) {
       throw new Error('Must pass an element or selector to `doubleClick`.');

--- a/addon-test-support/@ember/test-helpers/dom/double-click.ts
+++ b/addon-test-support/@ember/test-helpers/dom/double-click.ts
@@ -4,6 +4,7 @@ import { __focus__ } from './focus';
 import settled from '../settled';
 import isFocusable from './-is-focusable';
 import { nextTickPromise } from '../-utils';
+import Target from './-target';
 
 /**
   @private
@@ -57,14 +58,14 @@ export function __doubleClick__(element, options) {
   The exact listing of events that are triggered may change over time as needed
   to continue to emulate how actual browsers handle clicking a given element.
 
-  Use the `options` hash to change the parameters of the MouseEvents. 
+  Use the `options` hash to change the parameters of the MouseEvents.
 
   @public
   @param {string|Element} target the element or selector to double-click on
   @param {Object} options the options to be merged into the mouse events
   @return {Promise<void>} resolves when settled
 */
-export default function doubleClick(target, options = {}) {
+export default function doubleClick(target: Target, options = {}) {
   return nextTickPromise().then(() => {
     if (!target) {
       throw new Error('Must pass an element or selector to `doubleClick`.');

--- a/addon-test-support/@ember/test-helpers/dom/fill-in.ts
+++ b/addon-test-support/@ember/test-helpers/dom/fill-in.ts
@@ -4,6 +4,7 @@ import { __focus__ } from './focus';
 import settled from '../settled';
 import fireEvent from './fire-event';
 import { nextTickPromise } from '../-utils';
+import Target from './-target';
 
 /**
   Fill the provided text into the `value` property (or set `.innerHTML` when
@@ -15,7 +16,7 @@ import { nextTickPromise } from '../-utils';
   @param {string} text the text to fill into the target element
   @return {Promise<void>} resolves when the application is settled
 */
-export default function fillIn(target: any, text: string): Promise<void> {
+export default function fillIn(target: Target, text: string): Promise<void> {
   return nextTickPromise().then(() => {
     if (!target) {
       throw new Error('Must pass an element or selector to `fillIn`.');

--- a/addon-test-support/@ember/test-helpers/dom/find-all.ts
+++ b/addon-test-support/@ember/test-helpers/dom/find-all.ts
@@ -9,7 +9,7 @@ import toArray from './-to-array';
   @param {string} selector the selector to search for
   @return {Array} array of matched elements
 */
-export default function find(selector) {
+export default function find(selector: string): Element[] {
   if (!selector) {
     throw new Error('Must pass a selector to `findAll`.');
   }

--- a/addon-test-support/@ember/test-helpers/dom/find.ts
+++ b/addon-test-support/@ember/test-helpers/dom/find.ts
@@ -8,7 +8,7 @@ import getElement from './-get-element';
   @param {string} selector the selector to search for
   @return {Element} matched element or null
 */
-export default function find(selector) {
+export default function find(selector: string): Element | null {
   if (!selector) {
     throw new Error('Must pass a selector to `find`.');
   }

--- a/addon-test-support/@ember/test-helpers/dom/focus.ts
+++ b/addon-test-support/@ember/test-helpers/dom/focus.ts
@@ -3,6 +3,7 @@ import fireEvent from './fire-event';
 import settled from '../settled';
 import isFocusable from './-is-focusable';
 import { nextTickPromise } from '../-utils';
+import Target from './-target';
 
 /**
   @private
@@ -45,7 +46,7 @@ export function __focus__(element) {
   @param {string|Element} target the element or selector to focus
   @return {Promise<void>} resolves when the application is settled
 */
-export default function focus(target) {
+export default function focus(target: Target) {
   return nextTickPromise().then(() => {
     if (!target) {
       throw new Error('Must pass an element or selector to `focus`.');

--- a/addon-test-support/@ember/test-helpers/dom/focus.ts
+++ b/addon-test-support/@ember/test-helpers/dom/focus.ts
@@ -46,7 +46,7 @@ export function __focus__(element) {
   @param {string|Element} target the element or selector to focus
   @return {Promise<void>} resolves when the application is settled
 */
-export default function focus(target: Target) {
+export default function focus(target: Target): Promise<void> {
   return nextTickPromise().then(() => {
     if (!target) {
       throw new Error('Must pass an element or selector to `focus`.');

--- a/addon-test-support/@ember/test-helpers/dom/get-root-element.ts
+++ b/addon-test-support/@ember/test-helpers/dom/get-root-element.ts
@@ -6,7 +6,7 @@ import { getContext } from '../setup-context';
   @public
   @returns {Element} the root element
 */
-export default function getRootElement() {
+export default function getRootElement(): Element {
   let context = getContext();
   let owner = context && context.owner;
 
@@ -30,7 +30,7 @@ export default function getRootElement() {
   ) {
     return rootElement;
   } else if (typeof rootElement === 'string') {
-    return document.querySelector(rootElement);
+    return document.querySelector(rootElement)!; // TODO remove "!"
   } else {
     throw new Error('Application.rootElement must be an element or a selector string');
   }

--- a/addon-test-support/@ember/test-helpers/dom/tap.ts
+++ b/addon-test-support/@ember/test-helpers/dom/tap.ts
@@ -3,6 +3,7 @@ import fireEvent from './fire-event';
 import { __click__ } from './click';
 import settled from '../settled';
 import { nextTickPromise } from '../-utils';
+import Target from './-target';
 
 /**
   Taps on the specified target.
@@ -32,14 +33,14 @@ import { nextTickPromise } from '../-utils';
   The exact listing of events that are triggered may change over time as needed
   to continue to emulate how actual browsers handle tapping on a given element.
 
-  Use the `options` hash to change the parameters of the tap events. 
+  Use the `options` hash to change the parameters of the tap events.
 
   @public
   @param {string|Element} target the element or selector to tap on
   @param {Object} options the options to be merged into the touch events
   @return {Promise<void>} resolves when settled
 */
-export default function tap(target, options = {}) {
+export default function tap(target: Target, options = {}) {
   return nextTickPromise().then(() => {
     if (!target) {
       throw new Error('Must pass an element or selector to `tap`.');

--- a/addon-test-support/@ember/test-helpers/dom/tap.ts
+++ b/addon-test-support/@ember/test-helpers/dom/tap.ts
@@ -40,7 +40,7 @@ import Target from './-target';
   @param {Object} options the options to be merged into the touch events
   @return {Promise<void>} resolves when settled
 */
-export default function tap(target: Target, options = {}) {
+export default function tap(target: Target, options: object = {}): Promise<void> {
   return nextTickPromise().then(() => {
     if (!target) {
       throw new Error('Must pass an element or selector to `tap`.');

--- a/addon-test-support/@ember/test-helpers/dom/trigger-event.ts
+++ b/addon-test-support/@ember/test-helpers/dom/trigger-event.ts
@@ -2,6 +2,7 @@ import getElement from './-get-element';
 import fireEvent from './fire-event';
 import settled from '../settled';
 import { nextTickPromise } from '../-utils';
+import Target from './-target';
 
 /**
  * Triggers an event on the specified target.
@@ -24,7 +25,7 @@ import { nextTickPromise } from '../-utils';
  *   [new Blob(['Ember Rules!'])]
  * );
  */
-export default function triggerEvent(target, eventType, options) {
+export default function triggerEvent(target: Target, eventType, options) {
   return nextTickPromise().then(() => {
     if (!target) {
       throw new Error('Must pass an element or selector to `triggerEvent`.');

--- a/addon-test-support/@ember/test-helpers/dom/trigger-event.ts
+++ b/addon-test-support/@ember/test-helpers/dom/trigger-event.ts
@@ -25,7 +25,11 @@ import Target from './-target';
  *   [new Blob(['Ember Rules!'])]
  * );
  */
-export default function triggerEvent(target: Target, eventType, options) {
+export default function triggerEvent(
+  target: Target,
+  eventType: string,
+  options?: object
+): Promise<void> {
   return nextTickPromise().then(() => {
     if (!target) {
       throw new Error('Must pass an element or selector to `triggerEvent`.');

--- a/addon-test-support/@ember/test-helpers/dom/trigger-key-event.ts
+++ b/addon-test-support/@ember/test-helpers/dom/trigger-key-event.ts
@@ -6,7 +6,16 @@ import { KEYBOARD_EVENT_TYPES } from './fire-event';
 import { nextTickPromise, isNumeric } from '../-utils';
 import Target from './-target';
 
-const DEFAULT_MODIFIERS = Object.freeze({
+export type KeyEvent = 'keydown' | 'keyup' | 'keypress';
+
+export interface KeyModifiers {
+  ctrlKey?: boolean;
+  altKey?: boolean;
+  shiftKey?: boolean;
+  metaKey?: boolean;
+}
+
+const DEFAULT_MODIFIERS: KeyModifiers = Object.freeze({
   ctrlKey: false,
   altKey: false,
   shiftKey: false,
@@ -123,7 +132,12 @@ function keyCodeFromKey(key) {
   @param {boolean} [modifiers.metaKey=false] if true the generated event will indicate the meta key was pressed during the key event
   @return {Promise<void>} resolves when the application is settled
 */
-export default function triggerKeyEvent(target: Target, eventType, key, modifiers = DEFAULT_MODIFIERS) {
+export default function triggerKeyEvent(
+  target: Target,
+  eventType: KeyEvent,
+  key: number | string,
+  modifiers: KeyModifiers = DEFAULT_MODIFIERS
+): Promise<void> {
   return nextTickPromise().then(() => {
     if (!target) {
       throw new Error('Must pass an element or selector to `triggerKeyEvent`.');

--- a/addon-test-support/@ember/test-helpers/dom/trigger-key-event.ts
+++ b/addon-test-support/@ember/test-helpers/dom/trigger-key-event.ts
@@ -4,6 +4,7 @@ import fireEvent from './fire-event';
 import settled from '../settled';
 import { KEYBOARD_EVENT_TYPES } from './fire-event';
 import { nextTickPromise, isNumeric } from '../-utils';
+import Target from './-target';
 
 const DEFAULT_MODIFIERS = Object.freeze({
   ctrlKey: false,
@@ -122,7 +123,7 @@ function keyCodeFromKey(key) {
   @param {boolean} [modifiers.metaKey=false] if true the generated event will indicate the meta key was pressed during the key event
   @return {Promise<void>} resolves when the application is settled
 */
-export default function triggerKeyEvent(target, eventType, key, modifiers = DEFAULT_MODIFIERS) {
+export default function triggerKeyEvent(target: Target, eventType, key, modifiers = DEFAULT_MODIFIERS) {
   return nextTickPromise().then(() => {
     if (!target) {
       throw new Error('Must pass an element or selector to `triggerKeyEvent`.');

--- a/addon-test-support/@ember/test-helpers/dom/type-in.ts
+++ b/addon-test-support/@ember/test-helpers/dom/type-in.ts
@@ -5,6 +5,7 @@ import isFormControl from './-is-form-control';
 import { __focus__ } from './focus';
 import { Promise } from 'rsvp';
 import fireEvent from './fire-event';
+import Target from './-target';
 
 /**
  * Mimics character by character entry into the target `input` or `textarea` element.
@@ -23,7 +24,7 @@ import fireEvent from './fire-event';
  * @param {Object} options {delay: x} (default 50) number of milliseconds to wait per keypress
  * @return {Promise<void>} resolves when the application is settled
  */
-export default function typeIn(target, text, options = { delay: 50 }) {
+export default function typeIn(target: Target, text, options = { delay: 50 }) {
   return nextTickPromise().then(() => {
     if (!target) {
       throw new Error('Must pass an element or selector to `typeIn`.');

--- a/addon-test-support/@ember/test-helpers/dom/type-in.ts
+++ b/addon-test-support/@ember/test-helpers/dom/type-in.ts
@@ -24,7 +24,7 @@ import Target from './-target';
  * @param {Object} options {delay: x} (default 50) number of milliseconds to wait per keypress
  * @return {Promise<void>} resolves when the application is settled
  */
-export default function typeIn(target: Target, text, options = { delay: 50 }) {
+export default function typeIn(target: Target, text, options = { delay: 50 }): Promise<void> {
   return nextTickPromise().then(() => {
     if (!target) {
       throw new Error('Must pass an element or selector to `typeIn`.');

--- a/addon-test-support/@ember/test-helpers/dom/wait-for.ts
+++ b/addon-test-support/@ember/test-helpers/dom/wait-for.ts
@@ -18,7 +18,7 @@ import { nextTickPromise } from '../-utils';
 export default function waitFor(
   selector,
   { timeout = 1000, count = null, timeoutMessage = '' } = {}
-) {
+): Promise<Element | Element[]> {
   return nextTickPromise().then(() => {
     if (!selector) {
       throw new Error('Must pass a selector to `waitFor`.');
@@ -27,7 +27,7 @@ export default function waitFor(
       timeoutMessage = `waitFor timed out waiting for selector "${selector}"`;
     }
 
-    let callback;
+    let callback: () => Element | Element[] | void;
     if (count !== null) {
       callback = () => {
         let elements = getElements(selector);

--- a/addon-test-support/@ember/test-helpers/resolver.ts
+++ b/addon-test-support/@ember/test-helpers/resolver.ts
@@ -1,4 +1,6 @@
-var __resolver__;
+import Resolver from '@ember/application/resolver';
+
+var __resolver__: Resolver;
 
 /**
   Stores the provided resolver instance so that tests being ran can resolve
@@ -9,7 +11,7 @@ var __resolver__;
   @public
   @param {Ember.Resolver} resolver the resolver to be used for testing
 */
-export function setResolver(resolver) {
+export function setResolver(resolver: Resolver): void {
   __resolver__ = resolver;
 }
 
@@ -19,6 +21,6 @@ export function setResolver(resolver) {
   @public
   @returns {Ember.Resolver} the previously stored resolver
 */
-export function getResolver() {
+export function getResolver(): Resolver {
   return __resolver__;
 }

--- a/addon-test-support/@ember/test-helpers/settled.ts
+++ b/addon-test-support/@ember/test-helpers/settled.ts
@@ -139,6 +139,14 @@ function checkWaiters() {
   return false;
 }
 
+export interface SettledState {
+  hasRunLoop: boolean;
+  hasPendingTimers: boolean;
+  hasPendingWaiters: boolean;
+  hasPendingRequests: boolean;
+  pendingRequestCount: number;
+}
+
 /**
   Check various settledness metrics, and return an object with the following properties:
 
@@ -158,7 +166,7 @@ function checkWaiters() {
   @public
   @returns {Object} object with properties for each of the metrics used to determine settledness
 */
-export function getSettledState() {
+export function getSettledState(): SettledState {
   let pendingRequestCount = pendingRequests();
 
   return {
@@ -180,7 +188,7 @@ export function getSettledState() {
   @public
   @returns {boolean} `true` if settled, `false` otherwise
 */
-export function isSettled() {
+export function isSettled(): boolean {
   let { hasPendingTimers, hasRunLoop, hasPendingRequests, hasPendingWaiters } = getSettledState();
 
   if (hasPendingTimers || hasRunLoop || hasPendingRequests || hasPendingWaiters) {

--- a/addon-test-support/@ember/test-helpers/setup-application-context.ts
+++ b/addon-test-support/@ember/test-helpers/setup-application-context.ts
@@ -9,9 +9,10 @@ import settled from './settled';
   Navigate the application to the provided URL.
 
   @public
+  @param {string} url The URL to visit (e.g. `/posts`)
   @returns {Promise<void>} resolves when settled
 */
-export function visit() {
+export function visit(url: string): Promise<void> {
   let context = getContext();
   let { owner } = context;
 
@@ -33,7 +34,7 @@ export function visit() {
   @public
   @returns {string} the currently active route name
 */
-export function currentRouteName() {
+export function currentRouteName(): string {
   let { owner } = getContext();
   let router = owner.lookup('router:main');
   return get(router, 'currentRouteName');
@@ -45,7 +46,7 @@ const HAS_CURRENT_URL_ON_ROUTER = hasEmberVersion(2, 13);
   @public
   @returns {string} the applications current url
 */
-export function currentURL() {
+export function currentURL(): string {
   let { owner } = getContext();
   let router = owner.lookup('router:main');
 
@@ -69,6 +70,8 @@ export function currentURL() {
   @param {Object} context the context to setup
   @returns {Promise<Object>} resolves with the context that was setup
 */
-export default function setupApplicationContext() {
+export default function setupApplicationContext<Context extends object>(
+  context: Context
+): Promise<void> {
   return nextTickPromise();
 }

--- a/addon-test-support/@ember/test-helpers/setup-rendering-context.ts
+++ b/addon-test-support/@ember/test-helpers/setup-rendering-context.ts
@@ -6,7 +6,7 @@ import global from './global';
 import { getContext } from './setup-context';
 import { nextTickPromise } from './-utils';
 import settled from './settled';
-import hbs from 'htmlbars-inline-precompile';
+import hbs, { TemplateFactory } from 'htmlbars-inline-precompile';
 import getRootElement from './dom/get-root-element';
 
 export const RENDERING_CLEANUP = Object.create(null);
@@ -49,7 +49,7 @@ let templateId = 0;
   @param {CompiledTemplate} template the template to render
   @returns {Promise<void>} resolves when settled
 */
-export function render(template) {
+export function render(template: TemplateFactory): Promise<void> {
   let context = getContext();
 
   if (!template) {
@@ -112,7 +112,7 @@ export function render(template) {
   @public
   @returns {Promise<void>} resolves when settled
 */
-export function clearRender() {
+export function clearRender(): Promise<void> {
   let context = getContext();
 
   if (!context || typeof context.clearRender !== 'function') {
@@ -143,7 +143,9 @@ export function clearRender() {
   @param {Object} context the context to setup for rendering
   @returns {Promise<Object>} resolves with the context that was setup
 */
-export default function setupRenderingContext(context) {
+export default function setupRenderingContext<Context extends { owner: any }>(
+  context: Context
+): Promise<Context> {
   let contextGuid = guidFor(context);
   RENDERING_CLEANUP[contextGuid] = [];
 
@@ -182,7 +184,8 @@ export default function setupRenderingContext(context) {
       // `Ember._ContainerProxyMixin` and `Ember._RegistryProxyMixin` in this scenario we need to
       // manually start the event dispatcher.
       if (owner._emberTestHelpersMockOwner) {
-        let dispatcher = owner.lookup('event_dispatcher:main') || (Ember.EventDispatcher as any).create();
+        let dispatcher =
+          owner.lookup('event_dispatcher:main') || (Ember.EventDispatcher as any).create();
         dispatcher.setup({}, '#ember-testing');
       }
 

--- a/addon-test-support/@ember/test-helpers/teardown-application-context.ts
+++ b/addon-test-support/@ember/test-helpers/teardown-application-context.ts
@@ -7,6 +7,6 @@ import settled from './settled';
   @param {Object} context the context to setup
   @returns {Promise<void>} resolves when settled
 */
-export default function() {
+export default function(context: object): Promise<void> {
   return settled();
 }

--- a/addon-test-support/@ember/test-helpers/teardown-context.ts
+++ b/addon-test-support/@ember/test-helpers/teardown-context.ts
@@ -19,7 +19,9 @@ import Ember from 'ember';
   @param {Object} context the context to setup
   @returns {Promise<void>} resolves when settled
 */
-export default function teardownContext(context) {
+export default function teardownContext<Context extends { owner: any }>(
+  context: Context
+): Promise<void> {
   return nextTickPromise()
     .then(() => {
       let { owner } = context;

--- a/addon-test-support/@ember/test-helpers/teardown-rendering-context.ts
+++ b/addon-test-support/@ember/test-helpers/teardown-rendering-context.ts
@@ -15,7 +15,7 @@ import settled from './settled';
   @param {Object} context the context to setup
   @returns {Promise<void>} resolves when settled
 */
-export default function teardownRenderingContext(context) {
+export default function teardownRenderingContext(context: object): Promise<void> {
   return nextTickPromise().then(() => {
     let contextGuid = guidFor(context);
 

--- a/addon-test-support/@ember/test-helpers/wait-until.ts
+++ b/addon-test-support/@ember/test-helpers/wait-until.ts
@@ -3,6 +3,11 @@ import { futureTick, _Promise as Promise } from './-utils';
 const TIMEOUTS = [0, 1, 2, 5, 7];
 const MAX_TIMEOUT = 10;
 
+export interface Options {
+  timeout?: number;
+  timeoutMessage?: string;
+}
+
 /**
   Wait for the provided callback to return a truthy value.
 
@@ -16,8 +21,11 @@ const MAX_TIMEOUT = 10;
   @param {string} [options.timeoutMessage='waitUntil timed out'] the message to use in the reject on timeout
   @returns {Promise} resolves with the callback value when it returns a truthy value
 */
-export default function waitUntil(callback, options: any = {}) {
-  let timeout = 'timeout' in options ? options.timeout : 1000;
+export default function waitUntil<T>(
+  callback: () => T | void | false | null | undefined | '',
+  options: Options = {}
+): Promise<T> {
+  let timeout = 'timeout' in options ? (options.timeout as number) : 1000;
   let timeoutMessage = 'timeoutMessage' in options ? options.timeoutMessage : 'waitUntil timed out';
 
   // creating this error eagerly so it has the proper invocation stack


### PR DESCRIPTION
This PR imports the type definitions from the `@types/ember__test-helpers` npm package, and applies them to our own TypeScript files.

Further cleanup of those types will happen in follow-up PRs.