### PR TITLE
Default `click` and `doubleClick` to be left button clicks.

### DIFF
--- a/addon-test-support/@ember/test-helpers/dom/click.ts
+++ b/addon-test-support/@ember/test-helpers/dom/click.ts
@@ -1,3 +1,4 @@
+import { assign } from '@ember/polyfills';
 import getElement from './-get-element';
 import fireEvent from './fire-event';
 import { __focus__ } from './focus';
@@ -8,10 +9,22 @@ import isFormControl from './-is-form-control';
 import Target from './-target';
 import { log } from '@ember/test-helpers/dom/-logging';
 
+const PRIMARY_BUTTON = 1;
+const MAIN_BUTTON_PRESSED = 0;
+
+/**
+ * Represent a particular mouse button being clicked.
+ * See https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/buttons for available options.
+ */
+export const DEFAULT_CLICK_OPTIONS = {
+  buttons: PRIMARY_BUTTON,
+  button: MAIN_BUTTON_PRESSED,
+};
+
 /**
   @private
   @param {Element} element the element to click on
-  @param {Object} options the options to be merged into the mouse events
+  @param {MouseEventInit} options the options to be merged into the mouse events
 */
 export function __click__(element: Element | Document, options: MouseEventInit): void {
   fireEvent(element, 'mousedown', options);
@@ -53,7 +66,7 @@ export function __click__(element: Element | Document, options: MouseEventInit):
 
   @public
   @param {string|Element} target the element or selector to click on
-  @param {Object} options the options to be merged into the mouse events
+  @param {MouseEventInit} _options the options to be merged into the mouse events.
   @return {Promise<void>} resolves when settled
 
   @example
@@ -69,8 +82,10 @@ export function __click__(element: Element | Document, options: MouseEventInit):
 
   click('button', { shiftKey: true });
 */
-export default function click(target: Target, options: MouseEventInit = {}): Promise<void> {
+export default function click(target: Target, _options: MouseEventInit = {}): Promise<void> {
   log('click', target);
+
+  let options = assign({}, DEFAULT_CLICK_OPTIONS, _options);
 
   return nextTickPromise().then(() => {
     if (!target) {

--- a/addon-test-support/@ember/test-helpers/dom/double-click.ts
+++ b/addon-test-support/@ember/test-helpers/dom/double-click.ts
@@ -1,9 +1,11 @@
+import { assign } from '@ember/polyfills';
 import getElement from './-get-element';
 import fireEvent from './fire-event';
 import { __focus__ } from './focus';
 import settled from '../settled';
 import isFocusable from './-is-focusable';
 import { nextTickPromise } from '../-utils';
+import { DEFAULT_CLICK_OPTIONS } from './click';
 import Target from './-target';
 import { log } from '@ember/test-helpers/dom/-logging';
 import isFormControl from './-is-form-control';
@@ -11,7 +13,7 @@ import isFormControl from './-is-form-control';
 /**
   @private
   @param {Element} element the element to double-click on
-  @param {Object} options the options to be merged into the mouse events
+  @param {MouseEventInit} options the options to be merged into the mouse events
 */
 export function __doubleClick__(element: Element | Document, options: MouseEventInit): void {
   fireEvent(element, 'mousedown', options);
@@ -64,7 +66,7 @@ export function __doubleClick__(element: Element | Document, options: MouseEvent
 
   @public
   @param {string|Element} target the element or selector to double-click on
-  @param {Object} options the options to be merged into the mouse events
+  @param {MouseEventInit} _options the options to be merged into the mouse events
   @return {Promise<void>} resolves when settled
 
   @example
@@ -81,8 +83,10 @@ export function __doubleClick__(element: Element | Document, options: MouseEvent
 
   doubleClick('button', { shiftKey: true });
 */
-export default function doubleClick(target: Target, options: MouseEventInit = {}): Promise<void> {
+export default function doubleClick(target: Target, _options: MouseEventInit = {}): Promise<void> {
   log('doubleClick', target);
+
+  let options = assign({}, DEFAULT_CLICK_OPTIONS, _options);
 
   return nextTickPromise().then(() => {
     if (!target) {

--- a/tests/unit/dom/click-test.js
+++ b/tests/unit/dom/click-test.js
@@ -96,12 +96,20 @@ module('DOM Helper: click', function (hooks) {
       assert.verifySteps(['mousedown', 'mouseup', 'click']);
     });
 
-    test('clicking passes options through to mouse events', async function (assert) {
-      element = buildInstrumentedElement('div', ['clientX', 'clientY', 'button']);
+    test('clicking passes default options through to mouse events', async function (assert) {
+      element = buildInstrumentedElement('div', ['buttons', 'button']);
+
+      await click(element);
+
+      assert.verifySteps(['mousedown 1 0', 'mouseup 1 0', 'click 1 0']);
+    });
+
+    test('clicking passes options through to mouse events and merges with default options', async function (assert) {
+      element = buildInstrumentedElement('div', ['clientX', 'clientY', 'button', 'buttons']);
 
       await click(element, { clientX: 13, clientY: 17, button: 2 });
 
-      assert.verifySteps(['mousedown 13 17 2', 'mouseup 13 17 2', 'click 13 17 2']);
+      assert.verifySteps(['mousedown 13 17 2 1', 'mouseup 13 17 2 1', 'click 13 17 2 1']);
     });
 
     test('clicking accepts modifiers', async function (assert) {

--- a/tests/unit/dom/double-click-test.js
+++ b/tests/unit/dom/double-click-test.js
@@ -130,19 +130,35 @@ module('DOM Helper: doubleClick', function (hooks) {
       );
     });
 
-    test('double-clicking passes options through to mouse events', async function (assert) {
-      element = buildInstrumentedElement('div', ['clientX', 'clientY', 'button']);
+    test('double-clicking passes default options through to mouse events', async function (assert) {
+      element = buildInstrumentedElement('div', ['button', 'buttons']);
+
+      await doubleClick(element);
+
+      assert.verifySteps([
+        'mousedown 0 1',
+        'mouseup 0 1',
+        'click 0 1',
+        'mousedown 0 1',
+        'mouseup 0 1',
+        'click 0 1',
+        'dblclick 0 1',
+      ]);
+    });
+
+    test('double-clicking passes options through to mouse events and merges with default options', async function (assert) {
+      element = buildInstrumentedElement('div', ['clientX', 'clientY', 'button', 'buttons']);
 
       await doubleClick(element, { clientX: 13, clientY: 17, button: 1 });
 
       assert.verifySteps([
-        'mousedown 13 17 1',
-        'mouseup 13 17 1',
-        'click 13 17 1',
-        'mousedown 13 17 1',
-        'mouseup 13 17 1',
-        'click 13 17 1',
-        'dblclick 13 17 1',
+        'mousedown 13 17 1 1',
+        'mouseup 13 17 1 1',
+        'click 13 17 1 1',
+        'mousedown 13 17 1 1',
+        'mouseup 13 17 1 1',
+        'click 13 17 1 1',
+        'dblclick 13 17 1 1',
       ]);
     });
   });


### PR DESCRIPTION
Prior to this change, neither click nor double-click helpers were passing the `button` and `buttons` mouseEvent options necessary to emit a left click. I recently ran into an issue as a library I'm using was specifically looking for 'left' clicks and it dawned on me that this should likely be the default behavior for these helpers.

Question for public / repo owners: It's possible, albeit rather unlikely, that this is a breaking change for some people. I'm open to feedback regarding the best way to handle this change so that it does not negatively impact users of this addon.