### PR TITLE
Remove manual DOM cleanup code after each test.

### DIFF
--- a/addon-test-support/@ember/test-helpers/setup-context.ts
+++ b/addon-test-support/@ember/test-helpers/setup-context.ts
@@ -1,6 +1,5 @@
 import { run } from '@ember/runloop';
 import { set, setProperties, get, getProperties } from '@ember/object';
-import { guidFor } from '@ember/object/internals';
 import Resolver from '@ember/application/resolver';
 
 import buildOwner, { Owner } from './build-owner';
@@ -133,8 +132,6 @@ export function resumeTest(): void {
   context.resumeTest();
 }
 
-export const CLEANUP = Object.create(null);
-
 /**
   Used by test framework addons to setup the provided context for testing.
 
@@ -159,9 +156,6 @@ export default function setupContext(
   (Ember as any).testing = true;
   setContext(context);
 
-  let contextGuid = guidFor(context);
-  CLEANUP[contextGuid] = [];
-
   let testMetadata: ITestMetadata = getTestMetadata(context);
   testMetadata.setupTypes.push('setupContext');
 
@@ -176,15 +170,6 @@ export default function setupContext(
       return;
     })
     .then(() => {
-      let testElementContainer = document.getElementById('ember-testing-container')!; // TODO remove "!"
-      let fixtureResetValue = testElementContainer.innerHTML;
-
-      // push this into the final cleanup bucket, to be ran _after_ the owner
-      // is destroyed and settled (e.g. flushed run loops, etc)
-      CLEANUP[contextGuid].push(() => {
-        testElementContainer.innerHTML = fixtureResetValue;
-      });
-
       let { resolver } = options;
 
       // This handles precendence, specifying a specific option of

--- a/addon-test-support/@ember/test-helpers/setup-rendering-context.ts
+++ b/addon-test-support/@ember/test-helpers/setup-rendering-context.ts
@@ -1,5 +1,4 @@
 /* globals EmberENV */
-import { guidFor } from '@ember/object/internals';
 import { run } from '@ember/runloop';
 import Ember from 'ember';
 import global from './global';
@@ -13,7 +12,6 @@ import getTestMetadata, { ITestMetadata } from './test-metadata';
 import { deprecate } from '@ember/application/deprecations';
 import { runHooks } from './-internal/helper-hooks';
 
-export const RENDERING_CLEANUP = Object.create(null);
 const OUTLET_TEMPLATE = hbs`{{outlet}}`;
 const EMPTY_TEMPLATE = hbs``;
 
@@ -176,9 +174,6 @@ export function clearRender(): Promise<void> {
   @returns {Promise<Object>} resolves with the context that was setup
 */
 export default function setupRenderingContext(context: TestContext): Promise<RenderingTestContext> {
-  let contextGuid = guidFor(context);
-  RENDERING_CLEANUP[contextGuid] = [];
-
   let testMetadata: ITestMetadata = getTestMetadata(context);
   testMetadata.setupTypes.push('setupRenderingContext');
 

--- a/addon-test-support/@ember/test-helpers/teardown-context.ts
+++ b/addon-test-support/@ember/test-helpers/teardown-context.ts
@@ -1,8 +1,7 @@
-import { guidFor } from '@ember/object/internals';
 import { run } from '@ember/runloop';
 import { _teardownAJAXHooks } from './settled';
-import { unsetContext, CLEANUP, TestContext } from './setup-context';
-import { nextTickPromise, runDestroyablesFor } from './-utils';
+import { unsetContext, TestContext } from './setup-context';
+import { nextTickPromise } from './-utils';
 import settled from './settled';
 import Ember from 'ember';
 
@@ -47,10 +46,6 @@ export default function teardownContext(
       return nextTickPromise();
     })
     .finally(() => {
-      let contextGuid = guidFor(context);
-
-      runDestroyablesFor(CLEANUP, contextGuid);
-
       if (waitForSettled) {
         return settled();
       }

--- a/addon-test-support/@ember/test-helpers/teardown-rendering-context.ts
+++ b/addon-test-support/@ember/test-helpers/teardown-rendering-context.ts
@@ -1,6 +1,5 @@
-import { guidFor } from '@ember/object/internals';
-import { RENDERING_CLEANUP, RenderingTestContext } from './setup-rendering-context';
-import { nextTickPromise, runDestroyablesFor } from './-utils';
+import { RenderingTestContext } from './setup-rendering-context';
+import { nextTickPromise } from './-utils';
 import settled from './settled';
 
 /**
@@ -27,10 +26,6 @@ export default function teardownRenderingContext(
   }
 
   return nextTickPromise().then(() => {
-    let contextGuid = guidFor(context);
-
-    runDestroyablesFor(RENDERING_CLEANUP, contextGuid);
-
     if (waitForSettled) {
       return settled();
     }

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -79,19 +79,6 @@ QUnit.testDone(function ({ module, name }) {
     Ember.testing = false;
   }
 
-  // this is used to ensure that the testing container is always reset properly
-  let testElementContainer = document.getElementById('ember-testing-container');
-  let actual = testElementContainer.innerHTML;
-  let expected = `<div id="ember-testing"></div>`;
-  if (actual !== expected) {
-    let message = `Expected #ember-testing-container to be reset after ${module}: ${name}, but was \`${actual}\``;
-    cleanupFailures.push(message);
-
-    // eslint-disable-next-line
-    console.error(message);
-    testElementContainer.innerHTML = expected;
-  }
-
   if (!isSettled()) {
     let message = `Expected to be settled after ${module}: ${name}, but was \`${JSON.stringify(
       getSettledState()

--- a/tests/unit/teardown-rendering-context-test.js
+++ b/tests/unit/teardown-rendering-context-test.js
@@ -25,40 +25,6 @@ module('teardownRenderingContext', function (hooks) {
     return teardownContext(this);
   });
 
-  test('clears any attributes added to the ember-testing div', async function (assert) {
-    let beforeTeardownEl = document.getElementById('ember-testing');
-    beforeTeardownEl.setAttribute('data-was-set', '');
-
-    assert.ok(
-      beforeTeardownEl.hasAttribute('data-was-set'),
-      'precond - attribute is present before teardown'
-    );
-    assert.ok(
-      document.body.contains(beforeTeardownEl),
-      'precond - ember-testing element is in DOM'
-    );
-
-    await teardownRenderingContext(this);
-    await teardownContext(this);
-
-    let afterTeardownEl = document.getElementById('ember-testing');
-
-    assert.notOk(
-      afterTeardownEl.hasAttribute('data-was-set'),
-      'attribute is not present on ember-testing that is in DOM'
-    );
-    assert.ok(document.body.contains(afterTeardownEl), 'ember-testing element is still in DOM');
-
-    assert.ok(
-      beforeTeardownEl.hasAttribute('data-was-set'),
-      'attribute is still present on prior ember-testing element after teardown'
-    );
-    assert.notOk(
-      document.body.contains(beforeTeardownEl),
-      'previous ember-testing element is no longer in DOM'
-    );
-  });
-
   test('can opt out of waiting for settledness', async function (assert) {
     this.shouldWait = true;
 


### PR DESCRIPTION
Rely on test framework integration system (e.g. `ember-qunit` or `ember-mocha`) to handle cleanup.