### PR TITLE
Make it possible to call `triggerEvent(fileInput, 'change', { files })` twice with the same files

### DIFF
--- a/addon-test-support/@ember/test-helpers/dom/fire-event.ts
+++ b/addon-test-support/@ember/test-helpers/dom/fire-event.ts
@@ -262,7 +262,7 @@ function buildFileEvent(
       value(index: number) {
         return typeof index === 'number' ? this[index] : null;
       },
-      configurable: true
+      configurable: true,
     });
     Object.defineProperty(element, 'files', {
       value: files,

--- a/addon-test-support/@ember/test-helpers/dom/fire-event.ts
+++ b/addon-test-support/@ember/test-helpers/dom/fire-event.ts
@@ -262,6 +262,7 @@ function buildFileEvent(
       value(index: number) {
         return typeof index === 'number' ? this[index] : null;
       },
+      configurable: true
     });
     Object.defineProperty(element, 'files', {
       value: files,

--- a/tests/unit/dom/select-files-test.js
+++ b/tests/unit/dom/select-files-test.js
@@ -81,7 +81,6 @@ module('DOM Helper: selectFiles', function (hooks) {
     assert.verifySteps(['change', 'empty']);
   });
 
-
   test('can trigger file event with same selection twice without error', async function (assert) {
     element = buildInstrumentedElement('input');
     element.setAttribute('type', 'file');
@@ -92,7 +91,7 @@ module('DOM Helper: selectFiles', function (hooks) {
 
     await setupContext(context);
 
-    const files = [ new File(['(⌐□_□)'], 'chucknorris.png', { type: 'image/png' }) ];
+    const files = [new File(['(⌐□_□)'], 'chucknorris.png', { type: 'image/png' })];
     await triggerEvent(element, 'change', { files });
     await triggerEvent(element, 'change', { files });
 

--- a/tests/unit/dom/select-files-test.js
+++ b/tests/unit/dom/select-files-test.js
@@ -80,4 +80,22 @@ module('DOM Helper: selectFiles', function (hooks) {
 
     assert.verifySteps(['change', 'empty']);
   });
+
+
+  test('can trigger file event with same selection twice without error', async function (assert) {
+    element = buildInstrumentedElement('input');
+    element.setAttribute('type', 'file');
+
+    element.addEventListener('change', e => {
+      assert.step(e.target.files[0].name);
+    });
+
+    await setupContext(context);
+
+    const files = [ new File(['(⌐□_□)'], 'chucknorris.png', { type: 'image/png' }) ];
+    await triggerEvent(element, 'change', { files });
+    await triggerEvent(element, 'change', { files });
+
+    assert.verifySteps(['change', 'chucknorris.png', 'change', 'chucknorris.png']);
+  });
 });

--- a/tests/unit/dom/trigger-event-test.js
+++ b/tests/unit/dom/trigger-event-test.js
@@ -170,4 +170,14 @@ module('DOM Helper: triggerEvent', function (hooks) {
 
     assert.verifySteps(['inner: mouseenter', 'outer: mouseenter', 'mouseenter']);
   });
+
+  test('can trigger file event twice without error', async function (assert) {
+    await setupContext(context);
+    let fileInput = buildInstrumentedElement('input');
+    fileInput.type = 'file';
+
+    const files = [ new File(['(⌐□_□)'], 'chucknorris.png', { type: 'image/png' }) ];
+    await triggerEvent(fileInput, 'change', { files });
+    await triggerEvent(fileInput, 'change', { files });
+  });
 });

--- a/tests/unit/dom/trigger-event-test.js
+++ b/tests/unit/dom/trigger-event-test.js
@@ -170,14 +170,4 @@ module('DOM Helper: triggerEvent', function (hooks) {
 
     assert.verifySteps(['inner: mouseenter', 'outer: mouseenter', 'mouseenter']);
   });
-
-  test('can trigger file event twice without error', async function (assert) {
-    await setupContext(context);
-    let fileInput = buildInstrumentedElement('input');
-    fileInput.type = 'file';
-
-    const files = [ new File(['(⌐□_□)'], 'chucknorris.png', { type: 'image/png' }) ];
-    await triggerEvent(fileInput, 'change', { files });
-    await triggerEvent(fileInput, 'change', { files });
-  });
 });


### PR DESCRIPTION
Fixes #921 

Not really sure what I did wrong the previous time, now it seems to work fine.

Also moved the testcase to a better location as suggested.