### PR TITLE
Add *.ts to `.npmignore`.

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -34,3 +34,9 @@ yarn.lock
 bower.json.ember-try
 package.json.ember-try
 /config/ember-try.js
+
+# typescript
+#
+# avoid publishing .d.ts or .ts files
+# until they have become enforced "public" APIs
+*.ts


### PR DESCRIPTION
We fully intend to publish official types support, however we need a better plan on _how_ to do things. Some specific issues are:

* How do we ensure we don't break the types accidentally?
* Since `typescript` itself does not maintain compatibility across versions, how do we ensure the `.d.ts` files that we publish will not become incompatible?
* Do we need an RFC to add this as new public API?