### PR TITLE
Move ember-cli-typescript to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "broccoli-funnel": "^2.0.2",
     "ember-assign-polyfill": "^2.6.0",
     "ember-cli-babel": "^7.6.0",
-    "ember-cli-htmlbars-inline-precompile": "^2.1.0"
+    "ember-cli-htmlbars-inline-precompile": "^2.1.0",
+    "ember-cli-typescript": "^1.5.0"
   },
   "devDependencies": {
     "@ember/optional-features": "^0.7.0",
@@ -55,7 +56,6 @@
     "ember-cli-pretender": "^3.1.1",
     "ember-cli-shims": "^1.2.0",
     "ember-cli-test-loader": "^2.2.0",
-    "ember-cli-typescript": "^1.5.0",
     "ember-data": "~3.7.0",
     "ember-debug-handlers-polyfill": "^1.0.3",
     "ember-disable-prototype-extensions": "^1.1.3",


### PR DESCRIPTION
Right now, ember-cli-typescript is listed as a devDependency.

However, `index.js` [references it directly](https://github.com/emberjs/ember-test-helpers/blob/master/index.js#L38).

Because it is currently listed in devDependencies and not dependencies, npm/yarn won't ensure that `ember-test-helpers` gets it's own copy, leading to the above linked line failing in certain cases.

I seems rather difficult to expose this - I suspect it had something to do with multiple versions of ember-cli-typescript being present in a monorepo I was working on.