### PR TITLE
Remove ember-cli-htmlbars-inline-precompile.

### DIFF
--- a/addon-test-support/@ember/test-helpers/setup-rendering-context.ts
+++ b/addon-test-support/@ember/test-helpers/setup-rendering-context.ts
@@ -6,7 +6,7 @@ import global from './global';
 import { BaseContext, TestContext, isTestContext, getContext } from './setup-context';
 import { nextTickPromise } from './-utils';
 import settled from './settled';
-import hbs, { TemplateFactory } from 'htmlbars-inline-precompile';
+import { hbs, TemplateFactory } from 'ember-cli-htmlbars';
 import getRootElement from './dom/get-root-element';
 import { Owner } from './build-owner';
 import { deprecate } from '@ember/application/deprecations';

--- a/index.js
+++ b/index.js
@@ -6,19 +6,6 @@ const debugTree = BroccoliDebug.buildDebugCallback('ember-test-helpers');
 module.exports = {
   name: require('./package').name,
 
-  init() {
-    this._super.init && this._super.init.apply(this, arguments);
-
-    // ensure `this.options` is setup properly, this is required by
-    // ember-cli-htmlbars-inline-precompile so that it properly registers
-    // itself with _our_ instance of ember-cli-babel and not the host
-    // applications instance
-    //
-    // newer versions of ember-cli (2.12+) define `this.options` for us,
-    // however older versions (e.g. 2.8) do not...
-    this.options = this.options || {};
-  },
-
   included() {
     this._super.included.apply(this, arguments);
 

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "broccoli-funnel": "^3.0.2",
     "ember-assign-polyfill": "^2.6.0",
     "ember-cli-babel": "^7.7.3",
-    "ember-cli-htmlbars-inline-precompile": "^2.1.0",
+    "ember-cli-htmlbars": "^4.3.1",
     "ember-test-waiters": "^2.0.1"
   },
   "devDependencies": {
@@ -53,7 +53,6 @@
     "documentation": "^12.3.0",
     "ember-cli": "~3.17.0",
     "ember-cli-dependency-checker": "^3.2.0",
-    "ember-cli-htmlbars": "^4.3.1",
     "ember-cli-inject-live-reload": "^2.0.2",
     "ember-cli-pretender": "^3.1.1",
     "ember-cli-shims": "^1.2.0",

--- a/tests/integration/dom/scroll-to-test.js
+++ b/tests/integration/dom/scroll-to-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import {
   render,
   scrollTo,

--- a/tests/integration/module-for-acceptance-interop-test.js
+++ b/tests/integration/module-for-acceptance-interop-test.js
@@ -5,7 +5,7 @@ import Component from '@ember/component';
 import { click } from '@ember/test-helpers';
 import hasEmberVersion from '@ember/test-helpers/has-ember-version';
 
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import ajax from '../helpers/ajax';
 import Pretender from 'pretender';
 import moduleForAcceptance from '../helpers/module-for-acceptance';

--- a/tests/integration/settled-test.js
+++ b/tests/integration/settled-test.js
@@ -13,7 +13,7 @@ import {
 } from '@ember/test-helpers';
 import hasEmberVersion from '@ember/test-helpers/has-ember-version';
 import { module, test } from 'qunit';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import Pretender from 'pretender';
 import ajax from '../helpers/ajax';
 

--- a/tests/integration/setup-rendering-context-test.js
+++ b/tests/integration/setup-rendering-context-test.js
@@ -14,7 +14,7 @@ import {
 
 import hasEmberVersion from '@ember/test-helpers/has-ember-version';
 import { setResolverRegistry } from '../helpers/resolver';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import { defer } from 'rsvp';
 
 const PromiseWrapperTemplate = hbs`

--- a/tests/unit/dom/logging-test.js
+++ b/tests/unit/dom/logging-test.js
@@ -9,7 +9,7 @@ import {
 } from '@ember/test-helpers';
 import hasEmberVersion from '@ember/test-helpers/has-ember-version';
 import { elementToString } from '@ember/test-helpers/dom/-logging';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 module('elementToString()', function (hooks) {
   if (!hasEmberVersion(2, 4)) {

--- a/tests/unit/legacy-0-6-x/test-module-for-acceptance-test.js
+++ b/tests/unit/legacy-0-6-x/test-module-for-acceptance-test.js
@@ -3,7 +3,7 @@ import EmberRouter from '@ember/routing/router';
 import EmberApplication from '@ember/application';
 import { TestModuleForAcceptance, getContext } from 'ember-test-helpers';
 
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import Resolver, { setResolverRegistry } from '../../helpers/resolver';
 import qunitModuleFor from '../../helpers/qunit-module-for';
 

--- a/tests/unit/legacy-0-6-x/test-module-for-component-test.js
+++ b/tests/unit/legacy-0-6-x/test-module-for-component-test.js
@@ -14,7 +14,7 @@ import hasEmberVersion from 'ember-test-helpers/has-ember-version';
 import { setResolverRegistry } from '../../helpers/resolver';
 import qunitModuleFor from '../../helpers/qunit-module-for';
 import hasjQuery from '../../helpers/has-jquery';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import { settled, triggerEvent, focus, blur } from '@ember/test-helpers';
 import { htmlSafe } from '@ember/string';
 

--- a/tests/unit/setup-application-context-test.js
+++ b/tests/unit/setup-application-context-test.js
@@ -16,7 +16,7 @@ import {
 } from '@ember/test-helpers';
 import hasEmberVersion from '@ember/test-helpers/has-ember-version';
 import { setResolverRegistry } from '../helpers/resolver';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 const Router = EmberRouter.extend({ location: 'none' });
 Router.map(function () {

--- a/tests/unit/setup-rendering-context-test.js
+++ b/tests/unit/setup-rendering-context-test.js
@@ -22,7 +22,7 @@ import {
 import hasEmberVersion from '@ember/test-helpers/has-ember-version';
 import hasjQuery from '../helpers/has-jquery';
 import { setResolverRegistry, application, resolver } from '../helpers/resolver';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 module('setupRenderingContext', function (hooks) {
   if (!hasEmberVersion(2, 4)) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2448,11 +2448,6 @@ babel-plugin-filter-imports@^4.0.0:
     "@babel/types" "^7.7.2"
     lodash "^4.17.15"
 
-babel-plugin-htmlbars-inline-precompile@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-htmlbars-inline-precompile/-/babel-plugin-htmlbars-inline-precompile-1.0.0.tgz#a9d2f6eaad8a3f3d361602de593a8cbef8179c22"
-  integrity sha512-4jvKEHR1bAX03hBDZ94IXsYCj3bwk9vYsn6ux6JZNL2U5pvzCWjqyrGahfsGNrhERyxw8IqcirOi9Q6WCo3dkQ==
-
 babel-plugin-htmlbars-inline-precompile@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-htmlbars-inline-precompile/-/babel-plugin-htmlbars-inline-precompile-3.0.1.tgz#e1e38a4087f446578e419a21c112530c8df02345"
@@ -4856,17 +4851,6 @@ ember-cli-get-component-path-option@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/ember-cli-get-component-path-option/-/ember-cli-get-component-path-option-1.0.0.tgz#0d7b595559e2f9050abed804f1d8eff1b08bc771"
   integrity sha1-DXtZVVni+QUKvtgE8djv8bCLx3E=
-
-ember-cli-htmlbars-inline-precompile@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/ember-cli-htmlbars-inline-precompile/-/ember-cli-htmlbars-inline-precompile-2.1.0.tgz#61b91ff1879d44ae504cadb46fb1f2604995ae08"
-  integrity sha512-BylIHduwQkncPhnj0ZyorBuljXbTzLgRo6kuHf1W+IHFxThFl2xG+r87BVwsqx4Mn9MTgW9SE0XWjwBJcSWd6Q==
-  dependencies:
-    babel-plugin-htmlbars-inline-precompile "^1.0.0"
-    ember-cli-version-checker "^2.1.2"
-    hash-for-dep "^1.2.3"
-    heimdalljs-logger "^0.1.9"
-    silent-error "^1.1.0"
 
 ember-cli-htmlbars@^4.3.1:
   version "4.3.1"


### PR DESCRIPTION
Now that we have upgrade to ember-cli-htmlbars@4 we can use it directly for inline precompilation.