### PR TITLE
Tab

### DIFF
--- a/addon-test-support/@ember/test-helpers/dom/-create-tree-walker.ts
+++ b/addon-test-support/@ember/test-helpers/dom/-create-tree-walker.ts
@@ -1,0 +1,28 @@
+let workaroundForIE11: boolean;
+
+try {
+  document.createTreeWalker(document, NodeFilter.SHOW_ELEMENT);
+  workaroundForIE11 = false;
+} catch (error) {
+  workaroundForIE11 = true;
+}
+
+export function createTreeWalker(
+  root: Element,
+  whatToShow: number,
+  filter: NodeFilter,
+  entityReferenceExpansion?: boolean
+): TreeWalker {
+  let ownerDocument = root.ownerDocument;
+  if (!ownerDocument) {
+    throw new Error('Element must be in the DOM');
+  }
+
+  // IE11 uses a different syntax, and expects just a function, not the `NodeFilter` object.
+  if (workaroundForIE11) {
+    let acceptNode = filter ? ((filter.acceptNode as any) as NodeFilter) : null;
+    return ownerDocument.createTreeWalker(root, whatToShow, acceptNode, entityReferenceExpansion);
+  } else {
+    return ownerDocument.createTreeWalker(root, whatToShow, filter, entityReferenceExpansion);
+  }
+}

--- a/addon-test-support/@ember/test-helpers/dom/fire-event.ts
+++ b/addon-test-support/@ember/test-helpers/dom/fire-event.ts
@@ -174,7 +174,7 @@ function buildMouseEvent(type: MouseEventType, options: any = {}) {
 }
 
 // eslint-disable-next-line require-jsdoc
