### PR TITLE
Allow ember-cli-htmlbars-inline-precompile 2.x and 1.x

### DIFF
--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -28,6 +28,9 @@ module.exports = function() {
               'ember-fetch': null,
               'ember-data': '~3.1.0',
             },
+            dependencies: {
+              'ember-cli-htmlbars-inline-precompile': '^1.0.5',
+            },
           },
         },
         {
@@ -45,6 +48,9 @@ module.exports = function() {
               'ember-source': null,
               'ember-fetch': null,
             },
+            dependencies: {
+              'ember-cli-htmlbars-inline-precompile': '^1.0.5',
+            },
           },
         },
         {
@@ -61,6 +67,9 @@ module.exports = function() {
             devDependencies: {
               'ember-source': null,
               'ember-fetch': null,
+            },
+            dependencies: {
+              'ember-cli-htmlbars-inline-precompile': '^1.0.5',
             },
           },
         },

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "broccoli-funnel": "^2.0.1",
     "ember-assign-polyfill": "^2.5.0",
     "ember-cli-babel": "^7.1.3",
-    "ember-cli-htmlbars-inline-precompile": "^1.0.5"
+    "ember-cli-htmlbars-inline-precompile": "^2.0.0 || ^1.0.5"
   },
   "devDependencies": {
     "@ember/optional-features": "^0.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1387,10 +1387,10 @@ babel-plugin-filter-imports@^0.3.1:
   resolved "https://registry.yarnpkg.com/babel-plugin-filter-imports/-/babel-plugin-filter-imports-0.3.1.tgz#e7859b56886b175dd2616425d277b219e209ea8b"
   integrity sha1-54WbVohrF13SYWQl0neyGeIJ6os=
 
-babel-plugin-htmlbars-inline-precompile@^0.2.5:
-  version "0.2.6"
-  resolved "https://registry.yarnpkg.com/babel-plugin-htmlbars-inline-precompile/-/babel-plugin-htmlbars-inline-precompile-0.2.6.tgz#c00b8a3f4b32ca04bf0f0d5169fcef3b5a66d69d"
-  integrity sha512-H4H75TKGUFij8ukwEYWEERAgrUf16R8NSK1uDPe3QwxT8mnE1K8+/s6DVjUqbM5Pv6lSIcE4XufXdlSX+DTB6g==
+babel-plugin-htmlbars-inline-precompile@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-htmlbars-inline-precompile/-/babel-plugin-htmlbars-inline-precompile-1.0.0.tgz#a9d2f6eaad8a3f3d361602de593a8cbef8179c22"
+  integrity sha512-4jvKEHR1bAX03hBDZ94IXsYCj3bwk9vYsn6ux6JZNL2U5pvzCWjqyrGahfsGNrhERyxw8IqcirOi9Q6WCo3dkQ==
 
 babel-plugin-module-resolver@^3.1.1:
   version "3.1.1"
@@ -3704,12 +3704,12 @@ ember-cli-get-component-path-option@^1.0.0:
   resolved "https://registry.yarnpkg.com/ember-cli-get-component-path-option/-/ember-cli-get-component-path-option-1.0.0.tgz#0d7b595559e2f9050abed804f1d8eff1b08bc771"
   integrity sha1-DXtZVVni+QUKvtgE8djv8bCLx3E=
 
-ember-cli-htmlbars-inline-precompile@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/ember-cli-htmlbars-inline-precompile/-/ember-cli-htmlbars-inline-precompile-1.0.5.tgz#312e050c9e3dd301c55fb399fd706296cd0b1d6a"
-  integrity sha512-/CNEqPxroIcbY6qejrt704ZaghHLCntZKYLizFfJ2esirXoJx6fuYKBY1YyJ8GOgjfbHHKjBZuK4vFFJpkGqkQ==
+"ember-cli-htmlbars-inline-precompile@^2.0.0 || ^1.0.5":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ember-cli-htmlbars-inline-precompile/-/ember-cli-htmlbars-inline-precompile-2.0.0.tgz#8cbc941370ac6e728ae3d49c4164b3c7131d6118"
+  integrity sha512-oqqmT31ZG+md5UgCsumFulGXZvC3SbHnhLZ24uc5vKQuzA1c5cZmbOxb+1CnqLIovPCbcJWE3pL9kUMHiBh5oQ==
   dependencies:
-    babel-plugin-htmlbars-inline-precompile "^0.2.5"
+    babel-plugin-htmlbars-inline-precompile "^1.0.0"
     ember-cli-version-checker "^2.1.2"
     hash-for-dep "^1.2.3"
     heimdalljs-logger "^0.1.9"


### PR DESCRIPTION
See #468 

This PR allows ember-cli-htmlbars-inline-precompile 2.x as well as 1.x, to continue supporting Ember <= 2.12.