### PR TITLE
Issue 871 - Make triggerKeyEvent compatible with the IE11 

### DIFF
--- a/addon-test-support/@ember/test-helpers/dom/trigger-key-event.ts
+++ b/addon-test-support/@ember/test-helpers/dom/trigger-key-event.ts
@@ -108,9 +108,9 @@ function keyFromKeyCodeAndModifiers(keycode: number, modifiers: KeyModifiers): s
  */
 function keyCodeFromKey(key: string) {
   let keys = Object.keys(keyFromKeyCode);
-  let keyCode = keys.find(keyCode => keyFromKeyCode[Number(keyCode)] === key);
+  let keyCode = keys.filter(keyCode => keyFromKeyCode[Number(keyCode)] === key)[0];
   if (!keyCode) {
-    keyCode = keys.find(keyCode => keyFromKeyCode[Number(keyCode)] === key.toLowerCase());
+    keyCode = keys.filter(keyCode => keyFromKeyCode[Number(keyCode)] === key.toLowerCase())[0];
   }
   return keyCode !== undefined ? parseInt(keyCode) : undefined;
 }


### PR DESCRIPTION
https://github.com/emberjs/ember-test-helpers/issues/871

In order to use triggerKeyEvent in IE11 `Array.find` was replaced by `Array.filter`

_`filter` is a bit slower than `find` here, if it's an issue I'll come up with another solution_ 
