### PR TITLE
bugfix - fillIn now reflects disabled attribute #680

### DIFF
--- a/addon-test-support/@ember/test-helpers/dom/fill-in.ts
+++ b/addon-test-support/@ember/test-helpers/dom/fill-in.ts
@@ -42,6 +42,10 @@ export default function fillIn(target: Target, text: string): Promise<void> {
       throw new Error('Must provide `text` when calling `fillIn`.');
     }
 
+    if (element.disabled) {
+      throw new Error('Selected element is disabled')
+    }
+
     __focus__(element);
 
     if (isControl) {

--- a/tests/unit/dom/fill-in-test.js
+++ b/tests/unit/dom/fill-in-test.js
@@ -44,6 +44,17 @@ module('DOM Helper: fillIn', function(hooks) {
     );
   });
 
+  test('filling in a disabled element', async function(assert) {
+    element = buildInstrumentedElement('input');
+    element.setAttribute('disabled', '')
+
+    await setupContext(context);
+    assert.rejects(
+      fillIn(`#${element.id}`, 'foo'),
+      /Selected element is disabled/
+    );
+  });
+
   test('rejects if selector is not found', async function(assert) {
     element = buildInstrumentedElement('div');
 


### PR DESCRIPTION
See #680 for a minimal reproduction and explanation of the bug.

Changed
- if you try to fillIn a disabled input, it throws an error "Selected element is disabled"

Added:
- a test for the new behavior