### PR TITLE
 tests: Adjust import paths to use `@ember/test-helpers` 

### DIFF
--- a/tests/helpers/resolver.js
+++ b/tests/helpers/resolver.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 import { dasherize } from '@ember/string';
 import { assign } from '@ember/polyfills';
 import { setRegistry } from '../../resolver';
-import { setResolver, setApplication } from 'ember-test-helpers';
+import { setResolver, setApplication } from '@ember/test-helpers';
 import require from 'require';
 import App from '../../app';
 import config from '../../config/environment';

--- a/tests/integration/settled-test.js
+++ b/tests/integration/settled-test.js
@@ -7,12 +7,12 @@ import {
   setupRenderingContext,
   teardownContext,
   teardownRenderingContext,
-} from 'ember-test-helpers';
-import hasEmberVersion from 'ember-test-helpers/has-ember-version';
+  click,
+} from '@ember/test-helpers';
+import hasEmberVersion from '@ember/test-helpers/has-ember-version';
 import { module, test } from 'qunit';
 import hbs from 'htmlbars-inline-precompile';
 import Pretender from 'pretender';
-import { click } from '@ember/test-helpers';
 import ajax from '../helpers/ajax';
 
 const TestComponent1 = Component.extend({

--- a/tests/integration/setup-rendering-context-test.js
+++ b/tests/integration/setup-rendering-context-test.js
@@ -12,7 +12,7 @@ import {
   click,
 } from '@ember/test-helpers';
 
-import hasEmberVersion from 'ember-test-helpers/has-ember-version';
+import hasEmberVersion from '@ember/test-helpers/has-ember-version';
 import { setResolverRegistry } from '../helpers/resolver';
 import hbs from 'htmlbars-inline-precompile';
 import { defer } from 'rsvp';

--- a/tests/unit/dom/blur-test.js
+++ b/tests/unit/dom/blur-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { focus, blur, setupContext, teardownContext } from '@ember/test-helpers';
 import { buildInstrumentedElement } from '../../helpers/events';
 import { isIE11, isEdge } from '../../helpers/browser-detect';
-import hasEmberVersion from 'ember-test-helpers/has-ember-version';
+import hasEmberVersion from '@ember/test-helpers/has-ember-version';
 
 let focusSteps = ['focus', 'focusin'];
 let blurSteps = ['blur', 'focusout'];

--- a/tests/unit/dom/click-test.js
+++ b/tests/unit/dom/click-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { click, setupContext, teardownContext } from '@ember/test-helpers';
 import { buildInstrumentedElement, instrumentElement, insertElement } from '../../helpers/events';
 import { isIE11 } from '../../helpers/browser-detect';
-import hasEmberVersion from 'ember-test-helpers/has-ember-version';
+import hasEmberVersion from '@ember/test-helpers/has-ember-version';
 
 module('DOM Helper: click', function(hooks) {
   if (!hasEmberVersion(2, 4)) {

--- a/tests/unit/dom/double-click-test.js
+++ b/tests/unit/dom/double-click-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { doubleClick, setupContext, teardownContext } from '@ember/test-helpers';
 import { buildInstrumentedElement, instrumentElement, insertElement } from '../../helpers/events';
 import { isIE11 } from '../../helpers/browser-detect';
-import hasEmberVersion from 'ember-test-helpers/has-ember-version';
+import hasEmberVersion from '@ember/test-helpers/has-ember-version';
 
 module('DOM Helper: doubleClick', function(hooks) {
   if (!hasEmberVersion(2, 4)) {

--- a/tests/unit/dom/fill-in-test.js
+++ b/tests/unit/dom/fill-in-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { fillIn, setupContext, teardownContext } from '@ember/test-helpers';
 import { buildInstrumentedElement } from '../../helpers/events';
 import { isIE11 } from '../../helpers/browser-detect';
-import hasEmberVersion from 'ember-test-helpers/has-ember-version';
+import hasEmberVersion from '@ember/test-helpers/has-ember-version';
 
 let clickSteps = ['focus', 'focusin', 'input', 'change'];
 

--- a/tests/unit/dom/find-all-test.js
+++ b/tests/unit/dom/find-all-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { findAll, setupContext, teardownContext } from '@ember/test-helpers';
-import hasEmberVersion from 'ember-test-helpers/has-ember-version';
+import hasEmberVersion from '@ember/test-helpers/has-ember-version';
 
 module('DOM Helper: findAll', function(hooks) {
   if (!hasEmberVersion(2, 4)) {

--- a/tests/unit/dom/find-test.js
+++ b/tests/unit/dom/find-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { find, setupContext, teardownContext } from '@ember/test-helpers';
-import hasEmberVersion from 'ember-test-helpers/has-ember-version';
+import hasEmberVersion from '@ember/test-helpers/has-ember-version';
 
 module('DOM Helper: find', function(hooks) {
   if (!hasEmberVersion(2, 4)) {

--- a/tests/unit/dom/focus-test.js
+++ b/tests/unit/dom/focus-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { focus, setupContext, teardownContext } from '@ember/test-helpers';
 import { buildInstrumentedElement } from '../../helpers/events';
 import { isIE11 } from '../../helpers/browser-detect';
-import hasEmberVersion from 'ember-test-helpers/has-ember-version';
+import hasEmberVersion from '@ember/test-helpers/has-ember-version';
 
 let focusSteps = ['focus', 'focusin'];
 

--- a/tests/unit/dom/get-root-element-test.js
+++ b/tests/unit/dom/get-root-element-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { getRootElement, setupContext, teardownContext } from '@ember/test-helpers';
-import hasEmberVersion from 'ember-test-helpers/has-ember-version';
+import hasEmberVersion from '@ember/test-helpers/has-ember-version';
 
 module('DOM Helper: getRootElement', function(hooks) {
   if (!hasEmberVersion(2, 4)) {

--- a/tests/unit/dom/select-files-test.js
+++ b/tests/unit/dom/select-files-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { triggerEvent, setupContext, teardownContext } from '@ember/test-helpers';
 import { buildInstrumentedElement } from '../../helpers/events';
-import hasEmberVersion from 'ember-test-helpers/has-ember-version';
+import hasEmberVersion from '@ember/test-helpers/has-ember-version';
 
 module('DOM Helper: selectFiles', function(hooks) {
   if (!hasEmberVersion(2, 4)) {

--- a/tests/unit/dom/tap-test.js
+++ b/tests/unit/dom/tap-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { tap, setupContext, teardownContext } from '@ember/test-helpers';
 import { buildInstrumentedElement } from '../../helpers/events';
 import { isIE11 } from '../../helpers/browser-detect';
-import hasEmberVersion from 'ember-test-helpers/has-ember-version';
+import hasEmberVersion from '@ember/test-helpers/has-ember-version';
 
 module('DOM Helper: tap', function(hooks) {
   if (!hasEmberVersion(2, 4)) {

--- a/tests/unit/dom/trigger-event-test.js
+++ b/tests/unit/dom/trigger-event-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { triggerEvent, setupContext, teardownContext } from '@ember/test-helpers';
 import { buildInstrumentedElement } from '../../helpers/events';
-import hasEmberVersion from 'ember-test-helpers/has-ember-version';
+import hasEmberVersion from '@ember/test-helpers/has-ember-version';
 
 module('DOM Helper: triggerEvent', function(hooks) {
   if (!hasEmberVersion(2, 4)) {

--- a/tests/unit/dom/trigger-key-event-test.js
+++ b/tests/unit/dom/trigger-key-event-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { triggerKeyEvent, setupContext, teardownContext } from '@ember/test-helpers';
 import { buildInstrumentedElement, insertElement } from '../../helpers/events';
-import hasEmberVersion from 'ember-test-helpers/has-ember-version';
+import hasEmberVersion from '@ember/test-helpers/has-ember-version';
 
 module('DOM Helper: triggerKeyEvent', function(hooks) {
   if (!hasEmberVersion(2, 4)) {

--- a/tests/unit/dom/type-in-test.js
+++ b/tests/unit/dom/type-in-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { typeIn, setupContext, teardownContext } from '@ember/test-helpers';
 import { buildInstrumentedElement } from '../../helpers/events';
 import { isIE11 } from '../../helpers/browser-detect';
-import hasEmberVersion from 'ember-test-helpers/has-ember-version';
+import hasEmberVersion from '@ember/test-helpers/has-ember-version';
 
 /*
  * Event order based on https://jsbin.com/zitazuxabe/edit?html,js,console,output

--- a/tests/unit/dom/wait-for-test.js
+++ b/tests/unit/dom/wait-for-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { waitFor, setupContext, teardownContext } from '@ember/test-helpers';
-import hasEmberVersion from 'ember-test-helpers/has-ember-version';
+import hasEmberVersion from '@ember/test-helpers/has-ember-version';
 
 module('DOM Helper: waitFor', function(hooks) {
   if (!hasEmberVersion(2, 4)) {

--- a/tests/unit/settled-test.js
+++ b/tests/unit/settled-test.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 import { module, test } from 'qunit';
-import { isSettled, getSettledState } from 'ember-test-helpers';
-import hasEmberVersion from 'ember-test-helpers/has-ember-version';
+import { isSettled, getSettledState } from '@ember/test-helpers';
+import hasEmberVersion from '@ember/test-helpers/has-ember-version';
 import { _setupAJAXHooks, _teardownAJAXHooks } from '@ember/test-helpers/settled';
 import { next, later, run, schedule } from '@ember/runloop';
 import Pretender from 'pretender';

--- a/tests/unit/setup-application-context-test.js
+++ b/tests/unit/setup-application-context-test.js
@@ -13,7 +13,7 @@ import {
   currentRouteName,
   currentURL,
 } from '@ember/test-helpers';
-import hasEmberVersion from 'ember-test-helpers/has-ember-version';
+import hasEmberVersion from '@ember/test-helpers/has-ember-version';
 import { setResolverRegistry, application } from '../helpers/resolver';
 import hbs from 'htmlbars-inline-precompile';
 

--- a/tests/unit/setup-context-test.js
+++ b/tests/unit/setup-context-test.js
@@ -8,8 +8,8 @@ import {
   resumeTest,
   setApplication,
   setResolver,
-} from 'ember-test-helpers';
-import hasEmberVersion from 'ember-test-helpers/has-ember-version';
+} from '@ember/test-helpers';
+import hasEmberVersion from '@ember/test-helpers/has-ember-version';
 import {
   setResolverRegistry,
   createCustomResolver,

--- a/tests/unit/setup-rendering-context-test.js
+++ b/tests/unit/setup-rendering-context-test.js
@@ -13,11 +13,14 @@ import {
   clearRender,
   setApplication,
   setResolver,
-} from 'ember-test-helpers';
-import hasEmberVersion from 'ember-test-helpers/has-ember-version';
+  triggerEvent,
+  focus,
+  blur,
+  click,
+} from '@ember/test-helpers';
+import hasEmberVersion from '@ember/test-helpers/has-ember-version';
 import hasjQuery from '../helpers/has-jquery';
 import { setResolverRegistry, application, resolver } from '../helpers/resolver';
-import { triggerEvent, focus, blur, click } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 module('setupRenderingContext', function(hooks) {

--- a/tests/unit/teardown-context-test.js
+++ b/tests/unit/teardown-context-test.js
@@ -1,9 +1,14 @@
 import { module, test } from 'qunit';
 import Service from '@ember/service';
-import { isSettled, getSettledState } from '@ember/test-helpers';
-import { getContext, setupContext, teardownContext } from 'ember-test-helpers';
+import {
+  getContext,
+  setupContext,
+  teardownContext,
+  isSettled,
+  getSettledState,
+} from '@ember/test-helpers';
 import { setResolverRegistry } from '../helpers/resolver';
-import hasEmberVersion from 'ember-test-helpers/has-ember-version';
+import hasEmberVersion from '@ember/test-helpers/has-ember-version';
 import Ember from 'ember';
 import hasjQuery from '../helpers/has-jquery';
 import ajax from '../helpers/ajax';

--- a/tests/unit/teardown-rendering-context-test.js
+++ b/tests/unit/teardown-rendering-context-test.js
@@ -7,7 +7,7 @@ import {
 } from 'ember-test-helpers';
 import hasEmberVersion from 'ember-test-helpers/has-ember-version';
 
-module('setupRenderingContext', function(hooks) {
+module('teardownRenderingContext', function(hooks) {
   if (!hasEmberVersion(2, 4)) {
     return;
   }

--- a/tests/unit/teardown-rendering-context-test.js
+++ b/tests/unit/teardown-rendering-context-test.js
@@ -4,8 +4,8 @@ import {
   setupRenderingContext,
   teardownContext,
   teardownRenderingContext,
-} from 'ember-test-helpers';
-import hasEmberVersion from 'ember-test-helpers/has-ember-version';
+} from '@ember/test-helpers';
+import hasEmberVersion from '@ember/test-helpers/has-ember-version';
 
 module('teardownRenderingContext', function(hooks) {
   if (!hasEmberVersion(2, 4)) {


### PR DESCRIPTION
... at least for those tests that use the new APIs