### PR TITLE
Fix deprecations with Ember 3.27+

### DIFF
--- a/addon-test-support/@ember/test-helpers/-internal/debug-info.ts
+++ b/addon-test-support/@ember/test-helpers/-internal/debug-info.ts
@@ -1,5 +1,5 @@
 import {
-  run,
+  _backburner,
   DebugInfo as BackburnerDebugInfo,
   QueueItem,
   DeferredActionQueues,
@@ -53,7 +53,7 @@ export default interface DebugInfo {
  * @returns {boolean} True if `getDebugInfo` is present in backburner, otherwise false.
  */
 export function backburnerDebugInfoAvailable() {
-  return typeof run.backburner.getDebugInfo === 'function';
+  return typeof _backburner.getDebugInfo === 'function';
 }
 
 /**
@@ -64,8 +64,8 @@ export function backburnerDebugInfoAvailable() {
  * @returns {MaybeDebugInfo | null} Backburner debugInfo or, if the getDebugInfo method is not present, null
  */
 export function getDebugInfo(): MaybeDebugInfo {
-  return run.backburner.DEBUG === true && backburnerDebugInfoAvailable()
-    ? <BackburnerDebugInfo>run.backburner.getDebugInfo()
+  return _backburner.DEBUG === true && backburnerDebugInfoAvailable()
+    ? <BackburnerDebugInfo>_backburner.getDebugInfo()
     : null;
 }
 

--- a/addon-test-support/@ember/test-helpers/settled.ts
+++ b/addon-test-support/@ember/test-helpers/settled.ts
@@ -1,5 +1,5 @@
 /* globals jQuery */
-import { run } from '@ember/runloop';
+import { _backburner } from '@ember/runloop';
 import Ember from 'ember';
 
 import { nextTick } from './-utils';
@@ -179,8 +179,8 @@ export interface SettledState {
   @returns {Object} object with properties for each of the metrics used to determine settledness
 */
 export function getSettledState(): SettledState {
-  let hasPendingTimers = Boolean((run as any).hasScheduledTimers());
-  let hasRunLoop = Boolean((run as any).currentRunLoop);
+  let hasPendingTimers = _backburner.hasTimers();
+  let hasRunLoop = Boolean(_backburner.currentInstance);
   let hasPendingLegacyWaiters = checkWaiters();
   let hasPendingTestWaiters = hasPendingWaiters();
   let pendingRequestCount = pendingRequests();

--- a/addon-test-support/@ember/test-helpers/setup-context.ts
+++ b/addon-test-support/@ember/test-helpers/setup-context.ts
@@ -1,4 +1,4 @@
-import { run } from '@ember/runloop';
+import { _backburner, run } from '@ember/runloop';
 import { set, setProperties, get, getProperties } from '@ember/object';
 import Resolver from '@ember/application/resolver';
 import { setOwner } from '@ember/application';
@@ -177,7 +177,7 @@ export default function setupContext(
   let testMetadata: ITestMetadata = getTestMetadata(context);
   testMetadata.setupTypes.push('setupContext');
 
-  run.backburner.DEBUG = true;
+  _backburner.DEBUG = true;
 
   registerDestructor(context, cleanup);
 

--- a/addon-test-support/@ember/test-helpers/setup-rendering-context.ts
+++ b/addon-test-support/@ember/test-helpers/setup-rendering-context.ts
@@ -199,7 +199,11 @@ export default function setupRenderingContext(context: TestContext): Promise<Ren
           {
             id: 'ember-test-helpers.setup-rendering-context.render',
             until: '3.0.0',
-          }
+            for: '@ember/test-helpers',
+            since: {
+              enabled: '2.0.0',
+            },
+          } as any // @types/ember is missing since + for
         );
 
         return render(template);
@@ -212,7 +216,11 @@ export default function setupRenderingContext(context: TestContext): Promise<Ren
           {
             id: 'ember-test-helpers.setup-rendering-context.clearRender',
             until: '3.0.0',
-          }
+            for: '@ember/test-helpers',
+            since: {
+              enabled: '2.0.0',
+            },
+          } as any // @types/ember is missing since + for
         );
 
         return clearRender();

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "broccoli-debug": "^0.6.5",
     "broccoli-funnel": "^3.0.3",
     "ember-cli-babel": "^7.26.1",
-    "ember-cli-htmlbars": "^5.7.0",
+    "ember-cli-htmlbars": "^5.7.1",
     "ember-destroyable-polyfill": "^2.0.3"
   },
   "devDependencies": {

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -4,7 +4,7 @@ import { registerDeprecationHandler } from '@ember/debug';
 import AbstractTestLoader from 'ember-cli-test-loader/test-support/index';
 import Ember from 'ember';
 import { isSettled, getSettledState } from '@ember/test-helpers';
-import { run } from '@ember/runloop';
+import { _backburner } from '@ember/runloop';
 import './helpers/resolver';
 
 import PromisePolyfill from '@ember/test-helpers/-internal/promise-polyfill';
@@ -22,7 +22,7 @@ let moduleLoadFailures = [];
 let cleanupFailures = [];
 let asyncLeakageFailures = [];
 
-run.backburner.DEBUG = true;
+_backburner.DEBUG = true;
 
 QUnit.done(function () {
   if (moduleLoadFailures.length) {
@@ -68,13 +68,13 @@ QUnit.testStart(function () {
 
 QUnit.testDone(function ({ module, name }) {
   // ensure no test accidentally change state of run.backburner.DEBUG
-  if (run.backburner.DEBUG !== true) {
-    let message = `Ember.run.backburner.DEBUG should be reset (to true) after test has completed. ${module}: ${name} did not.`;
+  if (_backburner.DEBUG !== true) {
+    let message = `backburner.DEBUG should be reset (to true) after test has completed. ${module}: ${name} did not.`;
     cleanupFailures.push(message);
 
     // eslint-disable-next-line
     console.error(message);
-    run.backburner.DEBUG = true;
+    _backburner.DEBUG = true;
   }
 
   // this is used to ensure that no tests accidentally leak `Ember.testing` state

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -51,23 +51,8 @@ class TestLoader extends AbstractTestLoader {
 
 new TestLoader().loadModules();
 
-let deprecations;
-registerDeprecationHandler((message, options, next) => {
-  // in case a deprecation is issued before a test is started
-  if (!deprecations) {
-    deprecations = [];
-  }
-
-  deprecations.push(message);
-  next(message, options);
-});
-
-QUnit.testStart(function () {
-  deprecations = [];
-});
-
 QUnit.testDone(function ({ module, name }) {
-  // ensure no test accidentally change state of run.backburner.DEBUG
+  // ensure no test accidentally change state of backburner.DEBUG
   if (_backburner.DEBUG !== true) {
     let message = `backburner.DEBUG should be reset (to true) after test has completed. ${module}: ${name} did not.`;
     cleanupFailures.push(message);
@@ -96,6 +81,50 @@ QUnit.testDone(function ({ module, name }) {
     // eslint-disable-next-line
     console.error(message);
   }
+});
+
+let deprecations;
+registerDeprecationHandler((message, options, next) => {
+  // in case a deprecation is issued before a test is started
+  if (!deprecations) {
+    deprecations = [];
+  }
+
+  deprecations.push(message);
+  next(message, options);
+});
+
+// Provide a way to squelch the this-property-fallback
+if (typeof URLSearchParams !== 'undefined') {
+  let queryParams = new URLSearchParams(document.location.search.substring(1));
+  let disabledDeprecations = queryParams.get('disabledDeprecations');
+  let debugDeprecations = queryParams.get('debugDeprecations');
+
+  // When using `/tests/index.html?disabledDeprecations=this-property-fallback,some-other-thing`
+  // those deprecations will be squelched
+  if (disabledDeprecations) {
+    registerDeprecationHandler((message, options, next) => {
+      if (!disabledDeprecations.includes(options.id)) {
+        next(message, options);
+      }
+    });
+  }
+
+  // When using `/tests/index.html?debugDeprecations=some-other-thing` when the
+  // `some-other-thing` deprecation is triggered, this `debugger` will be hit`
+  if (debugDeprecations) {
+    registerDeprecationHandler((message, options, next) => {
+      if (debugDeprecations.includes(options.id)) {
+        debugger; // eslint-disable-line no-debugger
+      }
+
+      next(message, options);
+    });
+  }
+}
+
+QUnit.testStart(function () {
+  deprecations = [];
 });
 
 QUnit.assert.noDeprecations = function (callback) {

--- a/tests/unit/test-debug-info-test.js
+++ b/tests/unit/test-debug-info-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { run } from '@ember/runloop';
+import { _backburner, run } from '@ember/runloop';
 import {
   TestDebugInfo,
   backburnerDebugInfoAvailable,
@@ -12,11 +12,11 @@ import { buildWaiter, _reset as resetWaiters } from '@ember/test-waiters';
 
 module('TestDebugInfo', function (hooks) {
   hooks.beforeEach(function () {
-    run.backburner.DEBUG = false;
+    _backburner.DEBUG = false;
   });
 
   hooks.afterEach(function () {
-    run.backburner.DEBUG = true;
+    _backburner.DEBUG = true;
   });
 
   test('summary returns minimal information when debugInfo is not present', function (assert) {
@@ -49,7 +49,7 @@ module('TestDebugInfo', function (hooks) {
       let cancelIds;
 
       hooks.beforeEach(function () {
-        run.backburner.DEBUG = true;
+        _backburner.DEBUG = true;
 
         cancelIds = [];
         overrideError(MockStableError);
@@ -58,7 +58,7 @@ module('TestDebugInfo', function (hooks) {
       hooks.afterEach(function () {
         cancelIds.forEach(cancelId => run.cancel(cancelId));
 
-        run.backburner.DEBUG = false;
+        _backburner.DEBUG = false;
 
         resetError();
       });
@@ -77,7 +77,7 @@ module('TestDebugInfo', function (hooks) {
             hasPendingTestWaiters: false,
             hasPendingRequests: false,
           },
-          run.backburner.getDebugInfo()
+          _backburner.getDebugInfo()
         );
 
         assert.deepEqual(testDebugInfo.summary, {

--- a/tests/unit/test-debug-info-test.js
+++ b/tests/unit/test-debug-info-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { _backburner, run } from '@ember/runloop';
+import { _backburner, later, cancel } from '@ember/runloop';
 import {
   TestDebugInfo,
   backburnerDebugInfoAvailable,
@@ -56,7 +56,7 @@ module('TestDebugInfo', function (hooks) {
       });
 
       hooks.afterEach(function () {
-        cancelIds.forEach(cancelId => run.cancel(cancelId));
+        cancelIds.forEach(cancelId => cancel(cancelId));
 
         _backburner.DEBUG = false;
 
@@ -66,8 +66,8 @@ module('TestDebugInfo', function (hooks) {
       test('summary returns full information when debugInfo is present', function (assert) {
         assert.expect(1);
 
-        cancelIds.push(run.later(() => {}, 5000));
-        cancelIds.push(run.later(() => {}, 10000));
+        cancelIds.push(later(() => {}, 5000));
+        cancelIds.push(later(() => {}, 10000));
 
         let testDebugInfo = new TestDebugInfo(
           {

--- a/types/@ember/runloop.d.ts
+++ b/types/@ember/runloop.d.ts
@@ -34,6 +34,8 @@ export interface DebugInfo {
 }
 
 export interface Backburner {
+  currentInstance: DeferredActionQueues | null;
+  hasTimers(): boolean;
   join(...args: any[]): void;
   on(...args: any[]): void;
   scheduleOnce(...args: any[]): void;
@@ -323,6 +325,7 @@ export interface RunNamespace {
   backburner: Backburner;
 }
 
+export const _backburner: Backburner;
 export const run: RunNamespace;
 export const begin: typeof run.begin;
 export const bind: typeof run.bind;
@@ -336,4 +339,3 @@ export const once: typeof run.once;
 export const schedule: typeof run.schedule;
 export const scheduleOnce: typeof run.scheduleOnce;
 export const throttle: typeof run.throttle;
-export const backburner: typeof run.backburner;

--- a/yarn.lock
+++ b/yarn.lock
@@ -6050,10 +6050,10 @@ ember-cli-get-component-path-option@^1.0.0:
   resolved "https://registry.yarnpkg.com/ember-cli-get-component-path-option/-/ember-cli-get-component-path-option-1.0.0.tgz#0d7b595559e2f9050abed804f1d8eff1b08bc771"
   integrity sha1-DXtZVVni+QUKvtgE8djv8bCLx3E=
 
-ember-cli-htmlbars@^5.7.0:
-  version "5.7.0"
-  resolved "https://registry.yarnpkg.com/ember-cli-htmlbars/-/ember-cli-htmlbars-5.7.0.tgz#ca10ab2716d7ee7ba08c6514868c69b46b7cc10d"
-  integrity sha512-Cda9caL1hgd7tOFH7ab1h8WXe9WxChmv766tMb6yunQuzaHLhn/E3NrNJB6TpqosfQH8nIo8TzqWTPRwJbRq2w==
+ember-cli-htmlbars@^5.7.1:
+  version "5.7.1"
+  resolved "https://registry.yarnpkg.com/ember-cli-htmlbars/-/ember-cli-htmlbars-5.7.1.tgz#eb5b88c7d9083bc27665fb5447a9b7503b32ce4f"
+  integrity sha512-9laCgL4tSy48orNoQgQKEHp93MaqAs9ZOl7or5q+8iyGGJHW6sVXIYrVv5/5O9HfV6Ts8/pW1rSoaeKyLUE+oA==
   dependencies:
     "@ember/edition-utils" "^1.2.0"
     babel-plugin-htmlbars-inline-precompile "^5.0.0"


### PR DESCRIPTION
- Add `for` and `since` to internal deprecations.
- Use ember-cli-htmlbars@5.7.1
- Fix deprecations introduced by `run.backburner` usage.
- Improve deprecation testing support.
- Fix deprecations for `run.*` method access.
