### PR TITLE
refactor(DebugInfo): Changes DebugInfo constructor signature to POJO

### DIFF
--- a/addon-test-support/@ember/test-helpers/-internal/debug-info.ts
+++ b/addon-test-support/@ember/test-helpers/-internal/debug-info.ts
@@ -85,22 +85,8 @@ export class TestDebugInfo implements DebugInfo {
   private _debugInfo: MaybeDebugInfo;
   private _summaryInfo: SummaryInfo | undefined = undefined;
 
-  constructor(
-    hasPendingTimers: boolean,
-    hasRunLoop: boolean,
-    hasPendingLegacyWaiters: boolean,
-    hasPendingTestWaiters: boolean,
-    hasPendingRequests: boolean,
-    debugInfo: MaybeDebugInfo = getDebugInfo()
-  ) {
-    this._settledState = {
-      hasPendingTimers,
-      hasRunLoop,
-      hasPendingLegacyWaiters,
-      hasPendingTestWaiters,
-      hasPendingRequests,
-    };
-
+  constructor(settledState: SettledState, debugInfo: MaybeDebugInfo = getDebugInfo()) {
+    this._settledState = settledState;
     this._debugInfo = debugInfo;
   }
 

--- a/addon-test-support/@ember/test-helpers/settled.ts
+++ b/addon-test-support/@ember/test-helpers/settled.ts
@@ -193,13 +193,13 @@ export function getSettledState(): SettledState {
     hasPendingRequests,
     hasPendingTransitions: hasPendingTransitions(),
     pendingRequestCount,
-    debugInfo: new TestDebugInfo(
+    debugInfo: new TestDebugInfo({
       hasPendingTimers,
       hasRunLoop,
       hasPendingLegacyWaiters,
       hasPendingTestWaiters,
-      hasPendingRequests
-    ),
+      hasPendingRequests,
+    }),
   };
 }
 

--- a/tests/unit/settled-test.js
+++ b/tests/unit/settled-test.js
@@ -33,7 +33,13 @@ module('settled', function(hooks) {
               hasPendingTransitions: null,
               hasRunLoop: false,
               pendingRequestCount: 0,
-              debugInfo: new TestDebugInfo(false, false, false, false, false),
+              debugInfo: new TestDebugInfo({
+                hasPendingTimers: false,
+                hasRunLoop: false,
+                hasPendingLegacyWaiters: false,
+                hasPendingTestWaiters: false,
+                hasPendingRequests: false,
+              }),
             },
             'post cond - getSettledState'
           );
@@ -180,7 +186,13 @@ module('settled', function(hooks) {
         hasPendingTransitions: null,
         hasRunLoop: false,
         pendingRequestCount: 0,
-        debugInfo: new TestDebugInfo(false, false, false, false, false),
+        debugInfo: new TestDebugInfo({
+          hasPendingTimers: false,
+          hasRunLoop: false,
+          hasPendingLegacyWaiters: false,
+          hasPendingTestWaiters: false,
+          hasPendingRequests: false,
+        }),
       });
     });
 
@@ -199,7 +211,13 @@ module('settled', function(hooks) {
         hasPendingTransitions: null,
         hasRunLoop: true,
         pendingRequestCount: 0,
-        debugInfo: new TestDebugInfo(true, true, false, false, false),
+        debugInfo: new TestDebugInfo({
+          hasPendingTimers: true,
+          hasRunLoop: true,
+          hasPendingLegacyWaiters: false,
+          hasPendingTestWaiters: false,
+          hasPendingRequests: false,
+        }),
       });
     });
 
@@ -219,7 +237,13 @@ module('settled', function(hooks) {
         hasPendingTransitions: null,
         hasRunLoop: false,
         pendingRequestCount: 0,
-        debugInfo: new TestDebugInfo(true, false, false, false, false),
+        debugInfo: new TestDebugInfo({
+          hasPendingTimers: true,
+          hasRunLoop: false,
+          hasPendingLegacyWaiters: false,
+          hasPendingTestWaiters: false,
+          hasPendingRequests: false,
+        }),
       });
     });
 
@@ -239,7 +263,13 @@ module('settled', function(hooks) {
         hasPendingTransitions: null,
         hasRunLoop: false,
         pendingRequestCount: 0,
-        debugInfo: new TestDebugInfo(true, false, false, false, false),
+        debugInfo: new TestDebugInfo({
+          hasPendingTimers: true,
+          hasRunLoop: false,
+          hasPendingLegacyWaiters: false,
+          hasPendingTestWaiters: false,
+          hasPendingRequests: false,
+        }),
       });
     });
 
@@ -256,7 +286,13 @@ module('settled', function(hooks) {
           hasPendingTransitions: null,
           hasRunLoop: true,
           pendingRequestCount: 0,
-          debugInfo: new TestDebugInfo(false, true, false, false, false),
+          debugInfo: new TestDebugInfo({
+            hasPendingTimers: false,
+            hasRunLoop: true,
+            hasPendingLegacyWaiters: false,
+            hasPendingTestWaiters: false,
+            hasPendingRequests: false,
+          }),
         });
       });
 
