### PR TITLE
Add pauseTestFor method.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,7 +16,7 @@ module.exports = {
   overrides: [
     {
       files: ['.eslintrc.js', '.prettierrc.js', 'index.js', 'config/ember-try.js', 'scripts/**'],
-      excludedFiles: ['addon-test-support/**', 'tests/**'],
+      excludedFiles: ['addon-test-support/**', 'addon/**', 'tests/**'],
       parserOptions: {
         ecmaVersion: 2015,
         sourceType: 'script',
@@ -47,7 +47,7 @@ module.exports = {
       },
     },
     {
-      files: ['index.js', 'addon-test-support/**/*.[jt]s', 'config/**/*.js'],
+      files: ['index.js', 'addon/**/*.[jt]s', 'addon-test-support/**/*.[jt]s', 'config/**/*.js'],
       plugins: ['disable-features'],
       rules: {
         'disable-features/disable-async-await': 'error',

--- a/API.md
+++ b/API.md
@@ -45,39 +45,43 @@
     -   [settled][41]
     -   [isSettled][42]
     -   [getSettledState][43]
--   [Pause Helpers][44]
-    -   [pauseTest][45]
-        -   [Examples][46]
-    -   [resumeTest][47]
--   [Test Framework APIs][48]
-    -   [setResolver][49]
-        -   [Parameters][50]
-    -   [getResolver][51]
-    -   [setupContext][52]
-        -   [Parameters][53]
-    -   [getContext][54]
-    -   [setContext][55]
-        -   [Parameters][56]
-    -   [unsetContext][57]
-    -   [teardownContext][58]
-        -   [Parameters][59]
-    -   [setupRenderingContext][60]
+    -   [pauseTestFor][44]
+        -   [Parameters][45]
+-   [Pause Helpers][46]
+    -   [pauseTest][47]
+        -   [Examples][48]
+    -   [resumeTest][49]
+-   [Test Framework APIs][50]
+    -   [setResolver][51]
+        -   [Parameters][52]
+    -   [getResolver][53]
+    -   [setupContext][54]
+        -   [Parameters][55]
+    -   [getContext][56]
+    -   [setContext][57]
+        -   [Parameters][58]
+    -   [unsetContext][59]
+    -   [teardownContext][60]
         -   [Parameters][61]
-    -   [teardownRenderingContext][62]
+    -   [setupRenderingContext][62]
         -   [Parameters][63]
-    -   [getApplication][64]
-    -   [setApplication][65]
-        -   [Parameters][66]
-    -   [setupApplicationContext][67]
+    -   [teardownRenderingContext][64]
+        -   [Parameters][65]
+    -   [getApplication][66]
+    -   [setApplication][67]
         -   [Parameters][68]
-    -   [teardownApplicationContext][69]
+    -   [setupApplicationContext][69]
         -   [Parameters][70]
-    -   [validateErrorHandler][71]
+    -   [teardownApplicationContext][71]
         -   [Parameters][72]
-        -   [Examples][73]
--   [setupOnerror][74]
-    -   [Parameters][75]
-    -   [Examples][76]
+    -   [validateErrorHandler][73]
+        -   [Parameters][74]
+        -   [Examples][75]
+-   [setupOnerror][76]
+    -   [Parameters][77]
+    -   [Examples][78]
+-   [resetOnerror][79]
+    -   [Examples][80]
 
 ## DOM Interaction Helpers
 
@@ -101,9 +105,9 @@ to continue to emulate how actual browsers handle unfocusing a given element.
 
 #### Parameters
 
--   `target` **([string][77] \| [Element][78])** the element or selector to unfocus (optional, default `document.activeElement`)
+-   `target` **([string][81] \| [Element][82])** the element or selector to unfocus (optional, default `document.activeElement`)
 
-Returns **[Promise][79]&lt;void>** resolves when settled
+Returns **[Promise][83]&lt;void>** resolves when settled
 
 ### click
 
@@ -130,14 +134,18 @@ For focusable (e.g. form control) elements the following events are triggered
 The exact listing of events that are triggered may change over time as needed
 to continue to emulate how actual browsers handle clicking a given element.
 
-Use the `options` hash to change the parameters of the MouseEvents.
+Use the `options` hash to change the parameters of the MouseEvents. You can use this to specifiy modifier keys as well. For example:
+
+```javascript
+await click('div', { shiftKey: true });
+```
 
 #### Parameters
 
--   `target` **([string][77] \| [Element][78])** the element or selector to click on
--   `options` **[Object][80]** the options to be merged into the mouse events (optional, default `{}`)
+-   `target` **([string][81] \| [Element][82])** the element or selector to click on
+-   `options` **[Object][84]** the options to be merged into the mouse events (optional, default `{}`)
 
-Returns **[Promise][79]&lt;void>** resolves when settled
+Returns **[Promise][83]&lt;void>** resolves when settled
 
 ### doubleClick
 
@@ -176,10 +184,10 @@ Use the `options` hash to change the parameters of the MouseEvents.
 
 #### Parameters
 
--   `target` **([string][77] \| [Element][78])** the element or selector to double-click on
--   `options` **[Object][80]** the options to be merged into the mouse events (optional, default `{}`)
+-   `target` **([string][81] \| [Element][82])** the element or selector to double-click on
+-   `options` **[Object][84]** the options to be merged into the mouse events (optional, default `{}`)
 
-Returns **[Promise][79]&lt;void>** resolves when settled
+Returns **[Promise][83]&lt;void>** resolves when settled
 
 ### fillIn
 
@@ -189,10 +197,10 @@ events on the specified target.
 
 #### Parameters
 
--   `target` **([string][77] \| [Element][78])** the element or selector to enter text into
--   `text` **[string][77]** the text to fill into the target element
+-   `target` **([string][81] \| [Element][82])** the element or selector to enter text into
+-   `text` **[string][81]** the text to fill into the target element
 
-Returns **[Promise][79]&lt;void>** resolves when the application is settled
+Returns **[Promise][83]&lt;void>** resolves when the application is settled
 
 ### focus
 
@@ -211,9 +219,9 @@ to continue to emulate how actual browsers handle focusing a given element.
 
 #### Parameters
 
--   `target` **([string][77] \| [Element][78])** the element or selector to focus
+-   `target` **([string][81] \| [Element][82])** the element or selector to focus
 
-Returns **[Promise][79]&lt;void>** resolves when the application is settled
+Returns **[Promise][83]&lt;void>** resolves when the application is settled
 
 ### tap
 
@@ -248,10 +256,10 @@ Use the `options` hash to change the parameters of the tap events.
 
 #### Parameters
 
--   `target` **([string][77] \| [Element][78])** the element or selector to tap on
--   `options` **[Object][80]** the options to be merged into the touch events (optional, default `{}`)
+-   `target` **([string][81] \| [Element][82])** the element or selector to tap on
+-   `options` **[Object][84]** the options to be merged into the touch events (optional, default `{}`)
 
-Returns **[Promise][79]&lt;void>** resolves when settled
+Returns **[Promise][83]&lt;void>** resolves when settled
 
 ### triggerEvent
 
@@ -259,16 +267,16 @@ Triggers an event on the specified target.
 
 #### Parameters
 
--   `target` **([string][77] \| [Element][78])** the element or selector to trigger the event on
--   `eventType` **[string][77]** the type of event to trigger
--   `options` **[Object][80]** additional properties to be set on the event
+-   `target` **([string][81] \| [Element][82])** the element or selector to trigger the event on
+-   `eventType` **[string][81]** the type of event to trigger
+-   `options` **[Object][84]** additional properties to be set on the event
 
 #### Examples
 
 Using triggerEvent to Upload a file
 When using triggerEvent to upload a file the `eventType` must be `change` and you must pass the
 `options` param as an object with a key `files` containing an array of
-[Blob][81].
+[Blob][85].
 
 
 ```javascript
@@ -279,27 +287,27 @@ triggerEvent(
 );
 ```
 
-Returns **[Promise][79]&lt;void>** resolves when the application is settled
+Returns **[Promise][83]&lt;void>** resolves when the application is settled
 
 ### triggerKeyEvent
 
 Triggers a keyboard event of given type in the target element.
-It also requires the developer to provide either a string with the [`key`][82]
-or the numeric [`keyCode`][83] of the pressed key.
+It also requires the developer to provide either a string with the [`key`][86]
+or the numeric [`keyCode`][87] of the pressed key.
 Optionally the user can also provide a POJO with extra modifiers for the event.
 
 #### Parameters
 
--   `target` **([string][77] \| [Element][78])** the element or selector to trigger the event on
+-   `target` **([string][81] \| [Element][82])** the element or selector to trigger the event on
 -   `eventType` **(`"keydown"` \| `"keyup"` \| `"keypress"`)** the type of event to trigger
--   `key` **([number][84] \| [string][77])** the `keyCode`(number) or `key`(string) of the event being triggered
--   `modifiers` **[Object][80]?** the state of various modifier keys (optional, default `DEFAULT_MODIFIERS`)
-    -   `modifiers.ctrlKey` **[boolean][85]** if true the generated event will indicate the control key was pressed during the key event (optional, default `false`)
-    -   `modifiers.altKey` **[boolean][85]** if true the generated event will indicate the alt key was pressed during the key event (optional, default `false`)
-    -   `modifiers.shiftKey` **[boolean][85]** if true the generated event will indicate the shift key was pressed during the key event (optional, default `false`)
-    -   `modifiers.metaKey` **[boolean][85]** if true the generated event will indicate the meta key was pressed during the key event (optional, default `false`)
+-   `key` **([number][88] \| [string][81])** the `keyCode`(number) or `key`(string) of the event being triggered
+-   `modifiers` **[Object][84]?** the state of various modifier keys (optional, default `DEFAULT_MODIFIERS`)
+    -   `modifiers.ctrlKey` **[boolean][89]** if true the generated event will indicate the control key was pressed during the key event (optional, default `false`)
+    -   `modifiers.altKey` **[boolean][89]** if true the generated event will indicate the alt key was pressed during the key event (optional, default `false`)
+    -   `modifiers.shiftKey` **[boolean][89]** if true the generated event will indicate the shift key was pressed during the key event (optional, default `false`)
+    -   `modifiers.metaKey` **[boolean][89]** if true the generated event will indicate the meta key was pressed during the key event (optional, default `false`)
 
-Returns **[Promise][79]&lt;void>** resolves when the application is settled
+Returns **[Promise][83]&lt;void>** resolves when the application is settled
 
 ### typeIn
 
@@ -315,11 +323,11 @@ per character of the passed text (this may vary on some browsers).
 
 #### Parameters
 
--   `target` **([string][77] \| [Element][78])** the element or selector to enter text into
--   `text` **[string][77]** the test to fill the element with
--   `options` **[Object][80]** {delay: x} (default 50) number of milliseconds to wait per keypress (optional, default `{}`)
+-   `target` **([string][81] \| [Element][82])** the element or selector to enter text into
+-   `text` **[string][81]** the test to fill the element with
+-   `options` **[Object][84]** {delay: x} (default 50) number of milliseconds to wait per keypress (optional, default `{}`)
 
-Returns **[Promise][79]&lt;void>** resolves when the application is settled
+Returns **[Promise][83]&lt;void>** resolves when the application is settled
 
 ## DOM Query Helpers
 
@@ -333,9 +341,9 @@ Find the first element matched by the given selector. Equivalent to calling
 
 #### Parameters
 
--   `selector` **[string][77]** the selector to search for
+-   `selector` **[string][81]** the selector to search for
 
-Returns **[Element][78]** matched element or null
+Returns **[Element][82]** matched element or null
 
 ### findAll
 
@@ -345,15 +353,15 @@ of a `NodeList`.
 
 #### Parameters
 
--   `selector` **[string][77]** the selector to search for
+-   `selector` **[string][81]** the selector to search for
 
-Returns **[Array][86]** array of matched elements
+Returns **[Array][90]** array of matched elements
 
 ### getRootElement
 
 Get the root element of the application under test (usually `#ember-testing`)
 
-Returns **[Element][78]** the root element
+Returns **[Element][82]** the root element
 
 ## Routing Helpers
 
@@ -366,18 +374,18 @@ Navigate the application to the provided URL.
 
 #### Parameters
 
--   `url` **[string][77]** The URL to visit (e.g. `/posts`)
--   `options` **[object][80]** app boot options
+-   `url` **[string][81]** The URL to visit (e.g. `/posts`)
+-   `options` **[object][84]** app boot options
 
-Returns **[Promise][79]&lt;void>** resolves when settled
+Returns **[Promise][83]&lt;void>** resolves when settled
 
 ### currentRouteName
 
-Returns **[string][77]** the currently active route name
+Returns **[string][81]** the currently active route name
 
 ### currentURL
 
-Returns **[string][77]** the applications current url
+Returns **[string][81]** the applications current url
 
 ## Rendering Helpers
 
@@ -392,7 +400,7 @@ Renders the provided template and appends it to the DOM.
 
 -   `template` **CompiledTemplate** the template to render
 
-Returns **[Promise][79]&lt;void>** resolves when settled
+Returns **[Promise][83]&lt;void>** resolves when settled
 
 ### clearRender
 
@@ -400,7 +408,7 @@ Clears any templates previously rendered. This is commonly used for
 confirming behavior that is triggered by teardown (e.g.
 `willDestroyElement`).
 
-Returns **[Promise][79]&lt;void>** resolves when settled
+Returns **[Promise][83]&lt;void>** resolves when settled
 
 ## Wait Helpers
 
@@ -415,12 +423,12 @@ interim DOM states (e.g. loading states, pending promises, etc).
 
 #### Parameters
 
--   `selector` **[string][77]** the selector to wait for
--   `options` **[Object][80]?** the options to be used (optional, default `{}`)
-    -   `options.timeout` **[number][84]** the time to wait (in ms) for a match (optional, default `1000`)
-    -   `options.count` **[number][84]** the number of elements that should match the provided selector (null means one or more) (optional, default `null`)
+-   `selector` **[string][81]** the selector to wait for
+-   `options` **[Object][84]?** the options to be used (optional, default `{}`)
+    -   `options.timeout` **[number][88]** the time to wait (in ms) for a match (optional, default `1000`)
+    -   `options.count` **[number][88]** the number of elements that should match the provided selector (null means one or more) (optional, default `null`)
 
-Returns **[Promise][79]&lt;([Element][78] \| [Array][86]&lt;[Element][78]>)>** resolves when the element(s) appear on the page
+Returns **[Promise][83]&lt;([Element][82] \| [Array][90]&lt;[Element][82]>)>** resolves when the element(s) appear on the page
 
 ### waitUntil
 
@@ -431,19 +439,19 @@ while _not_ settled (e.g. "loading" or "pending" states).
 
 #### Parameters
 
--   `callback` **[Function][87]** the callback to use for testing when waiting should stop
--   `options` **[Object][80]?** options used to override defaults (optional, default `{}`)
-    -   `options.timeout` **[number][84]** the maximum amount of time to wait (optional, default `1000`)
-    -   `options.timeoutMessage` **[string][77]** the message to use in the reject on timeout (optional, default `'waitUntil timed out'`)
+-   `callback` **[Function][91]** the callback to use for testing when waiting should stop
+-   `options` **[Object][84]?** options used to override defaults (optional, default `{}`)
+    -   `options.timeout` **[number][88]** the maximum amount of time to wait (optional, default `1000`)
+    -   `options.timeoutMessage` **[string][81]** the message to use in the reject on timeout (optional, default `'waitUntil timed out'`)
 
-Returns **[Promise][79]** resolves with the callback value when it returns a truthy value
+Returns **[Promise][83]** resolves with the callback value when it returns a truthy value
 
 ### settled
 
 Returns a promise that resolves when in a settled state (see `isSettled` for
 a definition of "settled state").
 
-Returns **[Promise][79]&lt;void>** resolves when settled
+Returns **[Promise][83]&lt;void>** resolves when settled
 
 ### isSettled
 
@@ -453,7 +461,7 @@ Settled generally means that there are no pending timers, no pending waiters,
 no pending AJAX requests, and no current run loop. However, new settledness
 metrics may be added and used as they become available.
 
-Returns **[boolean][85]** `true` if settled, `false` otherwise
+Returns **[boolean][89]** `true` if settled, `false` otherwise
 
 ### getSettledState
 
@@ -475,7 +483,22 @@ Check various settledness metrics, and return an object with the following prope
     if there are pending transitions, this will be `true`, otherwise `false`.
 -   `pendingRequestCount` - The count of pending AJAX requests.
 
-Returns **[Object][80]** object with properties for each of the metrics used to determine settledness
+Returns **[Object][84]** object with properties for each of the metrics used to determine settledness
+
+### pauseTestFor
+
+Ensures that tests wait for the provided promise before being considered "settled".
+
+This function is expected to be used in application/addon code (aka non-test code).
+When used during a test run, it ensures that the next `await settled()` check does
+not result until after the promise has settled, when used outside of a test it is a
+simple "pass through" function.
+
+#### Parameters
+
+-   `promise` **[Promise][83]&lt;T>** the promise to wait for
+
+Returns **[Promise][83]&lt;T>** the passed in promise
 
 ## Pause Helpers
 
@@ -520,7 +543,7 @@ module('awesome-sauce', function(hooks) {
 });
 ```
 
-Returns **[Promise][79]&lt;void>** resolves _only_ when `resumeTest()` is invoked
+Returns **[Promise][83]&lt;void>** resolves _only_ when `resumeTest()` is invoked
 
 ### resumeTest
 
@@ -562,17 +585,17 @@ Responsible for:
 
 #### Parameters
 
--   `context` **[Object][80]** the context to setup
--   `options` **[Object][80]?** options used to override defaults (optional, default `{}`)
+-   `context` **[Object][84]** the context to setup
+-   `options` **[Object][84]?** options used to override defaults (optional, default `{}`)
     -   `options.resolver` **Resolver?** a resolver to use for customizing normal resolution
 
-Returns **[Promise][79]&lt;[Object][80]>** resolves with the context that was setup
+Returns **[Promise][83]&lt;[Object][84]>** resolves with the context that was setup
 
 ### getContext
 
 Retrive the "global testing context" as stored by `setContext`.
 
-Returns **[Object][80]** the previously stored testing context
+Returns **[Object][84]** the previously stored testing context
 
 ### setContext
 
@@ -582,7 +605,7 @@ Generally setup automatically by `setupContext`.
 
 #### Parameters
 
--   `context` **[Object][80]** the context to use
+-   `context` **[Object][84]** the context to use
 
 ### unsetContext
 
@@ -602,11 +625,11 @@ Responsible for:
 
 #### Parameters
 
--   `context` **[Object][80]** the context to setup
--   `options` **[Object][80]?** options used to override defaults
-    -   `options.waitForSettled` **[boolean][85]** should the teardown wait for `settled()`ness (optional, default `true`)
+-   `context` **[Object][84]** the context to setup
+-   `options` **[Object][84]?** options used to override defaults
+    -   `options.waitForSettled` **[boolean][89]** should the teardown wait for `settled()`ness (optional, default `true`)
 
-Returns **[Promise][79]&lt;void>** resolves when settled
+Returns **[Promise][83]&lt;void>** resolves when settled
 
 ### setupRenderingContext
 
@@ -626,9 +649,9 @@ Responsible for:
 
 #### Parameters
 
--   `context` **[Object][80]** the context to setup for rendering
+-   `context` **[Object][84]** the context to setup for rendering
 
-Returns **[Promise][79]&lt;[Object][80]>** resolves with the context that was setup
+Returns **[Promise][83]&lt;[Object][84]>** resolves with the context that was setup
 
 ### teardownRenderingContext
 
@@ -641,11 +664,11 @@ Responsible for:
 
 #### Parameters
 
--   `context` **[Object][80]** the context to setup
--   `options` **[Object][80]?** options used to override defaults
-    -   `options.waitForSettled` **[boolean][85]** should the teardown wait for `settled()`ness (optional, default `true`)
+-   `context` **[Object][84]** the context to setup
+-   `options` **[Object][84]?** options used to override defaults
+    -   `options.waitForSettled` **[boolean][89]** should the teardown wait for `settled()`ness (optional, default `true`)
 
-Returns **[Promise][79]&lt;void>** resolves when settled
+Returns **[Promise][83]&lt;void>** resolves when settled
 
 ### getApplication
 
@@ -676,9 +699,9 @@ Sets up the basic framework used by application tests.
 
 #### Parameters
 
--   `context` **[Object][80]** the context to setup
+-   `context` **[Object][84]** the context to setup
 
-Returns **[Promise][79]&lt;[Object][80]>** resolves with the context that was setup
+Returns **[Promise][83]&lt;[Object][84]>** resolves with the context that was setup
 
 ### teardownApplicationContext
 
@@ -686,11 +709,11 @@ Used by test framework addons to tear down the provided context after testing is
 
 #### Parameters
 
--   `context` **[Object][80]** the context to setup
--   `options` **[Object][80]?** options used to override defaults
-    -   `options.waitForSettled` **[boolean][85]** should the teardown wait for `settled()`ness (optional, default `true`)
+-   `context` **[Object][84]** the context to setup
+-   `options` **[Object][84]?** options used to override defaults
+    -   `options.waitForSettled` **[boolean][89]** should the teardown wait for `settled()`ness (optional, default `true`)
 
-Returns **[Promise][79]&lt;void>** resolves when settled
+Returns **[Promise][83]&lt;void>** resolves when settled
 
 ### validateErrorHandler
 
@@ -705,7 +728,7 @@ everything is on fire...
 
 #### Parameters
 
--   `callback` **[Function][87]** the callback to validate (optional, default `Ember.onerror`)
+-   `callback` **[Function][91]** the callback to validate (optional, default `Ember.onerror`)
 
 #### Examples
 
@@ -721,17 +744,17 @@ test('Ember.onerror is functioning properly', function(assert) {
 });
 ```
 
-Returns **[Object][80]** object with `isValid` and `message`
+Returns **[Object][84]** object with `isValid` and `message`
 
 ## setupOnerror
 
 Sets the `Ember.onerror` function for tests. This value is intended to be reset after
- each test to ensure correct test isolation. To reset, you should simply call `setupOnerror`
- without an `onError` argument.
+each test to ensure correct test isolation. To reset, you should simply call `setupOnerror`
+without an `onError` argument.
 
 ### Parameters
 
--   `onError` **[Function][87]** the onError function to be set on Ember.onerror
+-   `onError` **[Function][91]** the onError function to be set on Ember.onerror
 
 ### Examples
 
@@ -741,16 +764,25 @@ Example implementation for `ember-qunit` or `ember-mocha`
 ```javascript
 import { setupOnerror } from '@ember/test-helpers';
 
- test('Ember.onerror is stubbed properly', function(assert) {
-   setupOnerror(function(err) {
-     assert.ok(err);
-   });
- });
+test('Ember.onerror is stubbed properly', function(assert) {
+  setupOnerror(function(err) {
+    assert.ok(err);
+  });
+});
+```
 
- // To reset `Ember.onerror` for each test to ensure isolation
- QUnit.testDone(function() {
-   setupOnerror();
- });
+## resetOnerror
+
+Resets `Ember.onerror` to the value it originally was at the start of the test run.
+
+### Examples
+
+```javascript
+import { resetOnerror } from '@ember/test-helpers';
+
+QUnit.testDone(function() {
+  resetOnerror();
+})
 ```
 
 [1]: #dom-interaction-helpers
@@ -839,90 +871,98 @@ import { setupOnerror } from '@ember/test-helpers';
 
 [43]: #getsettledstate
 
-[44]: #pause-helpers
+[44]: #pausetestfor
 
-[45]: #pausetest
+[45]: #parameters-15
 
-[46]: #examples-1
+[46]: #pause-helpers
 
-[47]: #resumetest
+[47]: #pausetest
 
-[48]: #test-framework-apis
+[48]: #examples-1
 
-[49]: #setresolver
+[49]: #resumetest
 
-[50]: #parameters-15
+[50]: #test-framework-apis
 
-[51]: #getresolver
+[51]: #setresolver
 
-[52]: #setupcontext
+[52]: #parameters-16
 
-[53]: #parameters-16
+[53]: #getresolver
 
-[54]: #getcontext
+[54]: #setupcontext
 
-[55]: #setcontext
+[55]: #parameters-17
 
-[56]: #parameters-17
+[56]: #getcontext
 
-[57]: #unsetcontext
+[57]: #setcontext
 
-[58]: #teardowncontext
+[58]: #parameters-18
 
-[59]: #parameters-18
+[59]: #unsetcontext
 
-[60]: #setuprenderingcontext
+[60]: #teardowncontext
 
 [61]: #parameters-19
 
-[62]: #teardownrenderingcontext
+[62]: #setuprenderingcontext
 
 [63]: #parameters-20
 
-[64]: #getapplication
+[64]: #teardownrenderingcontext
 
-[65]: #setapplication
+[65]: #parameters-21
 
-[66]: #parameters-21
+[66]: #getapplication
 
-[67]: #setupapplicationcontext
+[67]: #setapplication
 
 [68]: #parameters-22
 
-[69]: #teardownapplicationcontext
+[69]: #setupapplicationcontext
 
 [70]: #parameters-23
 
-[71]: #validateerrorhandler
+[71]: #teardownapplicationcontext
 
 [72]: #parameters-24
 
-[73]: #examples-2
+[73]: #validateerrorhandler
 
-[74]: #setuponerror
+[74]: #parameters-25
 
-[75]: #parameters-25
+[75]: #examples-2
 
-[76]: #examples-3
+[76]: #setuponerror
 
-[77]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String
+[77]: #parameters-26
 
-[78]: https://developer.mozilla.org/docs/Web/API/Element
+[78]: #examples-3
 
-[79]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise
+[79]: #resetonerror
 
-[80]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object
+[80]: #examples-4
 
-[81]: https://developer.mozilla.org/en-US/docs/Web/API/Blob
+[81]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String
 
-[82]: https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key/Key_Values
+[82]: https://developer.mozilla.org/docs/Web/API/Element
 
-[83]: https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode
+[83]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise
 
-[84]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number
+[84]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object
 
-[85]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean
+[85]: https://developer.mozilla.org/en-US/docs/Web/API/Blob
 
-[86]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array
+[86]: https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key/Key_Values
 
-[87]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function
+[87]: https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode
+
+[88]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number
+
+[89]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean
+
+[90]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array
+
+[91]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function

--- a/addon-test-support/@ember/test-helpers/index.ts
+++ b/addon-test-support/@ember/test-helpers/index.ts
@@ -18,7 +18,7 @@ export {
   currentURL,
 } from './setup-application-context';
 export { default as teardownApplicationContext } from './teardown-application-context';
-export { default as settled, isSettled, getSettledState } from './settled';
+export { default as settled, isSettled, getSettledState, pauseTestFor } from './settled';
 export { default as waitUntil } from './wait-until';
 export { default as validateErrorHandler } from './validate-error-handler';
 export { default as setupOnerror, resetOnerror } from './setup-onerror';

--- a/addon-test-support/@ember/test-helpers/settled.ts
+++ b/addon-test-support/@ember/test-helpers/settled.ts
@@ -155,7 +155,7 @@ let currentPauseTestPromises = new Map<Promise<unknown>, IPauseTestPromiseDetail
 
   This function is expected to be used in application/addon code (aka non-test code).
   When used during a test run, it ensures that the next `await settled()` check does
-  not result until after the promise has settled, when used outside of a test it is a
+  not resolve until after the promise has settled, when used outside of a test it is a
   simple "pass through" function.
 
   @public

--- a/addon/index.js
+++ b/addon/index.js
@@ -1,0 +1,9 @@
+/*
+  This is the production version of `pauseTestFor`, the "real" implementation
+  is in addon-test-support/@ember/test-helpers/settled.ts.
+
+  This is a simple pass through function...
+*/
+export function pauseTestFor(promise) {
+  return promise;
+}

--- a/documentation.yml
+++ b/documentation.yml
@@ -35,6 +35,7 @@ toc:
       - settled
       - isSettled
       - getSettledState
+      - pauseTestFor
 
   - name: Pause Helpers
     children:

--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ module.exports = {
   treeForAddonTestSupport(tree) {
     // intentionally not calling _super here
     // so that can have our `import`'s be
-    // import { ... } from 'ember-test-helpers';
+    // import { ... } from '@ember/test-helpers';
 
     let input = debugTree(tree, 'addon-test-support:input');
 


### PR DESCRIPTION
Ensures that tests wait for the provided promise before being considered "settled".

This function is expected to be used in application/addon code (aka non-test code).  When used during a test run, it ensures that the next `await settled()` check does not result until after the promise has settled, when used outside of a test it is a simple "pass through" function.