### PR TITLE
Remove floating dependencies CI run for v1.x branch.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,9 +38,6 @@ jobs:
       script:
         - yarn lint
         - yarn test
-    - name: 'floating dependencies'
-      install: yarn install --no-lockfile --non-interactive --ignore-engines
-      script: yarn test
 
     # runs tests against each supported Ember version
     - stage: older version tests


### PR DESCRIPTION
Many projects dropped support for Node 6, there is no way this will pass. This drops the floating dependencies test run and depends on our lock file + ember-try scenario tests.