@@ -285,7 +321,13 @@ module('settled', function(hooks) {
           hasPendingTransitions: null,
           hasRunLoop: false,
           pendingRequestCount: 1,
-          debugInfo: new TestDebugInfo(false, false, false, false, true),
+          debugInfo: new TestDebugInfo({
+            hasPendingTimers: false,
+            hasRunLoop: false,
+            hasPendingLegacyWaiters: false,
+            hasPendingTestWaiters: false,
+            hasPendingRequests: true,
+          }),
         });
       } else {
         assert.deepEqual(getSettledState(), {
@@ -295,7 +337,13 @@ module('settled', function(hooks) {
           hasPendingTransitions: null,
           hasRunLoop: false,
           pendingRequestCount: 0,
-          debugInfo: new TestDebugInfo(false, false, true, false, false),
+          debugInfo: new TestDebugInfo({
+            hasPendingTimers: false,
+            hasRunLoop: false,
+            hasPendingLegacyWaiters: true,
+            hasPendingTestWaiters: false,
+            hasPendingRequests: false,
+          }),
         });
       }
     });
@@ -314,7 +362,13 @@ module('settled', function(hooks) {
         hasPendingTransitions: null,
         hasRunLoop: false,
         pendingRequestCount: 0,
-        debugInfo: new TestDebugInfo(false, false, true, false, false),
+        debugInfo: new TestDebugInfo({
+          hasPendingTimers: false,
+          hasRunLoop: false,
+          hasPendingLegacyWaiters: true,
+          hasPendingTestWaiters: false,
+          hasPendingRequests: false,
+        }),
       });
 
       this.isWaiterPending = false;
@@ -338,7 +392,13 @@ module('settled', function(hooks) {
         hasPendingTransitions: null,
         hasRunLoop: false,
         pendingRequestCount: 0,
-        debugInfo: new TestDebugInfo(false, false, false, true, false),
+        debugInfo: new TestDebugInfo({
+          hasPendingTimers: false,
+          hasRunLoop: false,
+          hasPendingLegacyWaiters: false,
+          hasPendingTestWaiters: true,
+          hasPendingRequests: false,
+        }),
       });
 
       this._testWaiter.endAsync(waiterItem);
