### PR TITLE
Only require ember-cli-typescript while developing

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ module.exports = {
     let input = debugTree(tree, 'addon-test-support:input');
 
     let compiler = this.project._incrementalTsCompiler;
-    if (compiler) {
+    if (this.isDevelopingAddon() && compiler) {
       // eslint-disable-next-line node/no-unpublished-require
       let TypescriptOutput = require('ember-cli-typescript/js/lib/incremental-typescript-compiler/typescript-output-plugin');
       // eslint-disable-next-line node/no-unpublished-require


### PR DESCRIPTION
See #604 for context.

Wasn't sure what the `_incrementalTsCompiler` flag was doing - it's not referenced anywhere else in the codebase, so I just removed the reference, but I can add it back if it needs to be something like:

```
if (this.isDevelopingAddon() && this.project._incrementalTsCompiler) {
```