### PR TITLE
Fixes maxlength conditional check for textarea & constrained input types

### DIFF
--- a/addon-test-support/@ember/test-helpers/dom/-guard-for-maxlength.ts
+++ b/addon-test-support/@ember/test-helpers/dom/-guard-for-maxlength.ts
@@ -13,8 +13,8 @@ function isMaxLengthConstrained(
 ): element is HTMLInputElement | HTMLTextAreaElement {
   return (
     !!Number(element.getAttribute('maxLength')) &&
-    (element instanceof HTMLInputElement ||
-      (element instanceof HTMLTextAreaElement && constrainedInputTypes.indexOf(element.type) > -1))
+    (element instanceof HTMLTextAreaElement ||
+      (element instanceof HTMLInputElement && constrainedInputTypes.indexOf(element.type) > -1))
   );
 }
 

--- a/tests/unit/dom/fill-in-test.js
+++ b/tests/unit/dom/fill-in-test.js
@@ -254,4 +254,53 @@ module('DOM Helper: fillIn', function (hooks) {
       new Error("Can not `fillIn` with text: 'foo' that exceeds maxlength: '1'.")
     );
   });
+
+  test('filling in a non-constrained input type with maxlength', async function (assert) {
+    element = buildInstrumentedElement('input');
+    const maxLengthString = '1';
+    const tooLongString = maxLengthString.concat('23');
+    element.setAttribute('type', 'number');
+    element.setAttribute('maxlength', maxLengthString.length);
+    await setupContext(context);
+
+    await fillIn(element, tooLongString);
+
+    assert.verifySteps(clickSteps);
+    assert.equal(
+      element.value,
+      tooLongString,
+      'fillIn does not reject non-constrained input types'
+    );
+  });
+
+  test('filling a textarea with a maxlength with suitable value', async function (assert) {
+    element = buildInstrumentedElement('textarea');
+    const maxLengthString = 'f';
+    element.setAttribute('maxlength', maxLengthString.length);
+
+    await setupContext(context);
+
+    await fillIn(element, maxLengthString);
+
+    assert.verifySteps(clickSteps);
+    assert.equal(
+      element.value,
+      maxLengthString,
+      `fillIn respects textarea attribute [maxlength=${maxLengthString.length}]`
+    );
+  });
+
+  test('filling a textarea with a maxlength with too long value', async function (assert) {
+    element = buildInstrumentedElement('textarea');
+    const maxLengthString = 'f';
+    const tooLongString = maxLengthString.concat('oo');
+    element.setAttribute('maxlength', maxLengthString.length);
+
+    await setupContext(context);
+
+    assert.rejects(
+      fillIn(element, tooLongString),
+      new Error("Can not `fillIn` with text: 'foo' that exceeds maxlength: '1'.")
+    );
+  });
 });


### PR DESCRIPTION
Currently, the `maxlength` guard for `typeIn` and `fillIn` helpers doesn't actually execute for `textarea` elements, nor does it discriminate between constrained and non-constrained input types. The issue is actually from an [inverted check](https://github.com/emberjs/ember-test-helpers/blob/master/addon-test-support/%40ember/test-helpers/dom/-guard-for-maxlength.ts#L16-L17) in the conditional. I've also added more tests to catch this sort of thing. The non-constrained test is slightly contrived, but it would definitely catch a problem if the input type isn't properly verified.