### PR TITLE
Blur the previous active element on focus

### DIFF
--- a/addon-test-support/@ember/test-helpers/dom/focus.ts
+++ b/addon-test-support/@ember/test-helpers/dom/focus.ts
@@ -6,6 +6,7 @@ import { nextTickPromise } from '../-utils';
 import Target from './-target';
 import { log } from '@ember/test-helpers/dom/-logging';
 import { runHooks, registerHook } from '../-internal/helper-hooks';
+import { __blur__ } from './blur';
 
 registerHook('focus', 'start', (target: Target) => {
   log('focus', target);
@@ -21,6 +22,14 @@ export function __focus__(element: HTMLElement | Element | Document | SVGElement
   }
 
   let browserIsNotFocused = document.hasFocus && !document.hasFocus();
+
+  if (
+    document.activeElement &&
+    document.activeElement !== element &&
+    isFocusable(document.activeElement)
+  ) {
+    __blur__(document.activeElement);
+  }
 
   // makes `document.activeElement` be `element`. If the browser is focused, it also fires a focus event
   element.focus();


### PR DESCRIPTION
implements [suggestion](https://github.com/emberjs/ember-test-helpers/issues/692#issuecomment-617563815) by @Turbo87 

I don't feel strongly if we need to cover by tests each helper which uses `__focus__` internally. Please, let me know if we should.