### PR TITLE
Remove obsolete yarn `resolutions`

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,10 +82,6 @@
     "release-it-lerna-changelog": "^1.0.3",
     "typescript": "^3.8.3"
   },
-  "resolutions": {
-    "@types/handlebars": "npm:handlebars@^4.1.0",
-    "**/engine.io": "~3.3.0"
-  },
   "engines": {
     "node": "10.* || >= 12.*"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1621,7 +1621,7 @@
     "@types/minimatch" "*"
     "@types/node" "*"
 
-"@types/handlebars@*", "@types/handlebars@npm:handlebars@^4.1.0", handlebars@^4.0.11, handlebars@^4.0.4:
+"@types/handlebars@*", handlebars@^4.0.11, handlebars@^4.0.4:
   name "@types/handlebars"
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.1.0.tgz#0d6a6f34ff1f63cecec8423aa4169827bf787c3a"
@@ -5650,7 +5650,7 @@ engine.io-parser@~2.1.0, engine.io-parser@~2.1.1:
     blob "0.0.5"
     has-binary2 "~1.0.2"
 
-engine.io@~3.3.0, engine.io@~3.3.1:
+engine.io@~3.3.1:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/engine.io/-/engine.io-3.3.2.tgz#18cbc8b6f36e9461c5c0f81df2b830de16058a59"
   integrity sha512-AsaA9KG7cWPXWHp5FvHdDWY3AMWeZ8x+2pUVLcn71qE5AtAzgGbxuclOytygskw8XGmiQafTmnI9Bix3uihu2w==


### PR DESCRIPTION
These were done to fix issues with dependencies dropping support for Node.js 8 with a major version bump. We only support Node.js 10+ now, so these should no longer be necessary.