### PR TITLE
Remove ember-debug-handlers-polyfill.

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "ember-cli-test-loader": "^3.0.0",
     "ember-cli-typescript": "^1.5.0",
     "ember-data": "~3.17.0",
-    "ember-debug-handlers-polyfill": "^1.0.3",
     "ember-disable-prototype-extensions": "^1.1.3",
     "ember-fetch": "^8.0.1",
     "ember-load-initializers": "^2.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5103,11 +5103,6 @@ ember-data@~3.17.0:
     ember-cli-typescript "^3.1.3"
     ember-inflector "^3.0.1"
 
-ember-debug-handlers-polyfill@^1.0.3:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/ember-debug-handlers-polyfill/-/ember-debug-handlers-polyfill-1.1.1.tgz#e9ae0a720271a834221179202367421b580002ef"
-  integrity sha512-lO7FBAqJjzbL+IjnWhVfQITypPOJmXdZngZR/Vdn513W4g/Q6Sjicao/mDzeDCb48Y70C4Facwk0LjdIpSZkRg==
-
 ember-disable-prototype-extensions@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/ember-disable-prototype-extensions/-/ember-disable-prototype-extensions-1.1.3.tgz#1969135217654b5e278f9fe2d9d4e49b5720329e"


### PR DESCRIPTION
This is only needed to support Ember < 2.4.