### PR TITLE
Add examples to `waitUntil` and `waitFor`

### DIFF
--- a/API.md
+++ b/API.md
@@ -503,7 +503,7 @@ interim DOM states (e.g. loading states, pending promises, etc).
 
 #### Examples
 
-Waiting until a selector is rendered
+Waiting until a selector is rendered:
 
 
 ```javascript
@@ -528,7 +528,7 @@ while _not_ settled (e.g. "loading" or "pending" states).
 
 #### Examples
 
-Waiting until a selected element displays text
+Waiting until a selected element displays text:
 
 
 ```javascript

--- a/API.md
+++ b/API.md
@@ -503,6 +503,12 @@ interim DOM states (e.g. loading states, pending promises, etc).
 
 Returns **[Promise][54]&lt;([Element][53] \| [Array][64]&lt;[Element][53]>)>** resolves when the element(s) appear on the page
 
+#### Examples
+
+```javascript
+await waitFor('.my-selector', { timeout: 2000 })
+```
+
 ### waitUntil
 
 Wait for the provided callback to return a truthy value.
@@ -518,6 +524,14 @@ while _not_ settled (e.g. "loading" or "pending" states).
     -   `options.timeoutMessage` **[string][52]** the message to use in the reject on timeout (optional, default `'waitUntil timed out'`)
 
 Returns **[Promise][54]** resolves with the callback value when it returns a truthy value
+
+#### Examples
+
+```javascript
+await waitUntil(function() {
+   return find('.my-selector').textContent.includes('something')
+}, { timeout: 2000 })
+```
 
 ### settled
 

--- a/API.md
+++ b/API.md
@@ -371,7 +371,7 @@ Emulating pressing the `ENTER` key on a button using `triggerKeyEvent`
 triggerKeyEvent('button', 'keydown', 'Enter');
 ```
 
-Returns **[Promise][54]&lt;void>** resolves when the application is settled
+Returns **[Promise][54]&lt;void>** resolves when the application is settled unless awaitSettled is false
 
 ### typeIn
 
@@ -501,13 +501,16 @@ interim DOM states (e.g. loading states, pending promises, etc).
     -   `options.timeout` **[number][62]** the time to wait (in ms) for a match (optional, default `1000`)
     -   `options.count` **[number][62]** the number of elements that should match the provided selector (null means one or more) (optional, default `null`)
 
-Returns **[Promise][54]&lt;([Element][53] \| [Array][64]&lt;[Element][53]>)>** resolves when the element(s) appear on the page
-
 #### Examples
+
+Waiting until a selector is rendered
+
 
 ```javascript
 await waitFor('.my-selector', { timeout: 2000 })
 ```
+
+Returns **[Promise][54]&lt;([Element][53] \| [Array][64]&lt;[Element][53]>)>** resolves when the element(s) appear on the page
 
 ### waitUntil
 
@@ -523,15 +526,18 @@ while _not_ settled (e.g. "loading" or "pending" states).
     -   `options.timeout` **[number][62]** the maximum amount of time to wait (optional, default `1000`)
     -   `options.timeoutMessage` **[string][52]** the message to use in the reject on timeout (optional, default `'waitUntil timed out'`)
 
-Returns **[Promise][54]** resolves with the callback value when it returns a truthy value
-
 #### Examples
+
+Waiting until a selected element displays text
+
 
 ```javascript
 await waitUntil(function() {
-   return find('.my-selector').textContent.includes('something')
+return find('.my-selector').textContent.includes('something')
 }, { timeout: 2000 })
 ```
+
+Returns **[Promise][54]** resolves with the callback value when it returns a truthy value
 
 ### settled
 

--- a/addon-test-support/@ember/test-helpers/dom/wait-for.ts
+++ b/addon-test-support/@ember/test-helpers/dom/wait-for.ts
@@ -23,9 +23,8 @@ export interface Options {
 
   @example
   <caption>
-    Waiting until a selector is rendered
+    Waiting until a selector is rendered:
   </caption>
-
   await waitFor('.my-selector', { timeout: 2000 })
 */
 export default function waitFor(

--- a/addon-test-support/@ember/test-helpers/dom/wait-for.ts
+++ b/addon-test-support/@ember/test-helpers/dom/wait-for.ts
@@ -20,6 +20,13 @@ export interface Options {
   @param {number} [options.timeout=1000] the time to wait (in ms) for a match
   @param {number} [options.count=null] the number of elements that should match the provided selector (null means one or more)
   @return {Promise<Element|Element[]>} resolves when the element(s) appear on the page
+
+  @example
+  <caption>
+    Waiting until a selector is rendered
+  </caption>
+
+  await waitFor('.my-selector', { timeout: 2000 })
 */
 export default function waitFor(
   selector: string,

--- a/addon-test-support/@ember/test-helpers/wait-until.ts
+++ b/addon-test-support/@ember/test-helpers/wait-until.ts
@@ -22,6 +22,15 @@ export interface Options {
   @param {number} [options.timeout=1000] the maximum amount of time to wait
   @param {string} [options.timeoutMessage='waitUntil timed out'] the message to use in the reject on timeout
   @returns {Promise} resolves with the callback value when it returns a truthy value
+
+  @example
+  <caption>
+    Waiting until a selected element displays text
+  </caption>
+
+  await waitUntil(function() {
+    return find('.my-selector').textContent.includes('something')
+  }, { timeout: 2000 })
 */
 export default function waitUntil<T>(
   callback: () => T | void | Falsy,

--- a/addon-test-support/@ember/test-helpers/wait-until.ts
+++ b/addon-test-support/@ember/test-helpers/wait-until.ts
@@ -25,9 +25,8 @@ export interface Options {
 
   @example
   <caption>
-    Waiting until a selected element displays text
+    Waiting until a selected element displays text:
   </caption>
-
   await waitUntil(function() {
     return find('.my-selector').textContent.includes('something')
   }, { timeout: 2000 })


### PR DESCRIPTION
I personally need this reminder. I keep forgetting to await and return things.