### PR TITLE
fix `typeIn` documentation example

### DIFF
--- a/addon-test-support/@ember/test-helpers/dom/type-in.ts
+++ b/addon-test-support/@ember/test-helpers/dom/type-in.ts
@@ -36,7 +36,7 @@ export interface Options {
  *   Emulating typing in an input using `typeIn`
  * </caption>
  *
- * typeIn('hello world');
+ * typeIn('input', 'hello world');
  */
 export default function typeIn(target: Target, text: string, options: Options = {}): Promise<void> {
   log('typeIn', target, text);


### PR DESCRIPTION
the example was missing the selector string

replaces https://github.com/emberjs/ember-test-helpers/pull/742