### PR TITLE
The typeIn helper should not wait for settled promises between inputs

### DIFF
--- a/addon-test-support/@ember/test-helpers/dom/trigger-key-event.ts
+++ b/addon-test-support/@ember/test-helpers/dom/trigger-key-event.ts
@@ -2,6 +2,7 @@ import { assign } from '@ember/polyfills';
 import getElement from './-get-element';
 import fireEvent from './fire-event';
 import settled from '../settled';
+import { resolve } from 'rsvp';
 import { KEYBOARD_EVENT_TYPES, KeyboardEventType, isKeyboardEventType } from './fire-event';
 import { nextTickPromise, isNumeric } from '../-utils';
 import Target from './-target';
@@ -128,7 +129,8 @@ function keyCodeFromKey(key: string) {
   @param {boolean} [modifiers.altKey=false] if true the generated event will indicate the alt key was pressed during the key event
   @param {boolean} [modifiers.shiftKey=false] if true the generated event will indicate the shift key was pressed during the key event
   @param {boolean} [modifiers.metaKey=false] if true the generated event will indicate the meta key was pressed during the key event
-  @return {Promise<void>} resolves when the application is settled
+  @param {boolean} awaitSettled if true the event will wait for promises to settle by returning settled()
+  @return {Promise<void>} resolves when the application is settled unless awaitSettled is false
 
   @example
   <caption>
@@ -140,7 +142,8 @@ export default function triggerKeyEvent(
   target: Target,
   eventType: KeyboardEventType,
   key: number | string,
-  modifiers: KeyModifiers = DEFAULT_MODIFIERS
+  modifiers: KeyModifiers = DEFAULT_MODIFIERS,
+  awaitSettled: boolean = true
 ): Promise<void> {
   return nextTickPromise().then(() => {
     if (!target) {
@@ -189,7 +192,10 @@ export default function triggerKeyEvent(
     let options = assign(props, modifiers);
 
     fireEvent(element, eventType, options);
-
-    return settled();
+    if (awaitSettled) {
+      return settled();
+    } else {
+      return resolve();
+    }
   });
 }

--- a/addon-test-support/@ember/test-helpers/dom/type-in.ts
+++ b/addon-test-support/@ember/test-helpers/dom/type-in.ts
@@ -29,12 +29,12 @@ export interface Options {
  * @param {string} text the test to fill the element with
  * @param {Object} options {delay: x} (default 50) number of milliseconds to wait per keypress
  * @return {Promise<void>} resolves when the application is settled
- * 
+ *
  * @example
  * <caption>
  *   Emulating typing in an input using `typeIn`
  * </caption>
- * 
+ *
  * typeIn('hello world');
  */
 export default function typeIn(target: Target, text: string, options: Options = {}): Promise<void> {
@@ -82,13 +82,13 @@ function keyEntry(element: FormControl, character: string): () => void {
   let characterKey = character.toUpperCase();
 
   return function() {
-    return triggerKeyEvent(element, 'keydown', characterKey, options)
-      .then(() => triggerKeyEvent(element, 'keypress', characterKey, options))
+    return triggerKeyEvent(element, 'keydown', characterKey, options, false)
+      .then(() => triggerKeyEvent(element, 'keypress', characterKey, options, false))
       .then(() => {
         element.value = element.value + character;
         fireEvent(element, 'input');
       })
-      .then(() => triggerKeyEvent(element, 'keyup', characterKey, options));
+      .then(() => triggerKeyEvent(element, 'keyup', characterKey, options, false));
   };
 }
 

--- a/addon-test-support/@ember/test-helpers/dom/type-in.ts
+++ b/addon-test-support/@ember/test-helpers/dom/type-in.ts
@@ -7,7 +7,7 @@ import isFocusable from './-is-focusable';
 import { Promise } from 'rsvp';
 import fireEvent from './fire-event';
 import Target from './-target';
-import triggerKeyEvent from './trigger-key-event';
+import { __triggerKeyEvent__ } from './trigger-key-event';
 
 export interface Options {
   delay?: number;
@@ -82,13 +82,14 @@ function keyEntry(element: FormControl, character: string): () => void {
   let characterKey = character.toUpperCase();
 
   return function() {
-    return triggerKeyEvent(element, 'keydown', characterKey, options, false)
-      .then(() => triggerKeyEvent(element, 'keypress', characterKey, options, false))
+    return nextTickPromise()
+      .then(() => __triggerKeyEvent__(element, 'keydown', characterKey, options))
+      .then(() => __triggerKeyEvent__(element, 'keypress', characterKey, options))
       .then(() => {
         element.value = element.value + character;
         fireEvent(element, 'input');
       })
-      .then(() => triggerKeyEvent(element, 'keyup', characterKey, options, false));
+      .then(() => __triggerKeyEvent__(element, 'keyup', characterKey, options));
   };
 }
 


### PR DESCRIPTION
The current behavior of the `typeIn` helper waits for settled promises between text inputs/key events. This is not ideal because it prevents the helper from being used for testing things like debounced functions (like in a typeahead component for instance).

[Here is a repro repo demonstrating the issue.](https://github.com/jakebixbyavalara/concurrency-debounce-repro), I originally encountered the behavior using an `ember-concurrency` `timeout` to debounce a task, which worked fine in the app, but began failing in test due to the change to the `triggerKeyEvent` helper.

This PR fixes the issue by making the `triggerKeyEvent` helper optionally wait for settled promises via a boolean. It's a simple fix that may be overlooking something, so please let me know if there would be a more preferred solution.

_Initial PR text (when it was just a failing test PR):_
> Previous to [this PR](https://github.com/emberjs/ember-test-helpers/pull/465), the `typeIn` helper would not wait for settled promises, allowing the helper to work with things like `run.debounce` or ember-concurrency `timeout` in test. Now the helper waits for any unsettled promises to settle between input because it now uses the `triggerKeyEvent ` (which waits for settled promises).

> Added failing test for typeIn waiting for other promises, and will try and take a crack at fixing it as well. I mainly wanted to put this PR up for eyes and advice if I hit any walls.