### PR TITLE
Migrate to using @ember/destroyable for teardown.

### DIFF
--- a/addon-test-support/@ember/test-helpers/teardown-context.ts
+++ b/addon-test-support/@ember/test-helpers/teardown-context.ts
@@ -1,9 +1,7 @@
-import { run } from '@ember/runloop';
-import { _teardownAJAXHooks } from './settled';
-import { unsetContext, TestContext } from './setup-context';
+import { TestContext } from './setup-context';
 import { nextTickPromise } from './-utils';
 import settled from './settled';
-import Ember from 'ember';
+import { destroy } from '@ember/destroyable';
 
 /**
   Used by test framework addons to tear down the provided context after testing is completed.
@@ -28,28 +26,16 @@ export default function teardownContext(
   if (options !== undefined && 'waitForSettled' in options) {
     waitForSettled = options.waitForSettled!;
   }
+
   return nextTickPromise()
     .then(() => {
-      let { owner } = context;
-
-      _teardownAJAXHooks();
-
-      run(owner, 'destroy');
-      (Ember as any).testing = false;
-
-      unsetContext();
-
-      if (waitForSettled) {
-        return settled();
-      }
-
-      return nextTickPromise();
+      destroy(context);
     })
     .finally(() => {
       if (waitForSettled) {
         return settled();
       }
 
-      return nextTickPromise();
+      return;
     });
 }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "broccoli-debug": "^0.6.5",
     "broccoli-funnel": "^3.0.3",
     "ember-cli-babel": "^7.22.1",
-    "ember-cli-htmlbars": "^5.2.0"
+    "ember-cli-htmlbars": "^5.2.0",
+    "ember-destroyable-polyfill": "^2.0.1"
   },
   "devDependencies": {
     "@ember/optional-features": "^1.3.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -33,6 +33,7 @@
       "@ember/test-helpers/*": [
         "addon-test-support/@ember/test-helpers/*"
       ],
+      "@ember/destroyable": ["node_modules/ember-destroyable-polyfill"],
       "*": [
         "types/*"
       ]

--- a/yarn.lock
+++ b/yarn.lock
@@ -5151,6 +5151,15 @@ ember-compatibility-helpers@^1.1.1, ember-compatibility-helpers@^1.2.0:
     ember-cli-version-checker "^2.1.1"
     semver "^5.4.1"
 
+ember-compatibility-helpers@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/ember-compatibility-helpers/-/ember-compatibility-helpers-1.2.1.tgz#87c92c4303f990ff455c28ca39fb3ee11441aa16"
+  integrity sha512-6wzYvnhg1ihQUT5yGqnLtleq3Nv5KNv79WhrEuNU9SwR4uIxCO+KpyC7r3d5VI0EM7/Nmv9Nd0yTkzmTMdVG1A==
+  dependencies:
+    babel-plugin-debug-macros "^0.2.0"
+    ember-cli-version-checker "^2.1.1"
+    semver "^5.4.1"
+
 ember-data@~3.20.0:
   version "3.20.0"
   resolved "https://registry.yarnpkg.com/ember-data/-/ember-data-3.20.0.tgz#613cfca5276b16b4f4bbfb35432e58f3e5a2d9f3"
@@ -5170,6 +5179,15 @@ ember-data@~3.20.0:
     ember-cli-babel "^7.18.0"
     ember-cli-typescript "^3.1.3"
     ember-inflector "^3.0.1"
+
+ember-destroyable-polyfill@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/ember-destroyable-polyfill/-/ember-destroyable-polyfill-2.0.1.tgz#391cd95a99debaf24148ce953054008d00f151a6"
+  integrity sha512-hyK+/GPWOIxM1vxnlVMknNl9E5CAFVbcxi8zPiM0vCRwHiFS8Wuj7PfthZ1/OFitNNv7ITTeU8hxqvOZVsrbnQ==
+  dependencies:
+    ember-cli-babel "^7.22.1"
+    ember-cli-version-checker "^5.1.1"
+    ember-compatibility-helpers "^1.2.1"
 
 ember-disable-prototype-extensions@^1.1.3:
   version "1.1.3"


### PR DESCRIPTION
Moves actual logic from `teardownContext` into `setupContext` by using `registerDestructor` and `associateDestroyableChild`.