### PR TITLE
CI: Add test scenarios for Ember 3.8, 3.12 and 3.16

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,9 @@ jobs:
     - env: EMBER_TRY_SCENARIO=ember-lts-2.16
     - env: EMBER_TRY_SCENARIO=ember-2.18
     - env: EMBER_TRY_SCENARIO=ember-lts-3.4
+    - env: EMBER_TRY_SCENARIO=ember-lts-3.8
+    - env: EMBER_TRY_SCENARIO=ember-lts-3.12
+    - env: EMBER_TRY_SCENARIO=ember-lts-3.16
     - env: EMBER_TRY_SCENARIO=ember-release
     - env: EMBER_TRY_SCENARIO=ember-beta
     - env: EMBER_TRY_SCENARIO=ember-canary

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -113,6 +113,33 @@ module.exports = function() {
           },
         },
         {
+          name: 'ember-lts-3.8',
+          env: envWithoutJQuery,
+          npm: {
+            devDependencies: {
+              'ember-source': '~3.4.0',
+            },
+          },
+        },
+        {
+          name: 'ember-lts-3.12',
+          env: envWithoutJQuery,
+          npm: {
+            devDependencies: {
+              'ember-source': '~3.4.0',
+            },
+          },
+        },
+        {
+          name: 'ember-lts-3.16',
+          env: envWithoutJQuery,
+          npm: {
+            devDependencies: {
+              'ember-source': '~3.4.0',
+            },
+          },
+        },
+        {
           name: 'ember-release',
           env: envWithoutJQuery,
           npm: {


### PR DESCRIPTION
... to ensure that our code works correctly on these LTS releases