### PR TITLE
Failing test for helpers using `runHooks` being unsettled after resolving

### DIFF
--- a/tests/unit/dom/helper-hooks-test.js
+++ b/tests/unit/dom/helper-hooks-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { Promise } from 'rsvp';
-import { _registerHook, _runHooks } from '@ember/test-helpers';
+import { _registerHook, _runHooks, isSettled } from '@ember/test-helpers';
 
 module('helper hooks', function () {
   test('it can register a hook for a helper', async function (assert) {
@@ -81,6 +81,23 @@ module('helper hooks', function () {
     } finally {
       fooHook1.unregister();
       fooHook2.unregister();
+    }
+  });
+
+  test('it is settled after runHooks resolves', async function (assert) {
+    await _runHooks('missing-thing', 'start');
+
+    assert.ok(isSettled(), 'is settled after runHooks with no hooks');
+
+    let func = () => {};
+    let hook = _registerHook('present-thing', 'start', func);
+
+    try {
+      await _runHooks('click', 'start');
+
+      assert.ok(isSettled(), 'is settled after runHooks with no hooks');
+    } finally {
+      hook.unregister();
     }
   });
 });

--- a/tests/unit/setup-application-context-test.js
+++ b/tests/unit/setup-application-context-test.js
@@ -13,6 +13,7 @@ import {
   currentRouteName,
   currentURL,
   _registerHook,
+  isSettled,
 } from '@ember/test-helpers';
 import hasEmberVersion from '@ember/test-helpers/has-ember-version';
 import { setResolverRegistry } from '../helpers/resolver';
@@ -118,6 +119,12 @@ module('setupApplicationContext', function (hooks) {
 
     assert.equal(this.element.querySelector('.nav').textContent, 'posts | widgets');
     assert.equal(this.element.querySelector('h1').textContent, 'Hello World!');
+  });
+
+  test('is settled after a visit', async function(assert) {
+    await visit('/');
+
+    assert.ok(isSettled(), 'should be settled');
   });
 
   test('can perform a basic template rendering for nested route', async function (assert) {

--- a/tests/unit/setup-rendering-context-test.js
+++ b/tests/unit/setup-rendering-context-test.js
@@ -18,6 +18,7 @@ import {
   focus,
   blur,
   click,
+  isSettled,
 } from '@ember/test-helpers';
 import hasEmberVersion from '@ember/test-helpers/has-ember-version';
 import { setResolverRegistry, application, resolver } from '../helpers/resolver';
@@ -81,6 +82,12 @@ module('setupRenderingContext', function (hooks) {
         assert.equal(this.element.textContent, 'Hello!');
       });
     }
+
+    test('is settled after rendering', async function (assert) {
+      await render(hbs`Hi!`);
+
+      assert.ok(isSettled(), 'should be settled');
+    });
 
     overwriteTest('element');
 
@@ -150,6 +157,14 @@ module('setupRenderingContext', function (hooks) {
       assert.equal(this.element.textContent, '', 'has rendered content');
       assert.equal(testingRootElement.textContent, '', 'has rendered content');
       assert.strictEqual(this.element, originalElement, 'this.element is stable');
+    });
+
+    test('is settled after clearRender', async function (assert) {
+      await render(hbs`<p>Hello!</p>`);
+
+      await clearRender();
+
+      assert.ok(isSettled(), 'should be settled');
     });
 
     overwriteTest('render');


### PR DESCRIPTION
This commit introduces a number of (currently failing) tests that are attempting to confirm that after running various public methods that we are in a settled state.

The tests all fail at the moment, because the `Promise.all` that is done wihtin `runHooks` does **not** go through our custom `RSVP.configure('async', fn)`. This is because the `async` hook in RSVP
only receives a second argument (the `promise` argument) in some circumstances but not in the case where the parent promise is not in the pending state ([this branch in RSVP](https://github.com/tildeio/rsvp.js/blob/429ade2379dfbfb6e2c6f453b4aeb642515dbb74/lib/rsvp/then.js#L28-L33)). `RSVP.Promise.all([undefined, undefined])` is considered
settled immediately, so `RSVP.Promise.all().then(fn)` returns a promise that will **not** get our custom promise resolution scheduling.

Since our custom scheduling is not being used here, the normal `RSVP` integration is used which means that the promise will resolve in the `actions` queue of the run loop. Ultimately, this is why `isSettled()` returns false when `await runHooks(...)` completes: a run loop was started in order to resolve the `runHooks` promise, but it has not completed yet.

Reproduces the issue reported in https://github.com/emberjs/ember-test-helpers/issues/947.