### PR TITLE
Only customize RSVP's async for Ember < 1.7.

### DIFF
--- a/addon-test-support/ember-test-helpers/legacy-0-6-x/ext/rsvp.js
+++ b/addon-test-support/ember-test-helpers/legacy-0-6-x/ext/rsvp.js
@@ -1,5 +1,6 @@
 import RSVP from 'rsvp';
 import { run } from '@ember/runloop';
+import hasEmberVersion from '../../has-ember-version';
 
 let originalAsync;
 
@@ -11,13 +12,15 @@ let originalAsync;
   @private
 */
 export function _setupPromiseListeners() {
-  originalAsync = RSVP.configure('async');
+  if (!hasEmberVersion(1, 7)) {
+    originalAsync = RSVP.configure('async');
 
-  RSVP.configure('async', function(callback, promise) {
-    run.backburner.schedule('actions', () => {
-      callback(promise);
+    RSVP.configure('async', function(callback, promise) {
+      run.backburner.schedule('actions', () => {
+        callback(promise);
+      });
     });
-  });
+  }
 }
 
 /**
@@ -26,5 +29,7 @@ export function _setupPromiseListeners() {
   @private
 */
 export function _teardownPromiseListeners() {
-  RSVP.configure('async', originalAsync);
+  if (!hasEmberVersion(1, 7)) {
+    RSVP.configure('async', originalAsync);
+  }
 }


### PR DESCRIPTION
As of Ember 1.7 and higher, this customization is done automatically.  Originally we intended to just leave this alone, and not update (since these are already legacy testing systems) but apparently this is actively breaking other fixes in the newer system if *any* older style tests still exist in the test suite.

The main issue with this code on newer Ember versions is that it does not properly call `adapter.asyncStart()` and `adapter.asyncEnd()` which means that we no longer wait for the promise resolution in the test harness itself. :sob: