### PR TITLE
[breaking] disable interacting with disabled form controls

### DIFF
--- a/addon-test-support/@ember/test-helpers/dom/blur.ts
+++ b/addon-test-support/@ember/test-helpers/dom/blur.ts
@@ -1,16 +1,20 @@
 import getElement from './-get-element';
 import fireEvent from './fire-event';
 import settled from '../settled';
-import isFocusable from './-is-focusable';
 import { nextTickPromise } from '../-utils';
 import Target from './-target';
 import { log } from '@ember/test-helpers/dom/-logging';
+import isFocusable from './-is-focusable';
 
 /**
   @private
   @param {Element} element the element to trigger events on
 */
-export function __blur__(element: HTMLElement | SVGElement): void {
+export function __blur__(element: HTMLElement | Element | Document | SVGElement): void {
+  if (!isFocusable(element)) {
+    throw new Error(`${element} is not focusable`);
+  }
+
   let browserIsNotFocused = document.hasFocus && !document.hasFocus();
 
   // makes `document.activeElement` be `body`.
@@ -58,10 +62,6 @@ export default function blur(target: Target = document.activeElement!): Promise<
     let element = getElement(target);
     if (!element) {
       throw new Error(`Element not found when calling \`blur('${target}')\`.`);
-    }
-
-    if (!isFocusable(element)) {
-      throw new Error(`${target} is not focusable`);
     }
 
     __blur__(element);

--- a/addon-test-support/@ember/test-helpers/dom/click.ts
+++ b/addon-test-support/@ember/test-helpers/dom/click.ts
@@ -82,11 +82,11 @@ export default function click(target: Target, options: MouseEventInit = {}): Pro
       throw new Error(`Element not found when calling \`click('${target}')\`.`);
     }
 
-    let isDisabledFormControl = isFormControl(element) && element.disabled;
-
-    if (!isDisabledFormControl) {
-      __click__(element, options);
+    if (isFormControl(element) && element.disabled) {
+      throw new Error(`Can not \`click\` disabled ${element}`);
     }
+
+    __click__(element, options);
 
     return settled();
   });

--- a/addon-test-support/@ember/test-helpers/dom/double-click.ts
+++ b/addon-test-support/@ember/test-helpers/dom/double-click.ts
@@ -6,6 +6,7 @@ import isFocusable from './-is-focusable';
 import { nextTickPromise } from '../-utils';
 import Target from './-target';
 import { log } from '@ember/test-helpers/dom/-logging';
+import isFormControl from './-is-form-control';
 
 /**
   @private
@@ -93,7 +94,12 @@ export default function doubleClick(target: Target, options: MouseEventInit = {}
       throw new Error(`Element not found when calling \`doubleClick('${target}')\`.`);
     }
 
+    if (isFormControl(element) && element.disabled) {
+      throw new Error(`Can not \`doubleClick\` disabled ${element}`);
+    }
+
     __doubleClick__(element, options);
+
     return settled();
   });
 }

--- a/addon-test-support/@ember/test-helpers/dom/focus.ts
+++ b/addon-test-support/@ember/test-helpers/dom/focus.ts
@@ -10,7 +10,11 @@ import { log } from '@ember/test-helpers/dom/-logging';
   @private
   @param {Element} element the element to trigger events on
 */
