### PR TITLE
fix typo in example that calles `new File(...)`

### DIFF
--- a/addon-test-support/@ember/test-helpers/dom/trigger-event.ts
+++ b/addon-test-support/@ember/test-helpers/dom/trigger-event.ts
@@ -49,7 +49,7 @@ registerHook('triggerEvent', 'start', (target: Target, eventType: string) => {
  *   'drop',
  *   {
  *     dataTransfer: {
- *       files: [new File(['Ember Rules!', 'ember-rules.txt'])]
+ *       files: [new File(['Ember Rules!'], 'ember-rules.txt')]
  *     }
  *   }
  * )


### PR DESCRIPTION
The `File` constructor takes 2 arguments, first an array with data, second the name.