### PR TITLE
Refactor ember-try scenarios.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -18,7 +18,7 @@ module.exports = {
       files: ['.eslintrc.js', '.prettierrc.js', 'index.js', 'config/ember-try.js', 'scripts/**'],
       excludedFiles: ['addon-test-support/**', 'tests/**'],
       parserOptions: {
-        ecmaVersion: 2015,
+        ecmaVersion: 2017,
         sourceType: 'script',
       },
       env: {
@@ -47,7 +47,7 @@ module.exports = {
       },
     },
     {
-      files: ['index.js', 'addon-test-support/**/*.[jt]s', 'config/**/*.js'],
+      files: ['addon-test-support/**/*.[jt]s'],
       plugins: ['disable-features'],
       rules: {
         'disable-features/disable-async-await': 'error',

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -52,8 +52,8 @@ jobs:
           - ember-release
           - ember-beta
           - ember-canary
+          - ember-classic
           - ember-default-with-jquery
-          - ember-without-application-wrapper
 
     steps:
       - uses: actions/checkout@v2

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -2,107 +2,97 @@
 
 const getChannelURL = require('ember-source-channel-url');
 
-module.exports = function () {
-  return Promise.all([
-    getChannelURL('release'),
-    getChannelURL('beta'),
-    getChannelURL('canary'),
-  ]).then(urls => {
-    let envWithoutJQuery = {
-      EMBER_OPTIONAL_FEATURES: JSON.stringify({ 'jquery-integration': false }),
-    };
-
-    return {
-      useYarn: true,
-      scenarios: [
-        {
-          name: 'ember-lts-3.8',
-          env: envWithoutJQuery,
-          npm: {
-            devDependencies: {
-              'ember-source': '~3.4.0',
-            },
+module.exports = async function () {
+  return {
+    useYarn: true,
+    scenarios: [
+      {
+        name: 'ember-lts-3.8',
+        npm: {
+          devDependencies: {
+            'ember-source': '~3.8.0',
+          },
+          ember: {
+            edition: 'classic',
           },
         },
-        {
-          name: 'ember-lts-3.12',
-          env: envWithoutJQuery,
-          npm: {
-            devDependencies: {
-              'ember-source': '~3.4.0',
-            },
+      },
+      {
+        name: 'ember-lts-3.12',
+        npm: {
+          devDependencies: {
+            'ember-source': '~3.12.0',
+          },
+          ember: {
+            edition: 'classic',
           },
         },
-        {
-          name: 'ember-lts-3.16',
-          env: envWithoutJQuery,
-          npm: {
-            devDependencies: {
-              'ember-source': '~3.4.0',
-            },
+      },
+      {
+        name: 'ember-lts-3.16',
+        npm: {
+          devDependencies: {
+            'ember-source': '~3.16.0',
           },
         },
-        {
-          name: 'ember-release',
-          env: envWithoutJQuery,
-          npm: {
-            devDependencies: {
-              'ember-source': urls[0],
-            },
+      },
+      {
+        name: 'ember-release',
+        npm: {
+          devDependencies: {
+            'ember-source': await getChannelURL('release'),
           },
         },
-        {
-          name: 'ember-beta',
-          env: envWithoutJQuery,
-          npm: {
-            devDependencies: {
-              'ember-source': urls[1],
-            },
+      },
+      {
+        name: 'ember-beta',
+        npm: {
+          devDependencies: {
+            'ember-source': await getChannelURL('beta'),
           },
         },
-        {
-          name: 'ember-canary',
-          env: envWithoutJQuery,
-          npm: {
-            devDependencies: {
-              'ember-source': urls[2],
-            },
+      },
+      {
+        name: 'ember-canary',
+        npm: {
+          devDependencies: {
+            'ember-source': await getChannelURL('canary'),
           },
         },
-        {
-          name: 'ember-without-application-wrapper',
-          env: {
-            EMBER_OPTIONAL_FEATURES: JSON.stringify({
-              'application-template-wrapper': false,
-              'jquery-integration': false,
-            }),
-          },
-          npm: {
-            devDependencies: {
-              'ember-source': urls[2],
-            },
+      },
+      {
+        name: 'ember-default-with-jquery',
+        env: {
+          EMBER_OPTIONAL_FEATURES: JSON.stringify({ 'jquery-integration': true }),
+        },
+        npm: {
+          devDependencies: {
+            '@ember/jquery': '^0.6.0',
+            'ember-fetch': null,
           },
         },
-        {
-          name: 'ember-default-with-jquery',
-          env: {
-            EMBER_OPTIONAL_FEATURES: JSON.stringify({ 'jquery-integration': true }),
-          },
-          npm: {
-            devDependencies: {
-              '@ember/jquery': '^0.6.0',
-              'ember-fetch': null,
-            },
+      },
+      {
+        name: 'ember-classic',
+        env: {
+          EMBER_OPTIONAL_FEATURES: JSON.stringify({
+            'application-template-wrapper': true,
+            'default-async-observers': false,
+            'template-only-glimmer-components': false,
+          }),
+        },
+        npm: {
+          ember: {
+            edition: 'classic',
           },
         },
-        {
-          name: 'ember-default',
-          env: envWithoutJQuery,
-          npm: {
-            devDependencies: {},
-          },
+      },
+      {
+        name: 'ember-default',
+        npm: {
+          devDependencies: {},
         },
-      ],
-    };
-  });
+      },
+    ],
+  };
 };

--- a/package.json
+++ b/package.json
@@ -97,6 +97,9 @@
       "internal": ":house: Internal"
     }
   },
+  "ember": {
+    "edition": "octane"
+  },
   "ember-addon": {
     "configPath": "tests/dummy/config"
   },

--- a/tests/dummy/config/optional-features.json
+++ b/tests/dummy/config/optional-features.json
@@ -1,5 +1,5 @@
 {
   "application-template-wrapper": false,
   "jquery-integration": false,
-  "template-only-glimmer-components": false
+  "template-only-glimmer-components": true
 }

--- a/tests/dummy/config/optional-features.json
+++ b/tests/dummy/config/optional-features.json
@@ -1,3 +1,5 @@
 {
-  "jquery-integration": false
+  "application-template-wrapper": false,
+  "jquery-integration": false,
+  "template-only-glimmer-components": false
 }

--- a/tests/unit/setup-rendering-context-test.js
+++ b/tests/unit/setup-rendering-context-test.js
@@ -242,10 +242,25 @@ module('setupRenderingContext', function (hooks) {
     test('can pass function to be used as a "closure action"', async function (assert) {
       assert.expect(2);
 
+      this.owner.register('component:x-foo', Component.extend());
       this.owner.register(
         'template:components/x-foo',
         hbs`<button onclick={{action clicked}}>Click me!</button>`
       );
+
+      this.set('clicked', () => assert.ok(true, 'action was triggered'));
+      await this.render(hbs`{{x-foo clicked=clicked}}`);
+
+      assert.equal(this.element.textContent, 'Click me!', 'precond - component was rendered');
+      await click(this.element.querySelector('button'));
+    });
+
+    test('can pass function to be used as a "closure action" to a template only component', async function (assert) {
+      assert.expect(2);
+
+      let template = hbs`<button onclick={{action @clicked}}>Click me!</button>`;
+
+      this.owner.register('template:components/x-foo', template);
 
       this.set('clicked', () => assert.ok(true, 'action was triggered'));
       await this.render(hbs`{{x-foo clicked=clicked}}`);


### PR DESCRIPTION
* Use async/await for config/ember-try.js
* Add ember-classic try scenario
* Remove ember-without-application-wrapper scenario (tested in
    ember-classic scenario now)
* Fix bug in `ember-lts-3.12` and `ember-lts-3.16` scenario (they wer testing 3.4 :sob: )
* Enable `octane` by default
* Enable template only glimmer components

Closes #316