### PR TITLE
Add `ember-test-waiters` and integrate into settledness checks

### DIFF
--- a/addon-test-support/@ember/test-helpers/-internal/debug-info.ts
+++ b/addon-test-support/@ember/test-helpers/-internal/debug-info.ts
@@ -6,6 +6,12 @@ import {
 } from '@ember/runloop';
 import { DebugInfoHelper, debugInfoHelpers } from './debug-info-helpers';
 import { assign } from '@ember/polyfills';
+// @ts-ignore
+import {
+  getPendingWaiterState,
+  IPendingWaiterState,
+  ITestWaiterDebugInfo,
+} from 'ember-test-waiters';
 
 const PENDING_AJAX_REQUESTS = 'Pending AJAX requests';
 const PENDING_TEST_WAITERS = 'Pending test waiters';
@@ -17,13 +23,16 @@ type MaybeDebugInfo = BackburnerDebugInfo | null;
 interface SettledState {
   hasPendingTimers: boolean;
   hasRunLoop: boolean;
-  hasPendingWaiters: boolean;
+  hasPendingLegacyWaiters: boolean;
+  hasPendingTestWaiters: boolean;
   hasPendingRequests: boolean;
 }
 
 interface SummaryInfo {
   hasPendingRequests: boolean;
-  hasPendingWaiters: boolean;
+  hasPendingLegacyWaiters: boolean;
+  hasPendingTestWaiters: boolean;
+  pendingTestWaiterInfo: IPendingWaiterState;
   autorunStackTrace: string | undefined | null;
   pendingTimersCount: number;
   hasPendingTimers: boolean;
@@ -79,14 +88,16 @@ export class TestDebugInfo implements DebugInfo {
   constructor(
     hasPendingTimers: boolean,
     hasRunLoop: boolean,
-    hasPendingWaiters: boolean,
+    hasPendingLegacyWaiters: boolean,
+    hasPendingTestWaiters: boolean,
     hasPendingRequests: boolean,
     debugInfo: MaybeDebugInfo = getDebugInfo()
   ) {
     this._settledState = {
       hasPendingTimers,
       hasRunLoop,
-      hasPendingWaiters,
+      hasPendingLegacyWaiters,
+      hasPendingTestWaiters,
       hasPendingRequests,
     };
 
@@ -127,6 +138,10 @@ export class TestDebugInfo implements DebugInfo {
             return stacks;
           }, []);
       }
+
+      if (this._summaryInfo.hasPendingTestWaiters) {
+        this._summaryInfo.pendingTestWaiterInfo = getPendingWaiterState();
+      }
     }
 
     return this._summaryInfo;
@@ -139,8 +154,28 @@ export class TestDebugInfo implements DebugInfo {
       _console.log(PENDING_AJAX_REQUESTS);
     }
 
