### PR TITLE
Polyfilled test selector optimizations 

### DIFF
--- a/addon-test-support/@ember/test-helpers/dom/find-all.ts
+++ b/addon-test-support/@ember/test-helpers/dom/find-all.ts
@@ -1,5 +1,5 @@
 import getElements from './-get-elements';
-import toArray from './-to-array';
+import { toArray } from '../ie-11-polyfills';
 
 /**
   Find all elements matched by the given selector. Similar to calling

--- a/addon-test-support/@ember/test-helpers/dom/trigger-key-event.ts
+++ b/addon-test-support/@ember/test-helpers/dom/trigger-key-event.ts
@@ -8,6 +8,7 @@ import Target from './-target';
 import { log } from '@ember/test-helpers/dom/-logging';
 import isFormControl from './-is-form-control';
 import { runHooks, registerHook } from '../-internal/helper-hooks';
+import { find } from '../ie-11-polyfills';
 
 registerHook(
   'triggerKeyEvent',
@@ -117,10 +118,10 @@ function keyFromKeyCodeAndModifiers(keycode: number, modifiers: KeyModifiers): s
  */
 function keyCodeFromKey(key: string) {
   let keys = Object.keys(keyFromKeyCode);
-  let keyCode = keys.filter(keyCode => keyFromKeyCode[Number(keyCode)] === key)[0];
-  if (!keyCode) {
-    keyCode = keys.filter(keyCode => keyFromKeyCode[Number(keyCode)] === key.toLowerCase())[0];
-  }
+  let keyCode =
+    find(keys, (keyCode: string) => keyFromKeyCode[Number(keyCode)] === key) ||
+    find(keys, (keyCode: string) => keyFromKeyCode[Number(keyCode)] === key.toLowerCase());
+
   return keyCode !== undefined ? parseInt(keyCode) : undefined;
 }
 

--- a/addon-test-support/@ember/test-helpers/dom/wait-for.ts
+++ b/addon-test-support/@ember/test-helpers/dom/wait-for.ts
@@ -1,7 +1,7 @@
 import waitUntil from '../wait-until';
 import getElement from './-get-element';
 import getElements from './-get-elements';
-import toArray from './-to-array';
+import { toArray } from '../ie-11-polyfills';
 import { Promise } from '../-utils';
 
 export interface Options {

--- a/addon-test-support/@ember/test-helpers/ie-11-polyfills.ts
+++ b/addon-test-support/@ember/test-helpers/ie-11-polyfills.ts
@@ -1,0 +1,34 @@
+// @ts-nocheck
+/**
+ * Polyfills Array.prototype.find for ie11 without mocking the app during test execution
+ * @param {array} array to find an element
+ * @param {predicate} predicate function to find the element
+ * @returns {(number | string | array | function)} found element inside the array
+ */
+export function find<T>(array: Array<T>, predicate: Function) {
+  return Array.prototype.find ? array.find(predicate) : array.filter(predicate)[0];
+}
+
+/**
+ * Polyfills Array.from for ie11 without mocking the app during test execution
+ * @param {array} nodeList like data structure(e.g. NodeList)
+ * @returns {array} parameter converted to a JS array
+ */
+export function toArray<T extends Node>(nodeList: NodeListOf<T>): T[] {
+  return Array.from ? Array.from(nodeList) : toArrayPolyfill(nodeList);
+}
+
+/**
+ * @private
+ * Polyfills Array.from for ie11 without mocking the app during test execution
+ * @param {array} nodeList like data structure(e.g. NodeList)
+ * @returns {array} parameter converted to a JS array
+ */
+function toArrayPolyfill<T extends Node>(nodeList: NodeListOf<T>): T[] {
+  let array = new Array(nodeList.length);
+  for (let i = 0; i < nodeList.length; i++) {
+    array[i] = nodeList[i];
+  }
+
+  return array;
+}


### PR DESCRIPTION
- In the first commit we introduce a polyfill for ie11 to support `Array.from` and `Array.prototype.find`.
- In the second commit we optimize `findAll()` and `waitFor` to use `Array.from`
- In the third commit we optimize `triggerKeyEvent` to use `array.find()` instead of `array.filter(predicate)[0]`;
