### PR TITLE
Extract Prettier configuration to .prettierrc.js file.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,18 +11,11 @@ module.exports = {
     browser: true,
   },
   rules: {
-    'prettier/prettier': [
-      'error',
-      {
-        singleQuote: true,
-        trailingComma: 'es5',
-        printWidth: 100,
-      },
-    ],
+    'prettier/prettier': 'error',
   },
   overrides: [
     {
-      files: ['.eslintrc.js', 'index.js', 'config/ember-try.js', 'scripts/**'],
+      files: ['.eslintrc.js', '.prettierrc.js', 'index.js', 'config/ember-try.js', 'scripts/**'],
       excludedFiles: ['addon-test-support/**', 'tests/**'],
       parserOptions: {
         ecmaVersion: 2015,

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@
 /npm-debug.log*
 /testem.log
 /yarn-error.log
+/.eslintcache
 
 # ember-try
 /.node_modules.ember-try/

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,5 @@
+module.exports = {
+  singleQuote: true,
+  trailingComma: 'es5',
+  printWidth: 100,
+};


### PR DESCRIPTION
* Extract prettier config to stand alone `.prettierrc.js` file (allows other tooling to leverage the same config).
* Add `.eslintcache` to `.gitignore` (we started caching in `yarn lint` but forgot to add this to `.gitignore`)