### PR TITLE
Wait for pending route transitions as part of settledness check

### DIFF
--- a/addon-test-support/@ember/test-helpers/settled.ts
+++ b/addon-test-support/@ember/test-helpers/settled.ts
@@ -167,6 +167,9 @@ export interface SettledState {
   - `hasPendingRequests` - Checks if there are pending AJAX requests (based on
     `ajaxSend` / `ajaxComplete` events triggered by `jQuery.ajax`). If there
     are pending requests, this will be `true`, otherwise `false`.
+  - `hasPendingTransitions` - Checks if there are pending route transitions. If the
+    router has not been instantiated / setup for the test yet this will return `null`,
+    if there are pending transitions, this will be `true`, otherwise `false`.
   - `pendingRequestCount` - The count of pending AJAX requests.
 
   @public

--- a/addon-test-support/@ember/test-helpers/settled.ts
+++ b/addon-test-support/@ember/test-helpers/settled.ts
@@ -4,7 +4,7 @@ import jQuery from 'jquery';
 
 import Ember from 'ember';
 
-import { getContext } from './setup-context'
+import { getContext } from './setup-context';
 import { nextTick } from './-utils';
 import waitUntil from './wait-until';
 
@@ -213,9 +213,21 @@ export function getSettledState(): SettledState {
   @returns {boolean} `true` if settled, `false` otherwise
 */
 export function isSettled(): boolean {
-  let { hasPendingTimers, hasRunLoop, hasPendingRequests, hasPendingWaiters, hasPendingTransitions } = getSettledState();
+  let {
+    hasPendingTimers,
+    hasRunLoop,
+    hasPendingRequests,
+    hasPendingWaiters,
+    hasPendingTransitions,
+  } = getSettledState();
 
-  if (hasPendingTimers || hasRunLoop || hasPendingRequests || hasPendingWaiters || hasPendingTransitions) {
+  if (
+    hasPendingTimers ||
+    hasRunLoop ||
+    hasPendingRequests ||
+    hasPendingWaiters ||
+    hasPendingTransitions
+  ) {
     return false;
   }
 

--- a/addon-test-support/@ember/test-helpers/settled.ts
+++ b/addon-test-support/@ember/test-helpers/settled.ts
@@ -4,9 +4,9 @@ import jQuery from 'jquery';
 
 import Ember from 'ember';
 
-import { getContext } from './setup-context';
 import { nextTick } from './-utils';
 import waitUntil from './wait-until';
+import { hasPendingTransitions } from './setup-application-context';
 
 // Ember internally tracks AJAX requests in the same way that we do here for
 // legacy style "acceptance" tests using the `ember-testing.js` asset provided
@@ -41,23 +41,6 @@ function pendingRequests() {
   let internalRequestsPending = _internalPendingRequests();
 
   return localRequestsPending + internalRequestsPending;
-}
-
-/**
-  @private
-  @returns {boolean} if there are any pending router transitions
-*/
-function hasPendingTransitions() {
-  const context = getContext();
-  const owner = context && context.owner;
-
-  if (!owner) {
-    return false;
-  }
-
-  const router = owner.lookup('router:main');
-  const isLoading = router._routerMicrolib && !!router._routerMicrolib.activeTransition;
-  return isLoading;
 }
 
 /**
@@ -166,7 +149,7 @@ export interface SettledState {
   hasPendingTimers: boolean;
   hasPendingWaiters: boolean;
   hasPendingRequests: boolean;
-  hasPendingTransitions: boolean;
+  hasPendingTransitions: boolean | null;
   pendingRequestCount: number;
 }
 

--- a/addon-test-support/@ember/test-helpers/setup-application-context.ts
+++ b/addon-test-support/@ember/test-helpers/setup-application-context.ts
@@ -9,9 +9,59 @@ export interface ApplicationTestContext extends TestContext {
   element?: Element | null;
 }
 
+const CAN_USE_ROUTER_EVENTS = hasEmberVersion(3, 6);
+let routerTransitionsPending = false;
+const ROUTER = new WeakMap();
+
 // eslint-disable-next-line require-jsdoc
 export function isApplicationTestContext(context: BaseContext): context is ApplicationTestContext {
   return isTestContext(context);
+}
+
+/**
+  Resets the flag determining if transitions are pending (used by hasPendingTransitions)
+
+  @public
+  @returns {undefined}
+*/
+export function resetRouterTransitionPendingState() {
+  routerTransitionsPending = false;
+}
+
+/**
+  Determines if we have any pending router transtions (used to determine `settled` state)
+
+  @public
+  @returns {(boolean|null)} if there are pending transitions
+*/
+export function hasPendingTransitions(): boolean | null {
+  if (CAN_USE_ROUTER_EVENTS) {
+    return routerTransitionsPending;
+  }
+
+  let context = getContext();
+
+  // there is no current context, we cannot check
+  if (context === undefined) {
+    return null;
+  }
+
+  let router = ROUTER.get(context);
+
+  if (router === undefined) {
+    // if there is no router (e.g. no `visit` calls made yet), we cannot
+    // check for pending transitions but this is explicitly not an error
+    // condition
+    return null;
+  }
+
+  let routerMicrolib = router._routerMicrolib || router.router;
+
+  if (routerMicrolib === undefined) {
+    return null;
+  }
+
+  return !!routerMicrolib.activeTransition;
 }
 
 /**
@@ -32,7 +82,22 @@ export function visit(url: string, options?: { [key: string]: any }): Promise<vo
 
   return nextTickPromise()
     .then(() => {
-      return owner.visit(url, options);
+      let visitResult = owner.visit(url, options);
+
+      if (CAN_USE_ROUTER_EVENTS) {
+        let router = owner.lookup('service:router');
+
+        // track pending transitions via the public routeWillChange / routeDidChange APIs
+        // routeWillChange can fire many times and is only useful to know when we have _started_
+        // transitioning, we can then use routeDidChange to signal that the transition has settled
+        router.on('routeWillChange', () => (routerTransitionsPending = true));
+        router.on('routeDidChange', () => (routerTransitionsPending = false));
+      } else {
+        let router = owner.lookup('router:main');
+        ROUTER.set(context, router);
+      }
+
+      return visitResult;
     })
     .then(() => {
       if (global.EmberENV._APPLICATION_TEMPLATE_WRAPPER !== false) {

--- a/addon-test-support/@ember/test-helpers/setup-context.ts
+++ b/addon-test-support/@ember/test-helpers/setup-context.ts
@@ -174,7 +174,7 @@ export const CLEANUP = Object.create(null);
   @param {Resolver} [options.resolver] a resolver to use for customizing normal resolution
   @returns {Promise<Object>} resolves with the context that was setup
 */
-export default function(
+export default function setupContext(
   context: BaseContext,
   options: { resolver?: Resolver } = {}
 ): Promise<TestContext> {

--- a/addon-test-support/@ember/test-helpers/teardown-application-context.ts
+++ b/addon-test-support/@ember/test-helpers/teardown-application-context.ts
@@ -1,6 +1,6 @@
 import { nextTickPromise } from './-utils';
 import settled from './settled';
-import { resetRouterTransitionPendingState } from './setup-application-context';
+
 /**
   Used by test framework addons to tear down the provided context after testing is completed.
 
@@ -11,8 +11,6 @@ import { resetRouterTransitionPendingState } from './setup-application-context';
   @returns {Promise<void>} resolves when settled
 */
 export default function(context: object, options?: { waitForSettled?: boolean }): Promise<void> {
-  resetRouterTransitionPendingState();
-
   let waitForSettled = true;
   if (options !== undefined && 'waitForSettled' in options) {
     waitForSettled = options.waitForSettled!;

--- a/addon-test-support/@ember/test-helpers/teardown-application-context.ts
+++ b/addon-test-support/@ember/test-helpers/teardown-application-context.ts
@@ -1,6 +1,6 @@
 import { nextTickPromise } from './-utils';
 import settled from './settled';
-
+import { resetRouterTransitionPendingState } from './setup-application-context';
 /**
   Used by test framework addons to tear down the provided context after testing is completed.
 
@@ -11,6 +11,8 @@ import settled from './settled';
   @returns {Promise<void>} resolves when settled
 */
 export default function(context: object, options?: { waitForSettled?: boolean }): Promise<void> {
+  resetRouterTransitionPendingState();
+
   let waitForSettled = true;
   if (options !== undefined && 'waitForSettled' in options) {
     waitForSettled = options.waitForSettled!;

--- a/tests/unit/settled-test.js
+++ b/tests/unit/settled-test.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 import { module, test } from 'qunit';
-import { isSettled, getSettledState, setContext } from '@ember/test-helpers';
+import { isSettled, getSettledState, setContext, unsetContext } from '@ember/test-helpers';
 import hasEmberVersion from '@ember/test-helpers/has-ember-version';
 import { _setupAJAXHooks, _teardownAJAXHooks } from '@ember/test-helpers/settled';
 import { next, later, run, schedule } from '@ember/runloop';
@@ -169,6 +169,7 @@ module('settled', function(hooks) {
         }),
       };
       assert.strictEqual(isSettled(), true);
+      this.owner = undefined;
     });
   });
 
@@ -344,6 +345,7 @@ module('settled', function(hooks) {
         }),
       };
       assert.strictEqual(isSettled(), true, 'post cond');
+      this.owner = undefined;
     });
 
     test('all the things!', function(assert) {

--- a/tests/unit/settled-test.js
+++ b/tests/unit/settled-test.js
@@ -169,7 +169,7 @@ module('settled', function(hooks) {
         }),
       };
       assert.strictEqual(isSettled(), true);
-      this.owner = undefined;
+      unsetContext();
     });
   });
 
