### PR TITLE
Ensure typeIn has correct key option

### DIFF
--- a/addon-test-support/@ember/test-helpers/dom/type-in.ts
+++ b/addon-test-support/@ember/test-helpers/dom/type-in.ts
@@ -75,6 +75,7 @@ function keyEntry(element: FormControl, character: string): () => void {
     bubbles: true,
     cancellable: true,
     charCode,
+    key: character,
   };
 
   const keyEvents = {

--- a/tests/unit/dom/type-in-test.js
+++ b/tests/unit/dom/type-in-test.js
@@ -78,10 +78,11 @@ module('DOM Helper: typeIn', function(hooks) {
   });
 
   test('it triggers key events with correct arguments', async function(assert) {
-    element = buildInstrumentedElement('input', ['key', 'charCode']);
-    await typeIn(element, 'foo');
+    element = buildInstrumentedElement('input', ['key', 'shiftKey']);
+    await typeIn(element, 'F o');
 
-    let chars = ['f', 'o', 'o'];
+    let chars = ['F', ' ', 'o'];
+    let shiftKeys = [true, false, false];
     let expectedEventsWithArguments = expectedEvents.map(eventName => {
       // Only key events get the key arguments
       if (!['keydown', 'keypress', 'keyup'].includes(eventName)) {
@@ -89,8 +90,9 @@ module('DOM Helper: typeIn', function(hooks) {
       }
       // After each keyup, the next character comes up
       let char = eventName === 'keyup' ? chars.shift() : chars[0];
+      let shiftKey = eventName === 'keyup' ? shiftKeys.shift() : shiftKeys[0];
 
-      return `${eventName} ${char} ${char.charCodeAt()}`;
+      return `${eventName} ${char.toUpperCase()} ${shiftKey}`;
     });
 
     assert.verifySteps(expectedEventsWithArguments);

--- a/tests/unit/dom/type-in-test.js
+++ b/tests/unit/dom/type-in-test.js
@@ -77,6 +77,25 @@ module('DOM Helper: typeIn', function(hooks) {
     assert.equal(element.value, 'foo');
   });
 
+  test('it triggers key events with correct arguments', async function(assert) {
+    element = buildInstrumentedElement('input', ['key', 'charCode']);
+    await typeIn(element, 'foo');
+
+    let chars = ['f', 'o', 'o'];
+    let expectedEventsWithArguments = expectedEvents.map(eventName => {
+      // Only key events get the key arguments
+      if (!['keydown', 'keypress', 'keyup'].includes(eventName)) {
+        return `${eventName} undefined undefined`;
+      }
+      // After each keyup, the next character comes up
+      let char = eventName === 'keyup' ? chars.shift() : chars[0];
+
+      return `${eventName} ${char} ${char.charCodeAt()}`;
+    });
+
+    assert.verifySteps(expectedEventsWithArguments);
+  });
+
   test('filling in an input with a delay', async function(assert) {
     element = buildInstrumentedElement('input');
     await typeIn(element, 'foo', { delay: 150 });


### PR DESCRIPTION
Currently, the `typeIn()` helper will only set the `charCode` option of the `KeyboardEvent`. This PR also adds the correct `key` option.