### PR TITLE
cleanup: restrict Target to string or Element only

### DIFF
--- a/addon-test-support/@ember/test-helpers/dom/-get-element.ts
+++ b/addon-test-support/@ember/test-helpers/dom/-get-element.ts
@@ -1,11 +1,9 @@
 import getRootElement from './get-root-element';
-import Target, { isDocument, isElement } from './-target';
+import Target, { isElement } from './-target';
 
 function getElement(target: string): Element | null;
 function getElement(target: Element): Element;
-function getElement(target: Document): Document;
-function getElement(target: Window): Document;
-function getElement(target: Target): Element | Document | null;
+function getElement(target: Target): Element | null;
 /**
   Used internally by the DOM interaction helpers to find one element.
 
@@ -13,15 +11,13 @@ function getElement(target: Target): Element | Document | null;
   @param {string|Element} target the element or selector to retrieve
   @returns {Element} the target or selector
 */
-function getElement(target: Target): Element | Document | null {
+function getElement(target: Target): Element | null {
   if (typeof target === 'string') {
     let rootElement = getRootElement();
 
     return rootElement.querySelector(target);
-  } else if (isElement(target) || isDocument(target)) {
+  } else if (isElement(target)) {
     return target;
-  } else if (target instanceof Window) {
-    return target.document;
   } else {
     throw new Error('Must use an element or a selector string');
   }

--- a/addon-test-support/@ember/test-helpers/dom/-is-focusable.ts
+++ b/addon-test-support/@ember/test-helpers/dom/-is-focusable.ts
@@ -1,5 +1,5 @@
 import isFormControl from './-is-form-control';
-import { isDocument, isContentEditable } from './-target';
+import { isContentEditable } from './-target';
 
 const FOCUSABLE_TAGS = ['A'];
 
@@ -16,12 +16,8 @@ function isFocusableElement(element: Element): element is FocusableElement {
   @returns {boolean} `true` when the element is focusable, `false` otherwise
 */
 export default function isFocusable(
-  element: HTMLElement | SVGElement | Element | Document
+  element: HTMLElement | SVGElement | Element
 ): element is HTMLElement | SVGElement {
-  if (isDocument(element)) {
-    return false;
-  }
-
   if (isFormControl(element)) {
     return !element.disabled;
   }

--- a/addon-test-support/@ember/test-helpers/dom/-is-form-control.ts
+++ b/addon-test-support/@ember/test-helpers/dom/-is-form-control.ts
@@ -1,5 +1,3 @@
-import { isDocument } from './-target';
-
 const FORM_CONTROL_TAGS = ['INPUT', 'BUTTON', 'SELECT', 'TEXTAREA'];
 
 export type FormControl =
@@ -13,9 +11,8 @@ export type FormControl =
   @param {Element} element the element to check
   @returns {boolean} `true` when the element is a form control, `false` otherwise
 */
-export default function isFormControl(element: Element | Document): element is FormControl {
+export default function isFormControl(element: Element): element is FormControl {
   return (
-    !isDocument(element) &&
     FORM_CONTROL_TAGS.indexOf(element.tagName) > -1 &&
     (element as HTMLInputElement).type !== 'hidden'
   );

--- a/addon-test-support/@ember/test-helpers/dom/-target.ts
+++ b/addon-test-support/@ember/test-helpers/dom/-target.ts
@@ -1,4 +1,4 @@
-type Target = string | Element | Document | Window;
+type Target = string | Element;
 
 export default Target;
 

--- a/addon-test-support/@ember/test-helpers/dom/blur.ts
+++ b/addon-test-support/@ember/test-helpers/dom/blur.ts
@@ -10,7 +10,7 @@ import isFocusable from './-is-focusable';
   @private
   @param {Element} element the element to trigger events on
 */
-export function __blur__(element: HTMLElement | Element | Document | SVGElement): void {
+export function __blur__(element: HTMLElement | Element | SVGElement): void {
   if (!isFocusable(element)) {
     throw new Error(`${element} is not focusable`);
   }

--- a/addon-test-support/@ember/test-helpers/dom/click.ts
+++ b/addon-test-support/@ember/test-helpers/dom/click.ts
@@ -13,7 +13,7 @@ import { log } from '@ember/test-helpers/dom/-logging';
   @param {Element} element the element to click on
   @param {Object} options the options to be merged into the mouse events
 */
-export function __click__(element: Element | Document, options: MouseEventInit): void {
+export function __click__(element: Element, options: MouseEventInit): void {
   fireEvent(element, 'mousedown', options);
 
   if (isFocusable(element)) {

--- a/addon-test-support/@ember/test-helpers/dom/double-click.ts
+++ b/addon-test-support/@ember/test-helpers/dom/double-click.ts
@@ -13,7 +13,7 @@ import isFormControl from './-is-form-control';
   @param {Element} element the element to double-click on
   @param {Object} options the options to be merged into the mouse events
 */
-export function __doubleClick__(element: Element | Document, options: MouseEventInit): void {
+export function __doubleClick__(element: Element, options: MouseEventInit): void {
   fireEvent(element, 'mousedown', options);
 
   if (isFocusable(element)) {

--- a/addon-test-support/@ember/test-helpers/dom/focus.ts
+++ b/addon-test-support/@ember/test-helpers/dom/focus.ts
@@ -10,7 +10,7 @@ import { log } from '@ember/test-helpers/dom/-logging';
   @private
   @param {Element} element the element to trigger events on
 */
-export function __focus__(element: HTMLElement | Element | Document | SVGElement): void {
+export function __focus__(element: HTMLElement | Element | SVGElement): void {
   if (!isFocusable(element)) {
     throw new Error(`${element} is not focusable`);
   }

--- a/addon-test-support/@ember/test-helpers/dom/scroll-to.ts
+++ b/addon-test-support/@ember/test-helpers/dom/scroll-to.ts
@@ -2,7 +2,6 @@ import getElement from './-get-element';
 import fireEvent from './fire-event';
 import settled from '../settled';
 import { nextTickPromise } from '../-utils';
-import { isElement } from './-target';
 
 /**
   Scrolls DOM element or selector to the given coordinates.
@@ -37,12 +36,6 @@ export default function scrollTo(
     let element = getElement(target);
     if (!element) {
       throw new Error(`Element not found when calling \`scrollTo('${target}')\`.`);
-    }
-
-    if (!isElement(element)) {
-      throw new Error(
-        `"target" must be an element, but was a ${element.nodeType} when calling \`scrollTo('${target}')\`.`
-      );
     }
 
     element.scrollTop = y;

--- a/tests/integration/dom/scroll-to-test.js
+++ b/tests/integration/dom/scroll-to-test.js
@@ -107,8 +107,8 @@ module('DOM Helper: scroll-to', function (hooks) {
     assert.rejects(scrollTo('.container2', 0, 0), /Element not found when calling/);
   });
 
-  test('It throws an error if the target is not an element', async function (assert) {
-    assert.rejects(scrollTo(document, 0, 0), /"target" must be an element/);
-    assert.rejects(scrollTo(window, 0, 0), /"target" must be an element/);
+  test('It throws an error if the target is not an element or a selector string', async function (assert) {
+    assert.rejects(scrollTo(document, 0, 0), /Must use an element or a selector string/);
+    assert.rejects(scrollTo(window, 0, 0), /Must use an element or a selector string/);
   });
 });


### PR DESCRIPTION
for the majority of interaction helpers, having `Document` or `Window` as a target doesn't make sense.

The only helper which, looks like, may need `Document` or `Window` as a target, is `fireEvent` when handling mouse events https://github.com/emberjs/ember-test-helpers/blob/fa114a0287510ba9f87237d75644a1cc9fbc1c32/addon-test-support/%40ember/test-helpers/dom/fire-event.ts#L93-L96

if I'm not mistaken it can be only reached via `triggerEvent`. If such, then `Document` as a target should be only allowed in `triggerEvent` https://github.com/emberjs/ember-test-helpers/blob/fa114a0287510ba9f87237d75644a1cc9fbc1c32/addon-test-support/%40ember/test-helpers/dom/trigger-event.ts#L52-L53, which would allow to simplify code for the rest of helpers.

todo: 
 - [ ] figure out if we need `Document | Window` as a `triggerEvent` target
 - [ ] if "yes", implementation should be updated accordingly, and missing test case should be added