### PR TITLE
triggerKeyEvent() #=> keyCodeFromKey() optimization

### DIFF
--- a/addon-test-support/@ember/test-helpers/dom/trigger-key-event.ts
+++ b/addon-test-support/@ember/test-helpers/dom/trigger-key-event.ts
@@ -117,10 +117,11 @@ function keyFromKeyCodeAndModifiers(keycode: number, modifiers: KeyModifiers): s
  */
 function keyCodeFromKey(key: string) {
   let keys = Object.keys(keyFromKeyCode);
-  let keyCode = keys.filter(keyCode => keyFromKeyCode[Number(keyCode)] === key)[0];
+  let keyCode = keys.find(keyCode => keyFromKeyCode[Number(keyCode)] === key);
   if (!keyCode) {
-    keyCode = keys.filter(keyCode => keyFromKeyCode[Number(keyCode)] === key.toLowerCase())[0];
+    keyCode = keys.find(keyCode => keyFromKeyCode[Number(keyCode)] === key.toLowerCase());
   }
+
   return keyCode !== undefined ? parseInt(keyCode) : undefined;
 }
 

--- a/addon-test-support/@ember/test-helpers/dom/trigger-key-event.ts
+++ b/addon-test-support/@ember/test-helpers/dom/trigger-key-event.ts
@@ -117,10 +117,9 @@ function keyFromKeyCodeAndModifiers(keycode: number, modifiers: KeyModifiers): s
  */
 function keyCodeFromKey(key: string) {
   let keys = Object.keys(keyFromKeyCode);
-  let keyCode = keys.find(keyCode => keyFromKeyCode[Number(keyCode)] === key);
-  if (!keyCode) {
-    keyCode = keys.find(keyCode => keyFromKeyCode[Number(keyCode)] === key.toLowerCase());
-  }
+  let keyCode =
+    keys.find(keyCode => keyFromKeyCode[Number(keyCode)] === key) ||
+    keys.find(keyCode => keyFromKeyCode[Number(keyCode)] === key.toLowerCase());
 
   return keyCode !== undefined ? parseInt(keyCode) : undefined;
 }


### PR DESCRIPTION
- In the first commit replaced addon-test-support/@ember/test-helpers/dom/trigger-key-event.ts#120 `.filter()[0]` to `find()` for short circuit optimization.
- In the second commit made the second check lazy with `||`.
