### PR TITLE
Drop support for Node 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 ---
 language: node_js
 node_js:
-  - '8'
+  - '10'
 
 branches:
   only:

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "**/engine.io": "~3.3.0"
   },
   "engines": {
-    "node": "8.* || >= 10.*"
+    "node": "10.* || >= 12.*"
   },
   "publishConfig": {
     "access": "public",


### PR DESCRIPTION
similar to #744, this PR drops support for the outdated Node.js v8.