### PR TITLE
Avoid importing jQuery, depend on self.jQuery instead.

### DIFF
--- a/addon-test-support/@ember/test-helpers/settled.ts
+++ b/addon-test-support/@ember/test-helpers/settled.ts
@@ -1,7 +1,5 @@
+/* globals jQuery */
 import { run } from '@ember/runloop';
-
-import jQuery from 'jquery';
-
 import Ember from 'ember';
 
 import { nextTick } from './-utils';
@@ -90,7 +88,7 @@ export function _teardownAJAXHooks() {
   // We can no longer handle any remaining requests
   requests = [];
 
-  if (!jQuery) {
+  if (typeof jQuery === 'undefined') {
     return;
   }
 
@@ -106,7 +104,7 @@ export function _teardownAJAXHooks() {
 export function _setupAJAXHooks() {
   requests = [];
 
-  if (!jQuery) {
+  if (typeof jQuery === 'undefined') {
     return;
   }
 

--- a/addon-test-support/ember-test-helpers/legacy-0-6-x/test-module-for-component.js
+++ b/addon-test-support/ember-test-helpers/legacy-0-6-x/test-module-for-component.js
@@ -1,6 +1,5 @@
-/* globals EmberENV */
+/* globals EmberENV, jQuery */
 import { set, setProperties, get, getProperties } from '@ember/object';
-import $ from 'jquery';
 import { isArray } from '@ember/array';
 import { tryInvoke } from '@ember/utils';
 import { run } from '@ember/runloop';
@@ -292,7 +291,7 @@ export function setupComponentIntegrationTest() {
   context.$ = function(selector) {
     // emulates Ember internal behavor of `this.$` in a component
     // https://github.com/emberjs/ember.js/blob/v2.5.1/packages/ember-views/lib/views/states/has_element.js#L18
-    return selector ? $(selector, element) : $(element);
+    return selector ? jQuery(selector, element) : jQuery(element);
   };
 
   context.set = function(key, value) {

--- a/tests/dummy/config/optional-features.json
+++ b/tests/dummy/config/optional-features.json
@@ -1,0 +1,3 @@
+{
+  "jquery-integration": false
+}

--- a/tests/helpers/ajax.js
+++ b/tests/helpers/ajax.js
@@ -1,13 +1,13 @@
+/* globals jQuery */
 import { Promise } from 'rsvp';
 import hasjQuery from '../helpers/has-jquery';
-import $ from 'jquery'; // FYI - not present in all scenarios
 import require from 'require';
 import { join } from '@ember/runloop';
 
 export default function ajax(url) {
   if (hasjQuery()) {
     return new Promise((resolve, reject) => {
-      $.ajax(url, {
+      jQuery.ajax(url, {
         success: resolve,
         error(reason) {
           join(null, reject, reason);


### PR DESCRIPTION
`import jQuery from 'jquery'` may trigger a deprecation warning on newer Ember versions, this avoids importing it in favor of using `self.jQuery` directly.

Fixes https://github.com/emberjs/ember-test-helpers/issues/545.