### PR TITLE
Add treeType annotation to hint correct bundle to ember-auto-import

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,6 +38,7 @@ module.exports = {
 
     let output = this.preprocessJs(input, '/', this.name, {
       registry: this.registry,
+      treeType: 'addon-test-support',
     });
 
     return debugTree(output, 'addon-test-support:output');


### PR DESCRIPTION
Provides information to ember-auto-import so that it can know what the correct target asset should be.

References:

* https://github.com/ef4/ember-auto-import/pull/329
* https://github.com/ember-cli/ember-cli/pull/9411
