### PR TITLE
Remove ember-assign-polyfill dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
   "dependencies": {
     "broccoli-debug": "^0.6.5",
     "broccoli-funnel": "^3.0.2",
-    "ember-assign-polyfill": "^2.6.0",
     "ember-cli-babel": "^7.7.3",
     "ember-cli-htmlbars-inline-precompile": "^2.1.0",
     "ember-test-waiters": "^2.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4772,14 +4772,6 @@ electron-to-chromium@^1.3.390, electron-to-chromium@^1.3.47:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.413.tgz#9c457a4165c7b42e59d66dff841063eb9bfe5614"
   integrity sha512-Jm1Rrd3siqYHO3jftZwDljL2LYQafj3Kki5r+udqE58d0i91SkjItVJ5RwlJn9yko8i7MOcoidVKjQlgSdd1hg==
 
-ember-assign-polyfill@^2.6.0:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/ember-assign-polyfill/-/ember-assign-polyfill-2.6.0.tgz#07847e3357ee35b33f886a0b5fbec6873f6860eb"
-  integrity sha512-Y8NzOmHI/g4PuJ+xC14eTYiQbigNYddyHB8FY2kuQMxThTEIDE7SJtgttJrYYcPciOu0Tnb5ff36iO46LeiXkw==
-  dependencies:
-    ember-cli-babel "^6.16.0"
-    ember-cli-version-checker "^2.0.0"
-
 ember-cli-babel-plugin-helpers@^1.0.0, ember-cli-babel-plugin-helpers@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/ember-cli-babel-plugin-helpers/-/ember-cli-babel-plugin-helpers-1.1.0.tgz#de3baedd093163b6c2461f95964888c1676325ac"


### PR DESCRIPTION
Now that we have dropped support for Ember < 3.8, we no longer need the assign polyfill.