-export function __focus__(element: HTMLElement | SVGElement): void {
+export function __focus__(element: HTMLElement | Element | Document | SVGElement): void {
+  if (!isFocusable(element)) {
+    throw new Error(`${element} is not focusable`);
+  }
+
   let browserIsNotFocused = document.hasFocus && !document.hasFocus();
 
   // makes `document.activeElement` be `element`. If the browser is focused, it also fires a focus event
@@ -65,10 +69,6 @@ export default function focus(target: Target): Promise<void> {
     let element = getElement(target);
     if (!element) {
       throw new Error(`Element not found when calling \`focus('${target}')\`.`);
-    }
-
-    if (!isFocusable(element)) {
-      throw new Error(`${target} is not focusable`);
     }
 
     __focus__(element);

--- a/addon-test-support/@ember/test-helpers/dom/tap.ts
+++ b/addon-test-support/@ember/test-helpers/dom/tap.ts
@@ -5,6 +5,7 @@ import settled from '../settled';
 import { nextTickPromise } from '../-utils';
 import Target from './-target';
 import { log } from '@ember/test-helpers/dom/-logging';
+import isFormControl from './-is-form-control';
 
 /**
   Taps on the specified target.
@@ -59,6 +60,10 @@ export default function tap(target: Target, options: object = {}): Promise<void>
     let element = getElement(target);
     if (!element) {
       throw new Error(`Element not found when calling \`tap('${target}')\`.`);
+    }
+
+    if (isFormControl(element) && element.disabled) {
+      throw new Error(`Can not \`tap\` disabled ${element}`);
     }
 
     let touchstartEv = fireEvent(element, 'touchstart', options);

--- a/addon-test-support/@ember/test-helpers/dom/trigger-event.ts
+++ b/addon-test-support/@ember/test-helpers/dom/trigger-event.ts
@@ -4,6 +4,7 @@ import settled from '../settled';
 import { nextTickPromise } from '../-utils';
 import Target from './-target';
 import { log } from '@ember/test-helpers/dom/-logging';
+import isFormControl from './-is-form-control';
 
 /**
  * Triggers an event on the specified target.
@@ -60,13 +61,17 @@ export default function triggerEvent(
       throw new Error('Must pass an element or selector to `triggerEvent`.');
     }
 
+    if (!eventType) {
+      throw new Error(`Must provide an \`eventType\` to \`triggerEvent\``);
+    }
+
     let element = getElement(target);
     if (!element) {
       throw new Error(`Element not found when calling \`triggerEvent('${target}', ...)\`.`);
     }
 
-    if (!eventType) {
-      throw new Error(`Must provide an \`eventType\` to \`triggerEvent\``);
+    if (isFormControl(element) && element.disabled) {
+      throw new Error(`Can not \`triggerEvent\` on disabled ${element}`);
     }
 
     fireEvent(element, eventType, options);

--- a/addon-test-support/@ember/test-helpers/dom/trigger-key-event.ts
+++ b/addon-test-support/@ember/test-helpers/dom/trigger-key-event.ts
@@ -6,6 +6,7 @@ import { KEYBOARD_EVENT_TYPES, KeyboardEventType, isKeyboardEventType } from './
 import { nextTickPromise, isNumeric } from '../-utils';
 import Target from './-target';
 import { log } from '@ember/test-helpers/dom/-logging';
+import isFormControl from './-is-form-control';
 
 export interface KeyModifiers {
   ctrlKey?: boolean;
@@ -205,6 +206,10 @@ export default function triggerKeyEvent(
       throw new Error(
         `Must provide an \`eventType\` of ${validEventTypes} to \`triggerKeyEvent\` but you passed \`${eventType}\`.`
       );
+    }
+
+    if (isFormControl(element) && element.disabled) {
+      throw new Error(`Can not \`triggerKeyEvent\` on disabled ${element}`);
     }
 
     __triggerKeyEvent__(element, eventType, key, modifiers);

--- a/tests/unit/dom/click-test.js
+++ b/tests/unit/dom/click-test.js
@@ -174,14 +174,15 @@ module('DOM Helper: click', function (hooks) {
       );
     });
 
-    test('clicking a disabled input does nothing', async function (assert) {
+    test('clicking a disabled form control', async function (assert) {
       element = buildInstrumentedElement('input');
       element.setAttribute('disabled', true);
 
-      await click(element);
-
-      assert.verifySteps([]);
-      assert.notStrictEqual(document.activeElement, element, 'activeElement not updated');
+      await setupContext(context);
+      assert.rejects(
+        click(`#${element.id}`, 'foo'),
+        new Error('Can not `click` disabled [object HTMLInputElement]')
+      );
     });
   });
 

--- a/tests/unit/dom/double-click-test.js
+++ b/tests/unit/dom/double-click-test.js
@@ -110,6 +110,17 @@ module('DOM Helper: doubleClick', function (hooks) {
       );
     });
 
+    test('rejects for disabled form control', async function (assert) {
+      element = buildInstrumentedElement('select');
+      element.setAttribute('disabled', true);
+
+      await setupContext(context);
+      assert.rejects(
+        doubleClick(element),
+        new Error('Can not `doubleClick` disabled [object HTMLSelectElement]')
+      );
+    });
+
     test('double-clicking a div via selector without context set', function (assert) {
       element = buildInstrumentedElement('div');
 

--- a/tests/unit/dom/focus-test.js
+++ b/tests/unit/dom/focus-test.js
@@ -48,6 +48,17 @@ module('DOM Helper: focus', function (hooks) {
     assert.rejects(focus(element), /is not focusable/);
   });
 
+  test('focusing a disabled form control', async function (assert) {
+    element = buildInstrumentedElement('input');
+    element.setAttribute('disabled', '');
+
+    await setupContext(context);
+    assert.rejects(
+      focus(`#${element.id}`, 'foo'),
+      'Error: [object HTMLInputElement] is not focusable'
+    );
+  });
+
   test('does not run sync', async function (assert) {
     element = buildInstrumentedElement('input');
 

--- a/tests/unit/dom/tap-test.js
+++ b/tests/unit/dom/tap-test.js
@@ -149,5 +149,12 @@ module('DOM Helper: tap', function (hooks) {
         /Must setup rendering context before attempting to interact with elements/
       );
     });
+
+    test('tapping disabled form control', function (assert) {
+      element = buildInstrumentedElement('input');
+      element.setAttribute('disabled', '');
+
+      assert.rejects(tap(element), new Error('Can not `tap` disabled [object HTMLInputElement]'));
+    });
   });
 });

--- a/tests/unit/dom/trigger-event-test.js
+++ b/tests/unit/dom/trigger-event-test.js
@@ -111,6 +111,17 @@ module('DOM Helper: triggerEvent', function (hooks) {
     assert.rejects(triggerEvent(element), /Must provide an `eventType` to `triggerEvent`/);
   });
 
+  test('rejects for disabled form control', async function (assert) {
+    element = buildInstrumentedElement('textarea');
+    element.setAttribute('disabled', true);
+
+    await setupContext(context);
+    assert.rejects(
+      triggerEvent(element, 'mouseenter'),
+      new Error('Can not `triggerEvent` on disabled [object HTMLTextAreaElement]')
+    );
+  });
+
   test('events properly bubble upwards', async function (assert) {
     await setupContext(context);
     element = buildInstrumentedElement('div');

--- a/tests/unit/dom/trigger-key-event-test.js
+++ b/tests/unit/dom/trigger-key-event-test.js
@@ -95,6 +95,17 @@ module('DOM Helper: triggerKeyEvent', function (hooks) {
     );
   });
 
+  test('rejects for disabled form control', async function (assert) {
+    element = buildInstrumentedElement('textarea');
+    element.setAttribute('disabled', true);
+
+    await setupContext(context);
+    assert.rejects(
+      triggerKeyEvent(element, 'keypress', '13'),
+      new Error('Can not `triggerKeyEvent` on disabled [object HTMLTextAreaElement]')
+    );
+  });
+
   test('triggering via selector with context set', async function (assert) {
     element = buildInstrumentedElement('div');
 


### PR DESCRIPTION
With this, any action helper(`click`, `triggerEvent`,...) would fail on attempt to be invoked against `input`, `textarea`, `select` in `disabled` state.

I've extracted it from https://github.com/emberjs/ember-test-helpers/pull/741, cause `fillIn` and `typeIn` seem to be a bit different cases, and it should be easier to review this way. Also this is [possibly](https://github.com/emberjs/ember-test-helpers/pull/741#issuecomment-596437597) a breaking change, so we may want to postpone merging it, while `fillIn` and `typeIn` seem to be more critical to fix.