### PR TITLE
Reset scroll state on render

### DIFF
--- a/addon-test-support/@ember/test-helpers/setup-rendering-context.ts
+++ b/addon-test-support/@ember/test-helpers/setup-rendering-context.ts
@@ -144,6 +144,8 @@ export function render(template: TemplateFactory): Promise<void> {
     };
     toplevelView.setOutletState(outletState);
 
+    resetScrollState();
+
     // returning settled here because the actual rendering does not happen until
     // the renderer detects it is dirty (which happens on backburner's end
     // hook), see the following implementation details:
@@ -152,6 +154,17 @@ export function render(template: TemplateFactory): Promise<void> {
     // * [backburner's custom end hook](https://github.com/emberjs/ember.js/blob/f94a4b6aef5b41b96ef2e481f35e07608df01440/packages/ember-glimmer/lib/renderer.js#L145-L159) detects that the current revision of the root is no longer the latest, and triggers a new rendering transaction
     return settled();
   });
+}
+
+/**
+  Resets the scroll position of testing container.
+
+  @private
+  @returns void
+*/
+function resetScrollState(): void {
+  const testingContainer = getRootElement().parentElement as Element;
+  testingContainer.scrollTo(0, 0);
 }
 
 /**

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -45,5 +45,7 @@ module.exports = function(defaults) {
   app.import('vendor/shims/qunit.js', { type: 'test' });
   app.import('vendor/promise-polyfill.js', { type: 'test' });
 
+  app.import('vendor/test-container-styles.css', { type: 'test' });
+
   return app.toTree();
 };

--- a/tests/integration/setup-rendering-context-test.js
+++ b/tests/integration/setup-rendering-context-test.js
@@ -9,7 +9,10 @@ import {
   teardownRenderingContext,
   waitFor,
   render,
+  clearRender,
   click,
+  find,
+  getRootElement,
 } from '@ember/test-helpers';
 
 import hasEmberVersion from '@ember/test-helpers/has-ember-version';
@@ -171,4 +174,53 @@ module('setupRenderingContext "real world"', function(hooks) {
       });
     }
   }
+
+  test('it renders testing container and resets scroll state', async function(assert) {
+    function getScrollPosition(element) {
+      return {
+        scrollTop: parseInt(element.scrollTop),
+        scrollLeft: parseInt(element.scrollLeft),
+      };
+    }
+
+    var scrollPosition,
+      scrollTarget,
+      emberTestingContainer = getRootElement().parentElement;
+
+    await render(hbs`
+    {{#each (array 1 2 3 4 5 6 7) as |element|}}
+      <div id="box{{element}}"style="height:400px;background:#333;margin-bottom:10px;">
+        <p style="font-size:30px;color:#fff">{{element}}</p>
+      </div>
+    {{/each}}
+    `);
+
+    scrollPosition = getScrollPosition(emberTestingContainer);
+
+    assert.equal(scrollPosition.scrollLeft, 0, 'scrollLeft position is 0 after first render');
+    assert.equal(scrollPosition.scrollTop, 0, 'scrollTop position is 0 after first render');
+
+    scrollTarget = find('#box7');
+
+    scrollTarget.scrollIntoView();
+
+    scrollPosition = getScrollPosition(emberTestingContainer);
+
+    assert.equal(
+      scrollPosition.scrollTop,
+      1141,
+      'container scrollTop position is 1141 after scrolling element into view'
+    );
+
+    clearRender();
+
+    await render(hbs`
+      <div></div>
+    `);
+
+    scrollPosition = getScrollPosition(emberTestingContainer);
+
+    assert.equal(scrollPosition.scrollLeft, 0, 'scrollLeft position is 0 after second render');
+    assert.equal(scrollPosition.scrollTop, 0, 'scrollTop position is 0 after second render');
+  });
 });

--- a/vendor/test-container-styles.css
+++ b/vendor/test-container-styles.css
@@ -1,0 +1,46 @@
+/*!
+ * From Ember-Qunit
+ * https://github.com/emberjs/ember-qunit/blob/master/vendor/ember-qunit/test-container-styles.css
+ *
+ * Commit:
+ * https://github.com/emberjs/ember-qunit/commit/34a5ca6903982eaab3be6ecca56c20f8376bf3ea
+ *
+ */
+
+#ember-testing-container {
+  position: relative;
+  background: white;
+  bottom: 0;
+  right: 0;
+  width: 640px;
+  height: 384px;
+  overflow: auto;
+  z-index: 98;
+  border: 1px solid #ccc;
+  margin: 0 auto;
+
+  /* Prevent leaking position fixed elements outside the testing container */
+  transform: translateZ(0);
+}
+
+#ember-testing-container.full-screen {
+  width: 100%;
+  height: 100%;
+  overflow: auto;
+  z-index: 98;
+  border: none;
+}
+
+#ember-testing {
+  width: 200%;
+  height: 200%;
+  transform: scale(0.5);
+  transform-origin: top left;
+}
+
+.full-screen #ember-testing {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  transform: scale(1);
+}


### PR DESCRIPTION
Ensures`div#ember-testing-container` scrollTop and scrollLeft are zero on render. 

Fixes https://github.com/emberjs/ember-test-helpers/issues/729, where scrolling during a testA will persist to testB and thus make the tests brittle.

+Adds ember-qunit CSS so we can properly test the container.

Feedback/Changes welcome!