@@ -360,7 +420,13 @@ module('settled', function(hooks) {
         hasPendingTransitions: null,
         hasRunLoop: false,
         pendingRequestCount: 0,
-        debugInfo: new TestDebugInfo(false, false, true, false, false),
+        debugInfo: new TestDebugInfo({
+          hasPendingTimers: false,
+          hasRunLoop: false,
+          hasPendingLegacyWaiters: true,
+          hasPendingTestWaiters: false,
+          hasPendingRequests: false,
+        }),
       });
 
       run(() => {
@@ -371,7 +437,13 @@ module('settled', function(hooks) {
           hasPendingTransitions: null,
           hasRunLoop: true,
           pendingRequestCount: 0,
-          debugInfo: new TestDebugInfo(false, true, true, false, false),
+          debugInfo: new TestDebugInfo({
+            hasPendingTimers: false,
+            hasRunLoop: true,
+            hasPendingLegacyWaiters: true,
+            hasPendingTestWaiters: false,
+            hasPendingRequests: false,
+          }),
         });
 
         next(this.confirmSettles(done));
@@ -383,7 +455,13 @@ module('settled', function(hooks) {
           hasPendingTransitions: null,
           hasRunLoop: true,
           pendingRequestCount: 0,
-          debugInfo: new TestDebugInfo(true, true, true, false, false),
+          debugInfo: new TestDebugInfo({
+            hasPendingTimers: true,
+            hasRunLoop: true,
+            hasPendingLegacyWaiters: true,
+            hasPendingTestWaiters: false,
+            hasPendingRequests: false,
+          }),
         });
 
         this.isWaiterPending = false;

--- a/tests/unit/test-debug-info-test.js
+++ b/tests/unit/test-debug-info-test.js
@@ -27,13 +27,13 @@ module('TestDebugInfo', function(hooks) {
     let hasPendingTestWaiters = false;
     let hasRunLoop = getRandomBoolean();
     let hasPendingRequests = Boolean(Math.floor(Math.random(10)) > 0);
-    let testDebugInfo = new TestDebugInfo(
+    let testDebugInfo = new TestDebugInfo({
       hasPendingTimers,
       hasRunLoop,
       hasPendingLegacyWaiters,
       hasPendingTestWaiters,
-      hasPendingRequests
-    );
+      hasPendingRequests,
+    });
 
     assert.deepEqual(testDebugInfo.summary, {
       hasPendingRequests,
@@ -70,11 +70,13 @@ module('TestDebugInfo', function(hooks) {
         cancelIds.push(run.later(() => {}, 10000));
 
         let testDebugInfo = new TestDebugInfo(
-          false,
-          false,
-          false,
-          false,
-          false,
+          {
+            hasPendingTimers: false,
+            hasRunLoop: false,
+            hasPendingLegacyWaiters: false,
+            hasPendingTestWaiters: false,
+            hasPendingRequests: false,
+          },
           run.backburner.getDebugInfo()
         );
 
@@ -99,7 +101,13 @@ module('TestDebugInfo', function(hooks) {
 
     let mockConsole = new MockConsole();
 
-    let testDebugInfo = new TestDebugInfo(false, false, false, false, false);
+    let testDebugInfo = new TestDebugInfo({
+      hasPendingTimers: false,
+      hasRunLoop: false,
+      hasPendingLegacyWaiters: false,
+      hasPendingTestWaiters: false,
+      hasPendingRequests: false,
+    });
 
     testDebugInfo.toConsole(mockConsole);
 
@@ -112,11 +120,13 @@ module('TestDebugInfo', function(hooks) {
     let mockConsole = new MockConsole();
 
     let testDebugInfo = new TestDebugInfo(
-      false,
-      true,
-      false,
-      false,
-      false,
+      {
+        hasPendingTimers: false,
+        hasRunLoop: true,
+        hasPendingLegacyWaiters: false,
+        hasPendingTestWaiters: false,
+        hasPendingRequests: false,
+      },
       getMockDebugInfo(new MockStableError('STACK'), 0, null)
     );
 
@@ -134,7 +144,13 @@ STACK`
 
     let mockConsole = new MockConsole();
 
-    let testDebugInfo = new TestDebugInfo(false, false, false, false, true);
+    let testDebugInfo = new TestDebugInfo({
+      hasPendingTimers: false,
+      hasRunLoop: false,
+      hasPendingLegacyWaiters: false,
+      hasPendingTestWaiters: false,
+      hasPendingRequests: true,
+    });
 
     testDebugInfo.toConsole(mockConsole);
 
@@ -146,7 +162,13 @@ STACK`
 
     let mockConsole = new MockConsole();
 
-    let testDebugInfo = new TestDebugInfo(false, false, true, false, false);
+    let testDebugInfo = new TestDebugInfo({
+      hasPendingTimers: false,
+      hasRunLoop: false,
+      hasPendingLegacyWaiters: true,
+      hasPendingTestWaiters: false,
+      hasPendingRequests: false,
+    });
 
     testDebugInfo.toConsole(mockConsole);
 
@@ -164,7 +186,13 @@ STACK`
 
     testWaiter.beginAsync(waiterItem);
 
-    let testDebugInfo = new TestDebugInfo(false, false, false, true, false);
+    let testDebugInfo = new TestDebugInfo({
+      hasPendingTimers: false,
+      hasRunLoop: false,
+      hasPendingLegacyWaiters: false,
+      hasPendingTestWaiters: true,
+      hasPendingRequests: false,
+    });
 
     testDebugInfo.toConsole(mockConsole);
 
@@ -185,11 +213,13 @@ stack: STACK`
     let mockConsole = new MockConsole();
 
     let testDebugInfo = new TestDebugInfo(
-      true,
-      true,
-      false,
-      false,
-      false,
+      {
+        hasPendingTimers: true,
+        hasRunLoop: true,
+        hasPendingLegacyWaiters: false,
+        hasPendingTestWaiters: false,
+        hasPendingRequests: false,
+      },
       getMockDebugInfo(false, 2, [{ name: 'one', count: 1 }, { name: 'two', count: 1 }])
     );
 
@@ -211,11 +241,13 @@ STACK`
     let mockConsole = new MockConsole();
 
     let testDebugInfo = new TestDebugInfo(
-      false,
-      false,
-      false,
-      false,
-      false,
+      {
+        hasPendingTimers: false,
+        hasRunLoop: false,
+        hasPendingLegacyWaiters: false,
+        hasPendingTestWaiters: false,
+        hasPendingRequests: false,
+      },
       getMockDebugInfo(false, 0, [{ name: 'one', count: 1 }, { name: 'two', count: 1 }])
     );
 
@@ -252,7 +284,13 @@ STACK`
 
     registerDebugInfoHelper(debugInfoHelper);
 
-    let testDebugInfo = new TestDebugInfo(false, false, false, false);
+    let testDebugInfo = new TestDebugInfo({
+      hasPendingTimers: false,
+      hasRunLoop: false,
+      hasPendingLegacyWaiters: false,
+      hasPendingTestWaiters: false,
+      hasPendingRequests: false,
+    });
 
     testDebugInfo.toConsole(mockConsole);
 


### PR DESCRIPTION
The signature of the `DebugInfo` constructor used to take a series of booleans. This type of signature becomes very hard to use and read, as a succession of `true`/`false` parameters doesn't help the reader understand what's required.

This PR addresses this by converting the signature to take a POJO, in this case of type `SettledState`.