### PR TITLE
Support getOwner

### DIFF
--- a/addon-test-support/@ember/test-helpers/setup-context.ts
+++ b/addon-test-support/@ember/test-helpers/setup-context.ts
@@ -1,6 +1,7 @@
 import { run } from '@ember/runloop';
 import { set, setProperties, get, getProperties } from '@ember/object';
 import Resolver from '@ember/application/resolver';
+import { setOwner } from '@ember/application';
 
 import buildOwner, { Owner } from './build-owner';
 import { _setupAJAXHooks, _teardownAJAXHooks } from './settled';
@@ -211,6 +212,7 @@ export default function setupContext(
         value: owner,
         writable: false,
       });
+      setOwner(context, owner);
 
       Object.defineProperty(context, 'set', {
         configurable: true,

--- a/tests/unit/setup-rendering-context-test.js
+++ b/tests/unit/setup-rendering-context-test.js
@@ -23,6 +23,7 @@ import {
 import hasEmberVersion from '@ember/test-helpers/has-ember-version';
 import { setResolverRegistry, application, resolver } from '../helpers/resolver';
 import { hbs } from 'ember-cli-htmlbars';
+import { getOwner } from '@ember/application';
 
 module('setupRenderingContext', function (hooks) {
   if (!hasEmberVersion(2, 4)) {
@@ -429,6 +430,10 @@ module('setupRenderingContext', function (hooks) {
       assert.equal(this.element.textContent, '', 'has rendered content');
       assert.equal(testingRootElement.textContent, '', 'has rendered content');
       assert.strictEqual(this.element, originalElement, 'this.element is stable');
+    });
+
+    test('context supports getOwner', async function (assert) {
+      assert.equal(getOwner(this), this.owner);
     });
 
     module('this.render and this.clearRender deprecations', function () {


### PR DESCRIPTION
The test context already has an owner, in the sense of `this.owner` working. But the standard way to get an owner in Ember is `getOwner`, which doesn't work.

This makes `getOwner` work.

A motivating example are [these tests](https://github.com/embroider-build/embroider/blob/0349de7a5386c30dff8d4aa859fe01138b026878/packages/util/tests/integration/helpers/ensure-safe-component-test.js#L18-L22) which currently use a workaround. They're testing an API that accepts any owned object, and it's nice to use the test context as that object.