### PR TITLE
Test and document specifying options to click

### DIFF
--- a/addon-test-support/@ember/test-helpers/dom/click.ts
+++ b/addon-test-support/@ember/test-helpers/dom/click.ts
@@ -47,7 +47,10 @@ export function __click__(element: Element | Document, options: MouseEventInit):
   The exact listing of events that are triggered may change over time as needed
   to continue to emulate how actual browsers handle clicking a given element.
 
-  Use the `options` hash to change the parameters of the MouseEvents.
+  Use the `options` hash to change the parameters of the MouseEvents. You can use this to specifiy modifier keys as well. For example:
+  ```javascript
+  await click('div', { shiftKey: true });
+  ```
 
   @public
   @param {string|Element} target the element or selector to click on

--- a/tests/unit/dom/click-test.js
+++ b/tests/unit/dom/click-test.js
@@ -104,6 +104,17 @@ module('DOM Helper: click', function(hooks) {
       assert.verifySteps(['mousedown 13 17 2', 'mouseup 13 17 2', 'click 13 17 2']);
     });
 
+    test('clicking accepts modifiers', async function(assert) {
+      element = buildInstrumentedElement('div', ['clientX', 'clientY', 'button']);
+      let handler = e => {
+        assert.equal(e.altKey, true);
+      };
+      element.addEventListener('click', handler);
+      await click(element, { clientX: 13, clientY: 17, altKey: true });
+      assert.verifySteps(['mousedown 13 17 0', 'mouseup 13 17 0', 'click 13 17 0']);
+      element.removeEventListener('click', handler);
+    });
+
     test('clicking a div has window set as view by default', async function(assert) {
       element = buildInstrumentedElement('div', ['view']);
 


### PR DESCRIPTION
Fix #551
I copied verifying the key event receiving the modifier by shamelessly stealing from the `checkKey` helper [here](https://github.com/emberjs/ember-test-helpers/blob/master/tests/unit/dom/trigger-key-event-test.js#L163-L170) 