### PR TITLE
Drop support for Node 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 ---
 language: node_js
 node_js:
-  - '6'
+  - '8'
 
 branches:
   only:

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "**/engine.io": "~3.3.0"
   },
   "engines": {
-    "node": "6.* || 8.* || >= 10.*"
+    "node": "8.* || >= 10.*"
   },
   "publishConfig": {
     "access": "public",


### PR DESCRIPTION
because it has reached its EOL quite a while ago, and because it will unblock several dependency updates