### PR TITLE
Correctly handle resetOnerror

### DIFF
--- a/addon-test-support/@ember/test-helpers/setup-onerror.ts
+++ b/addon-test-support/@ember/test-helpers/setup-onerror.ts
@@ -43,6 +43,7 @@ export default function setupOnerror(onError?: (error: Error) => void): void {
 
 /**
  * Resets `Ember.onerror` to the value it originally was at the start of the test run.
+ * If there is no context or cached value this is a no-op.
  *
  * @public
  *
@@ -54,7 +55,13 @@ export default function setupOnerror(onError?: (error: Error) => void): void {
  *   resetOnerror();
  * })
  */
-export const resetOnerror: Function = setupOnerror;
+export function resetOnerror(): void {
+  let context = getContext();
+
+  if (context && cachedOnerror.has(context)) {
+    Ember.onerror = cachedOnerror.get(context);
+  }
+}
 
 /**
  * Caches the current value of Ember.onerror. When `setupOnerror` is called without a value

--- a/tests/unit/setup-ember-onerror-test.js
+++ b/tests/unit/setup-ember-onerror-test.js
@@ -63,5 +63,10 @@ module('setupOnerror', function (hooks) {
         setupOnerror();
       }, /Must setup test context before calling setupOnerror/);
     });
+
+    test('resetOnerror does not raise an error without context', function (assert) {
+      resetOnerror();
+      assert.ok(true, 'nothing was thrown');
+    });
   }
 });


### PR DESCRIPTION
* Ignores arguments (these were being passed by QUnit.testDone)
* No-op if missing context or cached value