### PR TITLE
fix: Stabilize test suite isolation

### DIFF
--- a/addon-test-support/@ember/test-helpers/wait-until.ts
+++ b/addon-test-support/@ember/test-helpers/wait-until.ts
@@ -59,6 +59,7 @@ export default function waitUntil<T>(
           value = callback();
         } catch (error) {
           reject(error);
+          return;
         }
 
         if (value) {
@@ -67,6 +68,7 @@ export default function waitUntil<T>(
           scheduleCheck(timeoutsIndex + 1);
         } else {
           reject(waitUntilTimedOut);
+          return;
         }
       }, interval);
     }

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -4,6 +4,7 @@ import AbstractTestLoader from 'ember-cli-test-loader/test-support/index';
 import Ember from 'ember';
 import { isSettled, getSettledState } from '@ember/test-helpers';
 import { run } from '@ember/runloop';
+import './helpers/resolver';
 
 if (QUnit.config.seed) {
   QUnit.config.reorder = false;

--- a/tests/unit/dom/double-click-test.js
+++ b/tests/unit/dom/double-click-test.js
@@ -20,6 +20,7 @@ module('DOM Helper: doubleClick', function (hooks) {
 
     if (element) {
       element.parentNode.removeChild(element);
+      element = null;
     }
     if (context.owner) {
       await teardownContext(context);

--- a/tests/unit/dom/fill-in-test.js
+++ b/tests/unit/dom/fill-in-test.js
@@ -26,6 +26,7 @@ module('DOM Helper: fillIn', function (hooks) {
 
     if (element) {
       element.parentNode.removeChild(element);
+      element = null;
     }
     if (context.owner) {
       await teardownContext(context);

--- a/tests/unit/dom/find-test.js
+++ b/tests/unit/dom/find-test.js
@@ -18,6 +18,7 @@ module('DOM Helper: find', function (hooks) {
   hooks.afterEach(async function () {
     if (element.parentNode) {
       element.parentNode.removeChild(element);
+      element = null;
     }
     if (context.owner) {
       await teardownContext(context);

--- a/tests/unit/dom/focus-test.js
+++ b/tests/unit/dom/focus-test.js
@@ -26,6 +26,7 @@ module('DOM Helper: focus', function (hooks) {
 
     if (element) {
       element.parentNode.removeChild(element);
+      element = null;
     }
     // only teardown if setupContext was called
     if (context.owner) {

--- a/tests/unit/dom/select-files-test.js
+++ b/tests/unit/dom/select-files-test.js
@@ -27,6 +27,7 @@ module('DOM Helper: selectFiles', function (hooks) {
   hooks.afterEach(async function () {
     if (element) {
       element.parentNode.removeChild(element);
+      element = null;
     }
 
     // only teardown if setupContext was called

--- a/tests/unit/dom/select-test.js
+++ b/tests/unit/dom/select-test.js
@@ -20,6 +20,7 @@ module('DOM Helper: select', function (hooks) {
     if (element) {
       element.setAttribute('data-skip-steps', true);
       element.parentNode.removeChild(element);
+      element = null;
     }
     if (context.owner) {
       await teardownContext(context);

--- a/tests/unit/dom/tap-test.js
+++ b/tests/unit/dom/tap-test.js
@@ -24,6 +24,7 @@ module('DOM Helper: tap', function (hooks) {
 
     if (element) {
       element.parentNode.removeChild(element);
+      element = null;
     }
     // only teardown if setupContext was called
     if (context.owner) {

--- a/tests/unit/dom/trigger-event-test.js
+++ b/tests/unit/dom/trigger-event-test.js
@@ -23,6 +23,7 @@ module('DOM Helper: triggerEvent', function (hooks) {
 
     if (element) {
       element.parentNode.removeChild(element);
+      element = null;
     }
 
     // only teardown if setupContext was called

--- a/tests/unit/dom/trigger-key-event-test.js
+++ b/tests/unit/dom/trigger-key-event-test.js
@@ -23,6 +23,7 @@ module('DOM Helper: triggerKeyEvent', function (hooks) {
 
     if (element) {
       element.parentNode.removeChild(element);
+      element = null;
     }
 
     // only teardown if setupContext was called

--- a/tests/unit/dom/type-in-test.js
+++ b/tests/unit/dom/type-in-test.js
@@ -62,6 +62,7 @@ module('DOM Helper: typeIn', function (hooks) {
 
     if (element) {
       element.parentNode.removeChild(element);
+      element = null;
     }
     if (context.owner) {
       await teardownContext(context);

--- a/tests/unit/setup-rendering-context-test.js
+++ b/tests/unit/setup-rendering-context-test.js
@@ -28,7 +28,7 @@ module('setupRenderingContext', function (hooks) {
     return;
   }
 
-  hooks.after(function () {
+  hooks.afterEach(function () {
     setApplication(application);
     setResolver(resolver);
   });

--- a/tests/unit/wait-until-test.js
+++ b/tests/unit/wait-until-test.js
@@ -1,4 +1,5 @@
 import { module, test } from 'qunit';
+import { Promise } from 'rsvp';
 import { waitUntil } from '@ember/test-helpers';
 
 module('DOM helper: waitUntil', function () {
@@ -68,5 +69,20 @@ module('DOM helper: waitUntil', function () {
     }).catch(reason => {
       assert.equal(reason.message, 'error goes here', 'valid error was thrown');
     });
+  });
+
+  test('does not continue to wait if callback throws', async function (assert) {
+    assert.expect(2);
+
+    try {
+      await waitUntil(() => {
+        assert.ok(true);
+        throw new Error('error goes here');
+      });
+    } catch (error) {
+      assert.equal(error.message, 'error goes here', 'valid error was thrown');
+    }
+
+    await new Promise(resolve => setTimeout(resolve, 100));
   });
 });


### PR DESCRIPTION
There were a few issues this PR is attempting to fix:

1. Correct reset `Application` when it's set to `null`
1. Correctly return from `waitUntil` when we reject so we stop recursing
1. Correctly sets `element` to `null` in tests where element is used.