-function buildKeyboardEvent(type: KeyboardEventType, options: any = {}) {
+export function buildKeyboardEvent(type: KeyboardEventType, options: any = {}) {
   let eventOpts: any = assign({}, DEFAULT_EVENT_OPTIONS, options);
   let event: Event | undefined;
   let eventMethodName: 'initKeyboardEvent' | 'initKeyEvent' | undefined;

--- a/addon-test-support/@ember/test-helpers/dom/tab.ts
+++ b/addon-test-support/@ember/test-helpers/dom/tab.ts
@@ -1,0 +1,184 @@
+import getRootElement from './get-root-element';
+import settled from '../settled';
+import { buildKeyboardEvent } from './fire-event';
+import { isDocument } from './-target';
+import { __blur__ } from './blur';
+import { nextTickPromise } from '../-utils';
+import { createTreeWalker } from './-create-tree-walker';
+
+const FORM_TAGS = ['INPUT', 'BUTTON', 'SELECT', 'TEXTAREA', 'FIELDSET'];
+const SUPPORTS_INHERT = Element.prototype.hasOwnProperty('inert');
+const FALLBACK_ELEMENTS = ['CANVAS', 'VIDEO', 'PICTURE'];
+
+function isVisible(element: HTMLElement): boolean {
+  let styles = window.getComputedStyle(element);
+  return styles.display !== 'none' && styles.visibility !== 'hidden';
+}
+
+function isDisabled(element: HTMLElement): boolean {
+  if (FORM_TAGS.indexOf(element.tagName) !== -1) {
+    return (element as HTMLInputElement).disabled;
+  }
+  return false;
+}
+
+interface InhertHTMLElement extends HTMLElement {
+  inhert: boolean;
+}
+
+// Compiles a list of nodes that can be focued. Walkes the tree, discardes hidden
+// elements and a few edge cases. To calculate the right
+function compileFocusAreas(root: Element = document.body) {
+  let activeElment = getActiveElement(root.ownerDocument!);
+  let treeWalker = createTreeWalker(
+    root,
+    NodeFilter.SHOW_ELEMENT,
+    {
+      acceptNode: (node: HTMLElement) => {
+        /// Only visible nodes can be focused, with, at least, one exception; the "area" element.
+        if (node.tagName !== 'AREA' && isVisible(node) === false) {
+          return NodeFilter.FILTER_REJECT;
+        }
+
+        // Reject any fallback elements. Fallback elements’s children are only rendered if the UA
+        // doesn’t support the element. We make an assumption that they are always supported, we
+        // could consider feature detecting every node type, or making it configurable.
+        let parentNode = node.parentNode as HTMLElement | null;
+        if (parentNode && FALLBACK_ELEMENTS.indexOf(parentNode.tagName) !== -1) {
+          return NodeFilter.FILTER_REJECT;
+        }
+
+        // Rejects inhert containers, if the user agent supports the feature (or if a polyfill is installed.)
+        if (SUPPORTS_INHERT && (node as InhertHTMLElement).inhert) {
+          return NodeFilter.FILTER_REJECT;
+        }
+
+        if (isDisabled(node)) {
+          return NodeFilter.FILTER_REJECT;
+        }
+
+        // Always accept the 'activeElement' of the document, as it might fail the next check, elements with tabindex="-1"
+        // can be focused programtically, we'll therefor ensure the current active element is in the list.
+        if (node === activeElment) {
+          return NodeFilter.FILTER_ACCEPT;
+        }
+
+        // UA parses the tabindex attribute and applies its default values, If the tabIndex is non negative, the UA can
+        // foucs it.
+        return node.tabIndex >= 0 ? NodeFilter.FILTER_ACCEPT : NodeFilter.FILTER_SKIP;
+      },
+    },
+    false
+  );
+
+  let node: Node | null;
+  let elements: HTMLElement[] = [];
+
+  while ((node = treeWalker.nextNode())) {
+    elements.push(node as HTMLElement);
+  }
+
+  return elements;
+}
+
+// Sort elements by tab indices, as older browsers doesn't necesarrly implement stabile sort,
+// we'll have to manually compare with the index in the original array.
+function sortElementsByTabIndices(elements: HTMLElement[]): HTMLElement[] {
+  return elements
+    .map((element, index) => {
+      return { index, element };
+    })
+    .sort((a, b) => {
+      if (a.element.tabIndex === b.element.tabIndex) {
+        return a.index - b.index;
+      } else if (a.element.tabIndex === 0 || b.element.tabIndex === 0) {
+        return b.element.tabIndex - a.element.tabIndex;
+      }
+      return a.element.tabIndex - b.element.tabIndex;
+    })
+    .map(entity => entity.element);
+}
+
+function findNextResponders(root: Element, element: HTMLElement) {
+  let focusAreas = compileFocusAreas(root);
+  let sortedFocusAreas = sortElementsByTabIndices(focusAreas);
+  let elements = element.tabIndex === -1 ? focusAreas : sortedFocusAreas;
+
+  let index = elements.indexOf(element);
+  if (index === -1) {
+    return {
+      next: sortedFocusAreas[0],
+      previous: sortedFocusAreas[sortedFocusAreas.length - 1],
+    };
+  }
+
+  return {
+    next: elements[index + 1],
+    previous: elements[index - 1],
+  };
+}
+
+/**
+  Emulates the user pressing the tab button.
+
+  Sends a number of events intending to simulate a "real" user pressing tab on their
+  keyboard.
+
+  @public
+  @param {Object} options {backwards: x} (default false) indicates if the the user navigates backwards
+  @return {Promise<void>} resolves when settled
+
+  @example
+  tab();
+  tab({backwards: true});
+*/
+export default function triggerTab(options?: { backwards: boolean }): Promise<void> {
+  return nextTickPromise().then(() => {
+    let backwards = (options && options.backwards) || false;
+    triggerResponderChange(backwards);
+    return settled();
+  });
+}
+
+function getActiveElement(ownerDocument: Document): HTMLElement {
+  return (ownerDocument.activeElement as HTMLElement) || ownerDocument.body;
+}
+
+function triggerResponderChange(backwards: boolean) {
+  let root = getRootElement();
+  let ownerDocument: Document;
+  let rootElement: HTMLElement;
+  if (isDocument(root)) {
+    rootElement = root.body;
+    ownerDocument = root;
+  } else {
+    rootElement = root as HTMLElement;
+    ownerDocument = root.ownerDocument as Document;
+  }
+
+  let activeElement = getActiveElement(ownerDocument);
+
+  let event = buildKeyboardEvent('keydown', {
+    keyCode: 9,
+    which: 9,
+    key: 'Tab',
+    code: 'Tab',
+    shiftKey: backwards,
+  });
+  let defaultNotPrevented = activeElement.dispatchEvent(event);
+
+  if (defaultNotPrevented) {
+    // Query the active element again, as it might change during event phase
+    activeElement = getActiveElement(ownerDocument);
+    let target = findNextResponders(rootElement, activeElement);
+    if (target) {
+      if (backwards && target.previous) {
+        target.previous.focus();
+      } else if (!backwards && target.next) {
+        target.next.focus();
+      } else {
+        __blur__(activeElement);
+      }
+    }
+  }
+}

--- a/addon-test-support/@ember/test-helpers/index.ts
+++ b/addon-test-support/@ember/test-helpers/index.ts
@@ -29,6 +29,7 @@ export { default as getTestMetadata } from './test-metadata';
 // DOM Helpers
 export { default as click } from './dom/click';
 export { default as doubleClick } from './dom/double-click';
+export { default as tab } from './dom/tab';
 export { default as tap } from './dom/tap';
 export { default as focus } from './dom/focus';
 export { default as blur } from './dom/blur';

--- a/tests/helpers/events.js
+++ b/tests/helpers/events.js
@@ -1,4 +1,5 @@
 // from https://mdn.mozilla.org/en-US/docs/Web/Events
+import { get } from '@ember/object';
 export const KNOWN_EVENTS = Object.freeze([
   'abort',
   'afterprint',
@@ -189,7 +190,7 @@ export function instrumentElement(element, logOptionsProperties) {
       if (!element.hasAttribute('data-skip-steps')) {
         if (logOptionsProperties) {
           logOptionsProperties.forEach(prop => {
-            step += ` ${e[prop]}`;
+            step += ` ${get(e, prop)}`;
           });
         }
         assert.step(step);

--- a/tests/helpers/events.js
+++ b/tests/helpers/events.js
@@ -188,9 +188,9 @@ export function instrumentElement(element, logOptionsProperties) {
       let step = type;
       if (!element.hasAttribute('data-skip-steps')) {
         if (logOptionsProperties) {
-          for (var prop of logOptionsProperties) {
+          logOptionsProperties.forEach(prop => {
             step += ` ${e[prop]}`;
-          }
+          });
         }
         assert.step(step);
       }

--- a/tests/unit/dom/tab-test.js
+++ b/tests/unit/dom/tab-test.js
@@ -1,0 +1,358 @@
+import { module, test } from 'qunit';
+import { tab, setupContext, teardownContext, waitFor, settled } from '@ember/test-helpers';
+import { buildInstrumentedElement, insertElement } from '../../helpers/events';
+import { isIE11, isEdge } from '../../helpers/browser-detect';
+import hasEmberVersion from '@ember/test-helpers/has-ember-version';
+
+let _focusSteps = isIE11 ? ['focusin', 'focus'] : ['focus', 'focusin'];
+let _blurSteps = isIE11 || isEdge ? ['focusout', 'blur'] : ['blur', 'focusout'];
+
+function focusSteps(name) {
+  return [`${_focusSteps[0]} ${name}`, `${_focusSteps[1]} ${name}`];
+}
+
+function blurSteps(name) {
+  return [`${_blurSteps[0]} ${name}`, `${_blurSteps[1]} ${name}`];
+}
+
+function moveFocus(from, to) {
+  if (isIE11) {
+    return [`focusout ${from}`, `focusin ${to}`, `blur ${from}`, `focus ${to}`];
+  }
+  return [...blurSteps(from), ...focusSteps(to)];
+}
+
+module('DOM Helper: tab', function(hooks) {
+  if (!hasEmberVersion(2, 4)) {
+    return;
+  }
+
+  let context, element, elements;
+
+  hooks.beforeEach(function() {
+    // used to simulate how `setupRenderingTest` (and soon `setupApplicationTest`)
+    // set context.element to the rootElement
+    context = {
+      element: document.querySelector('#qunit-fixture'),
+    };
+  });
+
+  hooks.afterEach(async function() {
+    if (elements) {
+      elements.forEach(element => {
+        element.setAttribute('data-skip-steps', true);
+      });
+      elements.forEach(element => {
+        element.parentNode.removeChild(element);
+      });
+      elements = undefined;
+    }
+
+    if (element) {
+      element.setAttribute('data-skip-steps', true);
+      element.parentNode.removeChild(element);
+      element = undefined;
+    }
+
+    // only teardown if setupContext was called
+    if (context.owner) {
+      await teardownContext(context);
+    }
+    document.getElementById('ember-testing').innerHTML = '';
+  });
+
+  test('tabs to focusable element', async function(assert) {
+    element = buildInstrumentedElement('input', ['target.className']);
+    element.className = 'a';
+
+    await setupContext(context);
+    await tab();
+
+    assert.verifySteps(focusSteps('a'));
+  });
+
+  test('tabs to focusable element', async function(assert) {
+    element = buildInstrumentedElement('input', ['target.className']);
+    element.className = 'a';
+
+    await setupContext(context);
+    await tab({ backwards: true });
+
+    assert.verifySteps(focusSteps('a'));
+  });
+
+  test('blurs target when tabs through the last target', async function(assert) {
+    elements = [buildInstrumentedElement('input', ['target.id'])];
+
+    await setupContext(context);
+    await tab();
+    await tab();
+
+    assert.verifySteps([
+      ...focusSteps(elements[0].id),
+      `keydown ${elements[0].id}`,
+      ...blurSteps(elements[0].id),
+    ]);
+  });
+
+  test('tabs between foucsable elements', async function(assert) {
+    elements = [
+      buildInstrumentedElement('input', ['target.className']),
+      buildInstrumentedElement('input', ['target.className']),
+    ];
+
+    elements[0].className = 'a';
+    elements[1].className = 'b';
+
+    await setupContext(context);
+
+    await tab();
+    await tab();
+
+    assert.verifySteps([...focusSteps('a'), 'keydown a', ...moveFocus('a', 'b')]);
+  });
+
+  test('ignores focusable elements with tab index = -1', async function(assert) {
+    elements = [
+      buildInstrumentedElement('input', ['target.id']),
+      buildInstrumentedElement('input', ['target.id']),
+    ];
+
+    elements[0].tabIndex = -1;
+
+    await setupContext(context);
+
+    await tab();
+
+    assert.verifySteps(focusSteps(elements[1].id));
+  });
+
+  test('ignores focusable elements with tab index = -1', async function(assert) {
+    elements = [
+      buildInstrumentedElement('input', ['target.id']),
+      buildInstrumentedElement('input', ['target.id']),
+    ];
+
+    elements[1].tabIndex = -1;
+
+    await setupContext(context);
+
+    await tab({ backwards: true });
+
+    assert.verifySteps(focusSteps(elements[0].id));
+  });
+
+  test('supports tabbing without any focusable areas', async function(assert) {
+    elements = [];
+    await setupContext(context);
+
+    await tab();
+
+    assert.ok(true);
+  });
+
+  test('tabs an input that prevents defaults', async function(assert) {
+    elements = [
+      buildInstrumentedElement('input', ['target.id']),
+      buildInstrumentedElement('input', ['target.id']),
+    ];
+
+    elements[0].addEventListener('keydown', event => {
+      event.preventDefault();
+    });
+
+    await setupContext(context);
+
+    await tab();
+    await tab();
+
+    assert.verifySteps([...focusSteps(elements[0].id), `keydown ${elements[0].id}`]);
+  });
+
+  test('tabs an input that moves focus during an event', async function(assert) {
+    elements = [
+      document.createElement('input'),
+      document.createElement('input'),
+      document.createElement('input'),
+    ];
+
+    elements.forEach(element => {
+      insertElement(element);
+    });
+
+    elements[0].addEventListener('keydown', event => {
+      elements[1].focus();
+    });
+
+    await setupContext(context);
+
+    elements[0].focus();
+    await settled();
+    await tab();
+
+    assert.equal(document.activeElement, elements[2]);
+  });
+
+  test('sorts focusable elements by their tab index', async function(assert) {
+    elements = [
+      buildInstrumentedElement('input', ['target.className']),
+      buildInstrumentedElement('div', ['target.className']),
+      buildInstrumentedElement('input', ['target.className']),
+      buildInstrumentedElement('input', ['target.className']),
+    ];
+
+    elements[0].className = 'b';
+    elements[1].className = 'c';
+    elements[2].className = 'd';
+    elements[3].className = 'a';
+
+    elements[0].tabIndex = 4;
+    elements[1].tabIndex = 4;
+    elements[2].tabIndex = 0;
+    elements[3].tabIndex = 1;
+
+    await setupContext(context);
+
+    await tab();
+    await tab();
+    await tab();
+    await tab();
+
+    assert.verifySteps([
+      ...focusSteps('a'),
+      'keydown a',
+      ...moveFocus('a', 'b'),
+      'keydown b',
+      ...moveFocus('b', 'c'),
+      'keydown c',
+      ...moveFocus('c', 'd'),
+    ]);
+  });
+
+  module('programmatically focusable elements', function(hooks) {
+    hooks.beforeEach(async function(assert) {
+      elements = [
+        buildInstrumentedElement('input', ['target.id']),
+        buildInstrumentedElement('input', ['target.id']),
+        buildInstrumentedElement('input', ['target.id']),
+      ];
+
+      elements[0].className = 'c';
+      elements[1].className = 'a';
+      elements[2].className = 'b';
+
+      elements[0].tabIndex = 1;
+      elements[1].tabIndex = -1;
+      elements[2].tabIndex = 2;
+
+      await setupContext(context);
+
+      elements[1].focus();
+    });
+
+    test('tabs backwards focuses previous node', async function(assert) {
+      await tab({ backwards: true });
+      assert.verifySteps([
+        ...focusSteps(elements[1].id),
+        `keydown ${elements[1].id}`,
+        ...moveFocus(elements[1].id, elements[0].id),
+      ]);
+    });
+
+    test('tabs focuses next focus area', async function(assert) {
+      await tab();
+      assert.verifySteps([
+        ...focusSteps(elements[1].id),
+        `keydown ${elements[1].id}`,
+        ...moveFocus(elements[1].id, elements[2].id),
+      ]);
+    });
+  });
+
+  module('invalid elements', function(hooks) {
+    hooks.beforeEach(async function() {
+      elements = [
+        buildInstrumentedElement('input', ['target.id']),
+        buildInstrumentedElement('input', ['target.id']),
+      ];
+    });
+
+    test('ignores disabled input elements', async function(assert) {
+      elements[0].disabled = true;
+
+      await setupContext(context);
+      await tab();
+
+      assert.verifySteps(focusSteps(elements[1].id));
+    });
+
+    test('ignores invisible elements', async function(assert) {
+      elements[0].style.display = 'none';
+
+      await setupContext(context);
+      await tab();
+
+      assert.verifySteps(focusSteps(elements[1].id));
+    });
+  });
+
+  test('ignores hidden parents', async function(assert) {
+    elements = [
+      buildInstrumentedElement('input', ['target.id']),
+      buildInstrumentedElement('input', ['target.id']),
+    ];
+
+    let container = document.createElement('div');
+    container.style.display = 'none';
+    insertElement(container);
+    container.appendChild(elements[0]);
+
+    await setupContext(context);
+    await tab();
+
+    assert.verifySteps(focusSteps(elements[1].id));
+  });
+
+  test('ignores children of disabled fieldset', async function(assert) {
+    elements = [
+      buildInstrumentedElement('input', ['target.id']),
+      buildInstrumentedElement('input', ['target.id']),
+    ];
+
+    let container = document.createElement('fieldset');
+    container.disabled = true;
+    insertElement(container);
+    container.appendChild(elements[0]);
+
+    await setupContext(context);
+    await tab();
+
+    assert.verifySteps(focusSteps(elements[1].id));
+  });
+
+  // IE11 doesn’t support the summary and detail and will fail this check
+  if (isIE11 === false) {
+    test('first summary element of a details should be focusable', async function(assert) {
+      elements = [
+        buildInstrumentedElement('summary', ['target.id']),
+        buildInstrumentedElement('summary', ['target.id']),
+      ];
+
+      let container = document.createElement('details');
+      insertElement(container);
+      container.appendChild(elements[0]);
+      container.appendChild(elements[1]);
+
+      await setupContext(context);
+
+      await tab();
+      await tab();
+
+      assert.verifySteps([
+        ...focusSteps(elements[0].id),
+        `keydown ${elements[0].id}`,
+        ...blurSteps(elements[0].id),
+      ]);
+    });
+  }
+});


### PR DESCRIPTION
Took a stab at making a tab-button emulator. (#738)

I wasn’t completely sure the best way to test it, had to make a few modifications to the existing test helper to test the events it generates. I realized a bit late that it might be good enough to test if the active element was set currently, and not ensuring the user-agent fires the right events. Should I refactor to just check the active element?

Few notes:

I exported `buildKeyboardEvent` as I had to knew if the event was prevented, it seems like the easiest way to accomplish that. IE11 doesn't support "Event.defaultPrevented".

I changed `instrumentElement` to accept key paths for its `logOptionsProperties` argument, to get information about the target of the event.

I wasn’t able to get the tests running in IE11, and had to port a native for-of loop to a `forEach`. But I assume I’m just doing something incorrect, any tricks I need to know. I added it as a dedicated commit, and can easily drop it.