-    if (summary.hasPendingWaiters) {
+    if (summary.hasPendingLegacyWaiters) {
       _console.log(PENDING_TEST_WAITERS);
+    }
+
+    if (summary.hasPendingTestWaiters) {
+      if (!summary.hasPendingLegacyWaiters) {
+        _console.log(PENDING_TEST_WAITERS);
+      }
+
+      Object.keys(summary.pendingTestWaiterInfo.waiters).forEach(waiter => {
+        _console.log(waiter);
+        // array of { stack: string, label: string }
+        let waiterDebugInfo = summary.pendingTestWaiterInfo.waiters[waiter];
+
+        if (Array.isArray(waiterDebugInfo)) {
+          waiterDebugInfo.forEach((debugInfo: ITestWaiterDebugInfo) => {
+            _console.log(`${debugInfo.label ? debugInfo.label : 'stack'}: ${debugInfo.stack}`);
+          });
+        } else {
+          _console.log(waiterDebugInfo);
+        }
+      });
     }
 
     if (summary.hasPendingTimers || summary.pendingScheduledQueueItemCount > 0) {

--- a/addon-test-support/@ember/test-helpers/-internal/debug-info.ts
+++ b/addon-test-support/@ember/test-helpers/-internal/debug-info.ts
@@ -163,17 +163,17 @@ export class TestDebugInfo implements DebugInfo {
         _console.log(PENDING_TEST_WAITERS);
       }
 
-      Object.keys(summary.pendingTestWaiterInfo.waiters).forEach(waiter => {
-        _console.log(waiter);
-
-        let waiterDebugInfo: WaiterDebugInfo = summary.pendingTestWaiterInfo.waiters[waiter];
+      Object.keys(summary.pendingTestWaiterInfo.waiters).forEach(waiterName => {
+        let waiterDebugInfo: WaiterDebugInfo = summary.pendingTestWaiterInfo.waiters[waiterName];
 
         if (Array.isArray(waiterDebugInfo)) {
+          _console.group(waiterName);
           waiterDebugInfo.forEach((debugInfo: ITestWaiterDebugInfo) => {
             _console.log(`${debugInfo.label ? debugInfo.label : 'stack'}: ${debugInfo.stack}`);
           });
+          _console.groupEnd();
         } else {
-          _console.log(waiterDebugInfo);
+          _console.log(waiterName);
         }
       });
     }

--- a/addon-test-support/@ember/test-helpers/-internal/debug-info.ts
+++ b/addon-test-support/@ember/test-helpers/-internal/debug-info.ts
@@ -18,6 +18,7 @@ const SCHEDULED_ASYNC = 'Scheduled async';
 const SCHEDULED_AUTORUN = 'Scheduled autorun';
 
 type MaybeDebugInfo = BackburnerDebugInfo | null;
+type WaiterDebugInfo = true | unknown[];
 
 interface SettledState {
   hasPendingTimers: boolean;
@@ -165,7 +166,7 @@ export class TestDebugInfo implements DebugInfo {
       Object.keys(summary.pendingTestWaiterInfo.waiters).forEach(waiter => {
         _console.log(waiter);
 
-        let waiterDebugInfo = summary.pendingTestWaiterInfo.waiters[waiter];
+        let waiterDebugInfo: WaiterDebugInfo = summary.pendingTestWaiterInfo.waiters[waiter];
 
         if (Array.isArray(waiterDebugInfo)) {
           waiterDebugInfo.forEach((debugInfo: ITestWaiterDebugInfo) => {

--- a/addon-test-support/@ember/test-helpers/-internal/debug-info.ts
+++ b/addon-test-support/@ember/test-helpers/-internal/debug-info.ts
@@ -6,7 +6,6 @@ import {
 } from '@ember/runloop';
 import { DebugInfoHelper, debugInfoHelpers } from './debug-info-helpers';
 import { assign } from '@ember/polyfills';
-// @ts-ignore
 import {
   getPendingWaiterState,
   IPendingWaiterState,

--- a/addon-test-support/@ember/test-helpers/-internal/debug-info.ts
+++ b/addon-test-support/@ember/test-helpers/-internal/debug-info.ts
@@ -164,7 +164,7 @@ export class TestDebugInfo implements DebugInfo {
 
       Object.keys(summary.pendingTestWaiterInfo.waiters).forEach(waiter => {
         _console.log(waiter);
-        // array of { stack: string, label: string }
+
         let waiterDebugInfo = summary.pendingTestWaiterInfo.waiters[waiter];
 
         if (Array.isArray(waiterDebugInfo)) {

--- a/addon-test-support/@ember/test-helpers/settled.ts
+++ b/addon-test-support/@ember/test-helpers/settled.ts
@@ -147,8 +147,7 @@ function checkWaiters() {
 export interface SettledState {
   hasRunLoop: boolean;
   hasPendingTimers: boolean;
-  hasPendingLegacyWaiters: boolean;
-  hasPendingTestWaiters: boolean;
+  hasPendingWaiters: boolean;
   hasPendingRequests: boolean;
   hasPendingTransitions: boolean | null;
   pendingRequestCount: number;
@@ -163,10 +162,7 @@ export interface SettledState {
   - `hasPendingTimers` - Checks if there are scheduled timers in the run-loop.
     These pending timers are primarily registered by `Ember.run.schedule`. If
     there are pending timers, this will be `true`, otherwise `false`.
-  - `hasPendingLegacyWaiters` - Checks if any registered legacy test waiters are still
-    pending (e.g. the waiter returns `true`). If there are pending waiters,
-    this will be `true`, otherwise `false`.
-  - `hasPendingTestWaiters` - Checks if any registered ember test waiters are still
+  - `hasPendingWaiters` - Checks if any registered test waiters are still
     pending (e.g. the waiter returns `true`). If there are pending waiters,
     this will be `true`, otherwise `false`.
   - `hasPendingRequests` - Checks if there are pending AJAX requests (based on
@@ -193,8 +189,7 @@ export function getSettledState(): SettledState {
   return {
     hasPendingTimers,
     hasRunLoop,
-    hasPendingLegacyWaiters,
-    hasPendingTestWaiters,
+    hasPendingWaiters: hasPendingLegacyWaiters || hasPendingTestWaiters,
     hasPendingRequests,
     hasPendingTransitions: hasPendingTransitions(),
     pendingRequestCount,
@@ -223,8 +218,7 @@ export function isSettled(): boolean {
     hasPendingTimers,
     hasRunLoop,
     hasPendingRequests,
-    hasPendingLegacyWaiters,
-    hasPendingTestWaiters,
+    hasPendingWaiters,
     hasPendingTransitions,
   } = getSettledState();
 
@@ -232,8 +226,7 @@ export function isSettled(): boolean {
     hasPendingTimers ||
     hasRunLoop ||
     hasPendingRequests ||
-    hasPendingLegacyWaiters ||
-    hasPendingTestWaiters ||
+    hasPendingWaiters ||
     hasPendingTransitions
   ) {
     return false;

--- a/addon-test-support/ember-test-helpers/wait.js
+++ b/addon-test-support/ember-test-helpers/wait.js
@@ -29,8 +29,7 @@ export default function wait(options = {}) {
         hasPendingTimers,
         hasRunLoop,
         hasPendingRequests,
-        hasPendingLegacyWaiters,
-        hasPendingTestWaiters,
+        hasPendingWaiters,
       } = getSettledState();
 
       if (waitForTimers && (hasPendingTimers || hasRunLoop)) {
@@ -41,7 +40,7 @@ export default function wait(options = {}) {
         return false;
       }
 
-      if (waitForWaiters && (hasPendingLegacyWaiters || hasPendingTestWaiters)) {
+      if (waitForWaiters && hasPendingWaiters) {
         return false;
       }
 

--- a/addon-test-support/ember-test-helpers/wait.js
+++ b/addon-test-support/ember-test-helpers/wait.js
@@ -29,7 +29,8 @@ export default function wait(options = {}) {
         hasPendingTimers,
         hasRunLoop,
         hasPendingRequests,
-        hasPendingWaiters,
+        hasPendingLegacyWaiters,
+        hasPendingTestWaiters,
       } = getSettledState();
 
       if (waitForTimers && (hasPendingTimers || hasRunLoop)) {
@@ -40,7 +41,7 @@ export default function wait(options = {}) {
         return false;
       }
 
-      if (waitForWaiters && hasPendingWaiters) {
+      if (waitForWaiters && (hasPendingLegacyWaiters || hasPendingTestWaiters)) {
         return false;
       }
 

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "broccoli-funnel": "^2.0.2",
     "ember-assign-polyfill": "^2.6.0",
     "ember-cli-babel": "^7.7.3",
-    "ember-cli-htmlbars-inline-precompile": "^2.1.0"
+    "ember-cli-htmlbars-inline-precompile": "^2.1.0",
+    "ember-test-waiters": "scalvert/ember-test-waiters#76c5bb14b4954ac8f6feb124288153721e54a919"
   },
   "devDependencies": {
     "@ember/optional-features": "^0.7.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "ember-assign-polyfill": "^2.6.0",
     "ember-cli-babel": "^7.7.3",
     "ember-cli-htmlbars-inline-precompile": "^2.1.0",
-    "ember-test-waiters": "scalvert/ember-test-waiters#76c5bb14b4954ac8f6feb124288153721e54a919"
+    "ember-test-waiters": "^0.9.0"
   },
   "devDependencies": {
     "@ember/optional-features": "^0.7.0",

--- a/tests/unit/settled-test.js
+++ b/tests/unit/settled-test.js
@@ -29,8 +29,7 @@ module('settled', function(hooks) {
             {
               hasPendingRequests: false,
               hasPendingTimers: false,
-              hasPendingLegacyWaiters: false,
-              hasPendingTestWaiters: false,
+              hasPendingWaiters: false,
               hasPendingTransitions: null,
               hasRunLoop: false,
               pendingRequestCount: 0,
@@ -177,8 +176,7 @@ module('settled', function(hooks) {
       assert.deepEqual(getSettledState(), {
         hasPendingRequests: false,
         hasPendingTimers: false,
-        hasPendingLegacyWaiters: false,
-        hasPendingTestWaiters: false,
+        hasPendingWaiters: false,
         hasPendingTransitions: null,
         hasRunLoop: false,
         pendingRequestCount: 0,
@@ -197,8 +195,7 @@ module('settled', function(hooks) {
       assert.deepEqual(getSettledState(), {
         hasPendingRequests: false,
         hasPendingTimers: true,
-        hasPendingLegacyWaiters: false,
-        hasPendingTestWaiters: false,
+        hasPendingWaiters: false,
         hasPendingTransitions: null,
         hasRunLoop: true,
         pendingRequestCount: 0,
@@ -218,8 +215,7 @@ module('settled', function(hooks) {
       assert.deepEqual(getSettledState(), {
         hasPendingRequests: false,
         hasPendingTimers: true,
-        hasPendingLegacyWaiters: false,
-        hasPendingTestWaiters: false,
+        hasPendingWaiters: false,
         hasPendingTransitions: null,
         hasRunLoop: false,
         pendingRequestCount: 0,
@@ -239,8 +235,7 @@ module('settled', function(hooks) {
       assert.deepEqual(getSettledState(), {
         hasPendingRequests: false,
         hasPendingTimers: true,
-        hasPendingLegacyWaiters: false,
-        hasPendingTestWaiters: false,
+        hasPendingWaiters: false,
         hasPendingTransitions: null,
         hasRunLoop: false,
         pendingRequestCount: 0,
@@ -257,8 +252,7 @@ module('settled', function(hooks) {
         assert.deepEqual(getSettledState(), {
           hasPendingRequests: false,
           hasPendingTimers: false,
-          hasPendingLegacyWaiters: false,
-          hasPendingTestWaiters: false,
+          hasPendingWaiters: false,
           hasPendingTransitions: null,
           hasRunLoop: true,
           pendingRequestCount: 0,
@@ -287,8 +281,7 @@ module('settled', function(hooks) {
         assert.deepEqual(getSettledState(), {
           hasPendingRequests: true,
           hasPendingTimers: false,
-          hasPendingLegacyWaiters: false,
-          hasPendingTestWaiters: false,
+          hasPendingWaiters: false,
           hasPendingTransitions: null,
           hasRunLoop: false,
           pendingRequestCount: 1,
@@ -298,8 +291,7 @@ module('settled', function(hooks) {
         assert.deepEqual(getSettledState(), {
           hasPendingRequests: false,
           hasPendingTimers: false,
-          hasPendingLegacyWaiters: true,
-          hasPendingTestWaiters: false,
+          hasPendingWaiters: true,
           hasPendingTransitions: null,
           hasRunLoop: false,
           pendingRequestCount: 0,
@@ -318,8 +310,7 @@ module('settled', function(hooks) {
       assert.deepEqual(getSettledState(), {
         hasPendingRequests: false,
         hasPendingTimers: false,
-        hasPendingLegacyWaiters: true,
-        hasPendingTestWaiters: false,
+        hasPendingWaiters: true,
         hasPendingTransitions: null,
         hasRunLoop: false,
         pendingRequestCount: 0,
@@ -343,8 +334,7 @@ module('settled', function(hooks) {
       assert.deepEqual(getSettledState(), {
         hasPendingRequests: false,
         hasPendingTimers: false,
-        hasPendingLegacyWaiters: false,
-        hasPendingTestWaiters: true,
+        hasPendingWaiters: true,
         hasPendingTransitions: null,
         hasRunLoop: false,
         pendingRequestCount: 0,
@@ -366,8 +356,7 @@ module('settled', function(hooks) {
       assert.deepEqual(getSettledState(), {
         hasPendingRequests: false,
         hasPendingTimers: false,
-        hasPendingLegacyWaiters: true,
-        hasPendingTestWaiters: false,
+        hasPendingWaiters: true,
         hasPendingTransitions: null,
         hasRunLoop: false,
         pendingRequestCount: 0,
@@ -378,8 +367,7 @@ module('settled', function(hooks) {
         assert.deepEqual(getSettledState(), {
           hasPendingRequests: false,
           hasPendingTimers: false,
-          hasPendingLegacyWaiters: true,
-          hasPendingTestWaiters: false,
+          hasPendingWaiters: true,
           hasPendingTransitions: null,
           hasRunLoop: true,
           pendingRequestCount: 0,
@@ -391,8 +379,7 @@ module('settled', function(hooks) {
         assert.deepEqual(getSettledState(), {
           hasPendingRequests: false,
           hasPendingTimers: true,
-          hasPendingLegacyWaiters: true,
-          hasPendingTestWaiters: false,
+          hasPendingWaiters: true,
           hasPendingTransitions: null,
           hasRunLoop: true,
           pendingRequestCount: 0,

--- a/tests/unit/utils/test-isolation-helpers.js
+++ b/tests/unit/utils/test-isolation-helpers.js
@@ -48,14 +48,16 @@ export function getMockDebugInfo(autorun = null, timersCount = 0, queues) {
 export function getMockSettledState(
   hasPendingTimers = false,
   hasRunLoop = false,
-  hasPendingWaiters = false,
+  hasPendingLegacyWaiters = false,
+  hasPendingTestWaiters = false,
   hasPendingRequests = false,
   pendingRequestCount = 0
 ) {
   return {
     hasPendingTimers,
     hasRunLoop,
-    hasPendingWaiters,
+    hasPendingLegacyWaiters,
+    hasPendingTestWaiters,
     hasPendingRequests,
     pendingRequestCount,
   };

--- a/yarn.lock
+++ b/yarn.lock
@@ -4548,6 +4548,12 @@ ember-source@~3.9.1:
     jquery "^3.3.1"
     resolve "^1.10.0"
 
+ember-test-waiters@scalvert/ember-test-waiters#76c5bb14b4954ac8f6feb124288153721e54a919:
+  version "0.0.0"
+  resolved "https://codeload.github.com/scalvert/ember-test-waiters/tar.gz/76c5bb14b4954ac8f6feb124288153721e54a919"
+  dependencies:
+    ember-cli-babel "^7.1.2"
+
 ember-try-config@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/ember-try-config/-/ember-try-config-3.0.0.tgz#012d8c90cae9eb624e2b62040bf7e76a1aa58edc"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4548,9 +4548,10 @@ ember-source@~3.9.1:
     jquery "^3.3.1"
     resolve "^1.10.0"
 
-ember-test-waiters@scalvert/ember-test-waiters#76c5bb14b4954ac8f6feb124288153721e54a919:
-  version "0.0.0"
-  resolved "https://codeload.github.com/scalvert/ember-test-waiters/tar.gz/76c5bb14b4954ac8f6feb124288153721e54a919"
+ember-test-waiters@^0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/ember-test-waiters/-/ember-test-waiters-0.9.0.tgz#601129bbf482dfd1b2615d1eef0316a886df0937"
+  integrity sha512-+8w4DbelsIW6jU1sZ+4V1knIvdhyYFOUxy/3aYhwbPObPdiNzWvW/D/xuAOTRAZqLsN6u47zAdh/Z7qVtb83pQ==
   dependencies:
     ember-cli-babel "^7.1.2"
 


### PR DESCRIPTION
This PR integrates the new [`ember-test-waiters`](https://github.com/rwjblue/ember-test-waiters) addon into the settled system. It utilizes the new system side-by-side with the legacy test waiters system. Specifically, the new test waiter system gives us

1. The ability to create named waiters
2. The ability to add debug information for when a waiter begins async tracking
3. Primitives that adopters can use to build their own more complicated waiters (though we expect 99% of users will just use the defaults)

This PR:

- [x] Adds the `ember-test-waiters` dependency
- [x] Updates `getSettledState` to include checking for the new test waiters pending state
- [x] Updates the `TestDebugInfo` class to include outputting pending waiter information when a pending waiter is detected
- [x] Updates all tests to include the new test waiters, and adds tests to include explicit checks for the new test waiters behavior.