### PR TITLE
task(config): Removes `--disable-gpu` flag

### DIFF
--- a/testem.js
+++ b/testem.js
@@ -10,7 +10,6 @@ module.exports = {
         // --no-sandbox is needed when running Chrome inside a container
         process.env.CI ? '--no-sandbox' : null,
         '--headless',
-        '--disable-gpu',
         '--disable-dev-shm-usage',
         '--disable-software-rasterizer',
         '--mute-audio',


### PR DESCRIPTION
Chrome ~77 will crash with the `--disable-gpu` flag present. This PR removes it.