### PR TITLE
Pin engine.io subdependency to avoid issues on Node 6.

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,8 @@
     "typescript-eslint-parser": "^22.0.0"
   },
   "resolutions": {
-    "@types/handlebars": "npm:handlebars@^4.1.0"
+    "@types/handlebars": "npm:handlebars@^4.1.0",
+    "**/engine.io": "~3.3.0"
   },
   "engines": {
     "node": "6.* || 8.* || >= 10.*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4843,7 +4843,7 @@ engine.io-parser@~2.1.0, engine.io-parser@~2.1.1:
     blob "0.0.5"
     has-binary2 "~1.0.2"
 
-engine.io@~3.3.1:
+engine.io@~3.3.0, engine.io@~3.3.1:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/engine.io/-/engine.io-3.3.2.tgz#18cbc8b6f36e9461c5c0f81df2b830de16058a59"
   integrity sha512-AsaA9KG7cWPXWHp5FvHdDWY3AMWeZ8x+2pUVLcn71qE5AtAzgGbxuclOytygskw8XGmiQafTmnI9Bix3uihu2w==


### PR DESCRIPTION
Reported upstream in https://github.com/socketio/engine.io/issues/589.