### PR TITLE
Add ability to opt-out of automatic settledness waiting in teardown.

### DIFF
--- a/addon-test-support/@ember/test-helpers/teardown-application-context.ts
+++ b/addon-test-support/@ember/test-helpers/teardown-application-context.ts
@@ -1,3 +1,4 @@
+import { nextTickPromise } from './-utils';
 import settled from './settled';
 
 /**
@@ -5,8 +6,19 @@ import settled from './settled';
 
   @public
   @param {Object} context the context to setup
+  @param {Object} [options] options used to override defaults
+  @param {boolean} [options.waitForSettled=true] should the teardown wait for `settled()`ness
   @returns {Promise<void>} resolves when settled
 */
-export default function(context: object): Promise<void> {
-  return settled();
+export default function(context: object, options?: { waitForSettled?: boolean }): Promise<void> {
+  let waitForSettled = true;
+  if (options !== undefined && 'waitForSettled' in options) {
+    waitForSettled = options.waitForSettled!;
+  }
+
+  if (waitForSettled) {
+    return settled();
+  }
+
+  return nextTickPromise();
 }

--- a/addon-test-support/@ember/test-helpers/teardown-context.ts
+++ b/addon-test-support/@ember/test-helpers/teardown-context.ts
@@ -17,9 +17,18 @@ import Ember from 'ember';
 
   @public
   @param {Object} context the context to setup
+  @param {Object} [options] options used to override defaults
+  @param {boolean} [options.waitForSettled=true] should the teardown wait for `settled()`ness
   @returns {Promise<void>} resolves when settled
 */
-export default function teardownContext(context: TestContext): Promise<void> {
+export default function teardownContext(
+  context: TestContext,
+  options?: { waitForSettled?: boolean }
+): Promise<void> {
+  let waitForSettled = true;
+  if (options !== undefined && 'waitForSettled' in options) {
+    waitForSettled = options.waitForSettled!;
+  }
   return nextTickPromise()
     .then(() => {
       let { owner } = context;
@@ -31,13 +40,21 @@ export default function teardownContext(context: TestContext): Promise<void> {
 
       unsetContext();
 
-      return settled();
+      if (waitForSettled) {
+        return settled();
+      }
+
+      return nextTickPromise();
     })
     .finally(() => {
       let contextGuid = guidFor(context);
 
       runDestroyablesFor(CLEANUP, contextGuid);
 
-      return settled();
+      if (waitForSettled) {
+        return settled();
+      }
+
+      return nextTickPromise();
     });
 }

--- a/addon-test-support/@ember/test-helpers/teardown-rendering-context.ts
+++ b/addon-test-support/@ember/test-helpers/teardown-rendering-context.ts
@@ -13,14 +13,28 @@ import settled from './settled';
 
   @public
   @param {Object} context the context to setup
+  @param {Object} [options] options used to override defaults
+  @param {boolean} [options.waitForSettled=true] should the teardown wait for `settled()`ness
   @returns {Promise<void>} resolves when settled
 */
-export default function teardownRenderingContext(context: RenderingTestContext): Promise<void> {
+export default function teardownRenderingContext(
+  context: RenderingTestContext,
+  options?: { waitForSettled?: boolean }
+): Promise<void> {
+  let waitForSettled = true;
+  if (options !== undefined && 'waitForSettled' in options) {
+    waitForSettled = options.waitForSettled!;
+  }
+
   return nextTickPromise().then(() => {
     let contextGuid = guidFor(context);
 
     runDestroyablesFor(RENDERING_CLEANUP, contextGuid);
 
-    return settled();
+    if (waitForSettled) {
+      return settled();
+    }
+
+    return nextTickPromise();
   });
 }

--- a/tests/helpers/manual-test-waiter.js
+++ b/tests/helpers/manual-test-waiter.js
@@ -1,0 +1,13 @@
+import { registerWaiter, unregisterWaiter } from '@ember/test';
+
+export default function setupManualTestWaiter(hooks) {
+  hooks.beforeEach(function() {
+    this.shouldWait = false;
+    this._waiter = () => !this.shouldWait;
+    registerWaiter(this._waiter);
+  });
+
+  hooks.afterEach(function() {
+    unregisterWaiter(this._waiter);
+  });
+}

--- a/tests/unit/teardown-context-test.js
+++ b/tests/unit/teardown-context-test.js
@@ -1,12 +1,19 @@
 import { module, test } from 'qunit';
 import Service from '@ember/service';
-import { getContext, setupContext, teardownContext, getSettledState } from '@ember/test-helpers';
+import {
+  getContext,
+  setupContext,
+  teardownContext,
+  getSettledState,
+  settled,
+} from '@ember/test-helpers';
 import { setResolverRegistry } from '../helpers/resolver';
 import hasEmberVersion from '@ember/test-helpers/has-ember-version';
 import Ember from 'ember';
 import hasjQuery from '../helpers/has-jquery';
 import ajax from '../helpers/ajax';
 import Pretender from 'pretender';
+import { later } from '@ember/runloop';
 
 module('teardownContext', function(hooks) {
   if (!hasEmberVersion(2, 4)) {
@@ -69,4 +76,16 @@ module('teardownContext', function(hooks) {
       assert.equal(state.pendingRequestCount, 0, 'pendingRequestCount is 0');
     });
   }
+
+  test('can opt out of waiting for settledness', async function(assert) {
+    later(() => assert.step('later'), 200);
+
+    await teardownContext(context, { waitForSettled: false });
+
+    assert.step('after teardown');
+
+    await settled();
+
+    assert.verifySteps(['after teardown', 'later']);
+  });
 });

--- a/tests/unit/teardown-rendering-context-test.js
+++ b/tests/unit/teardown-rendering-context-test.js
@@ -5,14 +5,16 @@ import {
   teardownContext,
   teardownRenderingContext,
   settled,
+  isSettled,
 } from '@ember/test-helpers';
 import hasEmberVersion from '@ember/test-helpers/has-ember-version';
-import { later } from '@ember/runloop';
+import setupManualTestWaiter from '../helpers/manual-test-waiter';
 
 module('teardownRenderingContext', function(hooks) {
   if (!hasEmberVersion(2, 4)) {
     return;
   }
+  setupManualTestWaiter(hooks);
 
   hooks.beforeEach(async function() {
     await setupContext(this);
@@ -58,15 +60,18 @@ module('teardownRenderingContext', function(hooks) {
   });
 
   test('can opt out of waiting for settledness', async function(assert) {
-    later(() => assert.step('later'), 200);
+    this.shouldWait = true;
+
+    assert.equal(isSettled(), false, 'should not be settled');
 
     await teardownRenderingContext(this, { waitForSettled: false });
     await teardownContext(this, { waitForSettled: false });
 
-    assert.step('after teardown');
+    assert.equal(isSettled(), false, 'should not be settled');
 
+    this.shouldWait = false;
     await settled();
 
-    assert.verifySteps(['after teardown', 'later']);
+    assert.equal(isSettled(), true, 'should be settled');
   });
 });

--- a/tests/unit/teardown-rendering-context-test.js
+++ b/tests/unit/teardown-rendering-context-test.js
@@ -4,8 +4,10 @@ import {
   setupRenderingContext,
   teardownContext,
   teardownRenderingContext,
+  settled,
 } from '@ember/test-helpers';
 import hasEmberVersion from '@ember/test-helpers/has-ember-version';
+import { later } from '@ember/runloop';
 
 module('teardownRenderingContext', function(hooks) {
   if (!hasEmberVersion(2, 4)) {
@@ -53,5 +55,18 @@ module('teardownRenderingContext', function(hooks) {
       document.body.contains(beforeTeardownEl),
       'previous ember-testing element is no longer in DOM'
     );
+  });
+
+  test('can opt out of waiting for settledness', async function(assert) {
+    later(() => assert.step('later'), 200);
+
+    await teardownRenderingContext(this, { waitForSettled: false });
+    await teardownContext(this, { waitForSettled: false });
+
+    assert.step('after teardown');
+
+    await settled();
+
+    assert.verifySteps(['after teardown', 'later']);
   });
 });


### PR DESCRIPTION
In order to allow things like `ember-qunit`'s upcoming async leak detection, we need to avoid waiting for `settled()`. By default we should continue to effectively `await settled()` but when ember-qunit (and soon ember-mocha) is configured to use async leak detection they can appropriately pass `waitForSettled` when they call `teardownContext` / `teardownRenderingContext` / `teardownApplicationContext`.