@@ -345,7 +345,7 @@ module('settled', function(hooks) {
         }),
       };
       assert.strictEqual(isSettled(), true, 'post cond');
-      this.owner = undefined;
+      unsetContext();
     });
 
     test('all the things!', function(assert) {

--- a/tests/unit/settled-test.js
+++ b/tests/unit/settled-test.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 import { module, test } from 'qunit';
-import { isSettled, getSettledState } from '@ember/test-helpers';
+import { isSettled, getSettledState, setContext } from '@ember/test-helpers';
 import hasEmberVersion from '@ember/test-helpers/has-ember-version';
 import { _setupAJAXHooks, _teardownAJAXHooks } from '@ember/test-helpers/settled';
 import { next, later, run, schedule } from '@ember/runloop';
@@ -26,6 +26,7 @@ module('settled', function(hooks) {
               hasPendingRequests: false,
               hasPendingTimers: false,
               hasPendingWaiters: false,
+              hasPendingTransitions: false,
               hasRunLoop: false,
               pendingRequestCount: 0,
             },
@@ -144,6 +145,31 @@ module('settled', function(hooks) {
 
       assert.strictEqual(isSettled(), true, 'post cond');
     });
+
+    test('when router is transitioning', async function(assert) {
+      assert.expect(3);
+
+      setContext(this);
+      assert.strictEqual(isSettled(), true);
+
+      this.owner = {
+        lookup: () => ({
+          _routerMicrolib: {
+            activeTransition: {},
+          },
+        }),
+      };
+      assert.strictEqual(isSettled(), false);
+
+      this.owner = {
+        lookup: () => ({
+          _routerMicrolib: {
+            activeTransition: null,
+          },
+        }),
+      };
+      assert.strictEqual(isSettled(), true);
+    });
   });
 
   module('getSettledState', function() {
@@ -152,6 +178,7 @@ module('settled', function(hooks) {
         hasPendingRequests: false,
         hasPendingTimers: false,
         hasPendingWaiters: false,
+        hasPendingTransitions: false,
         hasRunLoop: false,
         pendingRequestCount: 0,
       });
@@ -169,6 +196,7 @@ module('settled', function(hooks) {
         hasPendingRequests: false,
         hasPendingTimers: true,
         hasPendingWaiters: false,
+        hasPendingTransitions: false,
         hasRunLoop: true,
         pendingRequestCount: 0,
       });
@@ -187,6 +215,7 @@ module('settled', function(hooks) {
         hasPendingRequests: false,
         hasPendingTimers: true,
         hasPendingWaiters: false,
+        hasPendingTransitions: false,
         hasRunLoop: false,
         pendingRequestCount: 0,
       });
@@ -205,6 +234,7 @@ module('settled', function(hooks) {
         hasPendingRequests: false,
         hasPendingTimers: true,
         hasPendingWaiters: false,
+        hasPendingTransitions: false,
         hasRunLoop: false,
         pendingRequestCount: 0,
       });
@@ -220,6 +250,7 @@ module('settled', function(hooks) {
           hasPendingRequests: false,
           hasPendingTimers: false,
           hasPendingWaiters: false,
+          hasPendingTransitions: false,
           hasRunLoop: true,
           pendingRequestCount: 0,
         });
@@ -247,6 +278,7 @@ module('settled', function(hooks) {
           hasPendingRequests: true,
           hasPendingTimers: false,
           hasPendingWaiters: false,
+          hasPendingTransitions: false,
           hasRunLoop: false,
           pendingRequestCount: 1,
         });
@@ -255,6 +287,7 @@ module('settled', function(hooks) {
           hasPendingRequests: false,
           hasPendingTimers: false,
           hasPendingWaiters: true,
+          hasPendingTransitions: false,
           hasRunLoop: false,
           pendingRequestCount: 0,
         });
@@ -272,12 +305,44 @@ module('settled', function(hooks) {
         hasPendingRequests: false,
         hasPendingTimers: false,
         hasPendingWaiters: true,
+        hasPendingTransitions: false,
         hasRunLoop: false,
         pendingRequestCount: 0,
       });
 
       this.isWaiterPending = false;
 
+      assert.strictEqual(isSettled(), true, 'post cond');
+    });
+
+    test('when router is transitioning', function(assert) {
+      assert.expect(3);
+      assert.strictEqual(isSettled(), true);
+
+      setContext(this);
+      this.owner = {
+        lookup: () => ({
+          _routerMicrolib: {
+            activeTransition: {},
+          },
+        }),
+      };
+      assert.deepEqual(getSettledState(), {
+        hasPendingRequests: false,
+        hasPendingTimers: false,
+        hasPendingWaiters: false,
+        hasPendingTransitions: true,
+        hasRunLoop: false,
+        pendingRequestCount: 0,
+      });
+
+      this.owner = {
+        lookup: () => ({
+          _routerMicrolib: {
+            activeTransition: null,
+          },
+        }),
+      };
       assert.strictEqual(isSettled(), true, 'post cond');
     });
 
@@ -292,6 +357,7 @@ module('settled', function(hooks) {
         hasPendingRequests: false,
         hasPendingTimers: false,
         hasPendingWaiters: true,
+        hasPendingTransitions: false,
         hasRunLoop: false,
         pendingRequestCount: 0,
       });
@@ -301,6 +367,7 @@ module('settled', function(hooks) {
           hasPendingRequests: false,
           hasPendingTimers: false,
           hasPendingWaiters: true,
+          hasPendingTransitions: false,
           hasRunLoop: true,
           pendingRequestCount: 0,
         });
@@ -311,6 +378,7 @@ module('settled', function(hooks) {
           hasPendingRequests: false,
           hasPendingTimers: true,
           hasPendingWaiters: true,
+          hasPendingTransitions: false,
           hasRunLoop: true,
           pendingRequestCount: 0,
         });

--- a/tests/unit/settled-test.js
+++ b/tests/unit/settled-test.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 import { module, test } from 'qunit';
-import { isSettled, getSettledState, setContext, unsetContext } from '@ember/test-helpers';
+import { isSettled, getSettledState } from '@ember/test-helpers';
 import hasEmberVersion from '@ember/test-helpers/has-ember-version';
 import { _setupAJAXHooks, _teardownAJAXHooks } from '@ember/test-helpers/settled';
 import { next, later, run, schedule } from '@ember/runloop';
@@ -26,7 +26,7 @@ module('settled', function(hooks) {
               hasPendingRequests: false,
               hasPendingTimers: false,
               hasPendingWaiters: false,
-              hasPendingTransitions: false,
+              hasPendingTransitions: null,
               hasRunLoop: false,
               pendingRequestCount: 0,
             },
@@ -145,32 +145,6 @@ module('settled', function(hooks) {
 
       assert.strictEqual(isSettled(), true, 'post cond');
     });
-
-    test('when router is transitioning', async function(assert) {
-      assert.expect(3);
-
-      setContext(this);
-      assert.strictEqual(isSettled(), true);
-
-      this.owner = {
-        lookup: () => ({
-          _routerMicrolib: {
-            activeTransition: {},
-          },
-        }),
-      };
-      assert.strictEqual(isSettled(), false);
-
-      this.owner = {
-        lookup: () => ({
-          _routerMicrolib: {
-            activeTransition: null,
-          },
-        }),
-      };
-      assert.strictEqual(isSettled(), true);
-      unsetContext();
-    });
   });
 
   module('getSettledState', function() {
@@ -179,7 +153,7 @@ module('settled', function(hooks) {
         hasPendingRequests: false,
         hasPendingTimers: false,
         hasPendingWaiters: false,
-        hasPendingTransitions: false,
+        hasPendingTransitions: null,
         hasRunLoop: false,
         pendingRequestCount: 0,
       });
@@ -197,7 +171,7 @@ module('settled', function(hooks) {
         hasPendingRequests: false,
         hasPendingTimers: true,
         hasPendingWaiters: false,
-        hasPendingTransitions: false,
+        hasPendingTransitions: null,
         hasRunLoop: true,
         pendingRequestCount: 0,
       });
@@ -216,7 +190,7 @@ module('settled', function(hooks) {
         hasPendingRequests: false,
         hasPendingTimers: true,
         hasPendingWaiters: false,
-        hasPendingTransitions: false,
+        hasPendingTransitions: null,
         hasRunLoop: false,
         pendingRequestCount: 0,
       });
@@ -235,7 +209,7 @@ module('settled', function(hooks) {
         hasPendingRequests: false,
         hasPendingTimers: true,
         hasPendingWaiters: false,
-        hasPendingTransitions: false,
+        hasPendingTransitions: null,
         hasRunLoop: false,
         pendingRequestCount: 0,
       });
@@ -251,7 +225,7 @@ module('settled', function(hooks) {
           hasPendingRequests: false,
           hasPendingTimers: false,
           hasPendingWaiters: false,
-          hasPendingTransitions: false,
+          hasPendingTransitions: null,
           hasRunLoop: true,
           pendingRequestCount: 0,
         });
@@ -279,7 +253,7 @@ module('settled', function(hooks) {
           hasPendingRequests: true,
           hasPendingTimers: false,
           hasPendingWaiters: false,
-          hasPendingTransitions: false,
+          hasPendingTransitions: null,
           hasRunLoop: false,
           pendingRequestCount: 1,
         });
@@ -288,7 +262,7 @@ module('settled', function(hooks) {
           hasPendingRequests: false,
           hasPendingTimers: false,
           hasPendingWaiters: true,
-          hasPendingTransitions: false,
+          hasPendingTransitions: null,
           hasRunLoop: false,
           pendingRequestCount: 0,
         });
@@ -306,7 +280,7 @@ module('settled', function(hooks) {
         hasPendingRequests: false,
         hasPendingTimers: false,
         hasPendingWaiters: true,
-        hasPendingTransitions: false,
+        hasPendingTransitions: null,
         hasRunLoop: false,
         pendingRequestCount: 0,
       });
@@ -314,38 +288,6 @@ module('settled', function(hooks) {
       this.isWaiterPending = false;
 
       assert.strictEqual(isSettled(), true, 'post cond');
-    });
-
-    test('when router is transitioning', function(assert) {
-      assert.expect(3);
-      assert.strictEqual(isSettled(), true);
-
-      setContext(this);
-      this.owner = {
-        lookup: () => ({
-          _routerMicrolib: {
-            activeTransition: {},
-          },
-        }),
-      };
-      assert.deepEqual(getSettledState(), {
-        hasPendingRequests: false,
-        hasPendingTimers: false,
-        hasPendingWaiters: false,
-        hasPendingTransitions: true,
-        hasRunLoop: false,
-        pendingRequestCount: 0,
-      });
-
-      this.owner = {
-        lookup: () => ({
-          _routerMicrolib: {
-            activeTransition: null,
-          },
-        }),
-      };
-      assert.strictEqual(isSettled(), true, 'post cond');
-      unsetContext();
     });
 
     test('all the things!', function(assert) {
@@ -359,7 +301,7 @@ module('settled', function(hooks) {
         hasPendingRequests: false,
         hasPendingTimers: false,
         hasPendingWaiters: true,
-        hasPendingTransitions: false,
+        hasPendingTransitions: null,
         hasRunLoop: false,
         pendingRequestCount: 0,
       });
@@ -369,7 +311,7 @@ module('settled', function(hooks) {
           hasPendingRequests: false,
           hasPendingTimers: false,
           hasPendingWaiters: true,
-          hasPendingTransitions: false,
+          hasPendingTransitions: null,
           hasRunLoop: true,
           pendingRequestCount: 0,
         });
@@ -380,7 +322,7 @@ module('settled', function(hooks) {
           hasPendingRequests: false,
           hasPendingTimers: true,
           hasPendingWaiters: true,
-          hasPendingTransitions: false,
+          hasPendingTransitions: null,
           hasRunLoop: true,
           pendingRequestCount: 0,
         });

--- a/tests/unit/setup-application-context-test.js
+++ b/tests/unit/setup-application-context-test.js
@@ -33,7 +33,7 @@ module('setupApplicationContext', function(hooks) {
     return;
   }
 
-  hooks.beforeEach(async function(assert) {
+  hooks.beforeEach(async function() {
     setResolverRegistry({
       'router:main': Router,
       'template:application': hbs`
@@ -57,10 +57,10 @@ module('setupApplicationContext', function(hooks) {
       }),
       'route:slow': Route.extend({
         model() {
-          assert.step('model start');
+          QUnit.config.current.assert.step('model start');
           return new Promise(resolve => {
             setTimeout(() => {
-              assert.step('model resolving');
+              QUnit.config.current.assert.step('model resolving');
               resolve();
             }, 50);
           });

--- a/tests/unit/setup-application-context-test.js
+++ b/tests/unit/setup-application-context-test.js
@@ -12,7 +12,6 @@ import {
   visit,
   currentRouteName,
   currentURL,
-  setContext,
 } from '@ember/test-helpers';
 import hasEmberVersion from '@ember/test-helpers/has-ember-version';
 import { setResolverRegistry } from '../helpers/resolver';
@@ -68,7 +67,6 @@ module('setupApplicationContext', function(hooks) {
       }),
     });
 
-    setContext(this);
     await setupContext(this);
     await setupApplicationContext(this);
   });

--- a/tests/unit/setup-application-context-test.js
+++ b/tests/unit/setup-application-context-test.js
@@ -12,10 +12,14 @@ import {
   visit,
   currentRouteName,
   currentURL,
+  setResolver,
 } from '@ember/test-helpers';
 import hasEmberVersion from '@ember/test-helpers/has-ember-version';
-import { setResolverRegistry, application } from '../helpers/resolver';
+import { setResolverRegistry } from '../helpers/resolver';
 import hbs from 'htmlbars-inline-precompile';
+import { assign } from '@ember/polyfills';
+import App from '../../app';
+import config from '../../config/environment';
 
 const Router = EmberRouter.extend({ location: 'none' });
 Router.map(function() {
@@ -29,8 +33,22 @@ module('setupApplicationContext', function(hooks) {
   if (!hasEmberVersion(2, 4)) {
     return;
   }
-
+  let isolatedApp;
   hooks.beforeEach(async function() {
+
+    const AppConfig = assign({ autoboot: false }, config.APP);
+    // .extend() because initializers are stored in the constructor, and we
+    // don't want to pollute other tests using an application created from the
+    // same constructor.
+    isolatedApp = App.extend({}).create(AppConfig);
+    let resolver = isolatedApp.Resolver.create({
+      namespace: isolatedApp,
+      isResolverFromTestHelpers: true,
+    });
+
+    setResolver(resolver);
+    setApplication(isolatedApp);
+
     setResolverRegistry({
       'router:main': Router,
       'template:application': hbs`
@@ -52,8 +70,6 @@ module('setupApplicationContext', function(hooks) {
         },
       }),
     });
-
-    setApplication(application);
 
     await setupContext(this);
     await setupApplicationContext(this);

--- a/tests/unit/setup-application-context-test.js
+++ b/tests/unit/setup-application-context-test.js
@@ -35,7 +35,6 @@ module('setupApplicationContext', function(hooks) {
   }
   let isolatedApp;
   hooks.beforeEach(async function() {
-
     const AppConfig = assign({ autoboot: false }, config.APP);
     // .extend() because initializers are stored in the constructor, and we
     // don't want to pollute other tests using an application created from the

--- a/tests/unit/setup-application-context-test.js
+++ b/tests/unit/setup-application-context-test.js
@@ -8,19 +8,15 @@ import {
   setupApplicationContext,
   teardownContext,
   teardownApplicationContext,
-  setApplication,
   click,
   visit,
   currentRouteName,
   currentURL,
-  setResolver,
+  setContext,
 } from '@ember/test-helpers';
 import hasEmberVersion from '@ember/test-helpers/has-ember-version';
 import { setResolverRegistry } from '../helpers/resolver';
 import hbs from 'htmlbars-inline-precompile';
-import { assign } from '@ember/polyfills';
-import App from '../../app';
-import config from '../../config/environment';
 
 const Router = EmberRouter.extend({ location: 'none' });
 Router.map(function() {
@@ -36,21 +32,8 @@ module('setupApplicationContext', function(hooks) {
   if (!hasEmberVersion(2, 4)) {
     return;
   }
-  let isolatedApp;
+
   hooks.beforeEach(async function(assert) {
-    const AppConfig = assign({ autoboot: false }, config.APP);
-    // .extend() because initializers are stored in the constructor, and we
-    // don't want to pollute other tests using an application created from the
-    // same constructor.
-    isolatedApp = App.extend({}).create(AppConfig);
-    let resolver = isolatedApp.Resolver.create({
-      namespace: isolatedApp,
-      isResolverFromTestHelpers: true,
-    });
-
-    setResolver(resolver);
-    setApplication(isolatedApp);
-
     setResolverRegistry({
       'router:main': Router,
       'template:application': hbs`
@@ -85,6 +68,7 @@ module('setupApplicationContext', function(hooks) {
       }),
     });
 
+    setContext(this);
     await setupContext(this);
     await setupApplicationContext(this);
   });


### PR DESCRIPTION
This aims to resolve an issue where `settled()` isn't waiting for router transitions. See here: [#411](https://github.com/emberjs/ember-test-helpers/issues/411).

This is a combined effort from myself and @dexturr.