### PR TITLE
Use RSVP promises instead of `_Promise` class extension in helper hooks

### DIFF
--- a/addon-test-support/@ember/test-helpers/-internal/helper-hooks.ts
+++ b/addon-test-support/@ember/test-helpers/-internal/helper-hooks.ts
@@ -1,4 +1,4 @@
-import { _Promise as Promise } from '../-utils';
+import { Promise } from 'rsvp';
 
 type Hook = (...args: any[]) => void | Promise<void>;
 type HookLabel = 'start' | 'end' | string;


### PR DESCRIPTION
Still seeing a few strange async related test failures throughout a bunch of tests. For whatever reason, using RSVP promises directly resolves these failures. Applying this change has somewhat reduced the overall number of failing tests we've been seeing after upgrading to the new test dependencies.