### PR TITLE
Ensure `blur` event fires on prior focused element even if click target is not focusable

### DIFF
--- a/addon-test-support/@ember/test-helpers/dom/click.ts
+++ b/addon-test-support/@ember/test-helpers/dom/click.ts
@@ -3,12 +3,12 @@ import { getWindowOrElement } from './-get-window-or-element';
 import fireEvent from './fire-event';
 import { __focus__ } from './focus';
 import settled from '../settled';
-import isFocusable from './-is-focusable';
 import { Promise } from '../-utils';
 import isFormControl from './-is-form-control';
-import Target from './-target';
+import Target, { isWindow } from './-target';
 import { log } from '@ember/test-helpers/dom/-logging';
 import { runHooks, registerHook } from '../-internal/helper-hooks';
+import { __blur__ } from './blur';
 
 const PRIMARY_BUTTON = 1;
 const MAIN_BUTTON_PRESSED = 0;
@@ -34,7 +34,7 @@ export const DEFAULT_CLICK_OPTIONS = {
 export function __click__(element: Element | Document | Window, options: MouseEventInit): void {
   fireEvent(element, 'mousedown', options);
 
-  if (isFocusable(element)) {
+  if (!isWindow(element)) {
     __focus__(element);
   }
 

--- a/addon-test-support/@ember/test-helpers/dom/double-click.ts
+++ b/addon-test-support/@ember/test-helpers/dom/double-click.ts
@@ -3,10 +3,9 @@ import { getWindowOrElement } from './-get-window-or-element';
 import fireEvent from './fire-event';
 import { __focus__ } from './focus';
 import settled from '../settled';
-import isFocusable from './-is-focusable';
 import { Promise } from '../-utils';
 import { DEFAULT_CLICK_OPTIONS } from './click';
-import Target from './-target';
+import Target, { isWindow } from './-target';
 import { log } from '@ember/test-helpers/dom/-logging';
 import isFormControl from './-is-form-control';
 import { runHooks, registerHook } from '../-internal/helper-hooks';
@@ -26,7 +25,7 @@ export function __doubleClick__(
 ): void {
   fireEvent(element, 'mousedown', options);
 
-  if (isFocusable(element)) {
+  if (!isWindow(element)) {
     __focus__(element);
   }
 

--- a/tests/unit/dom/click-test.js
+++ b/tests/unit/dom/click-test.js
@@ -233,6 +233,47 @@ module('DOM Helper: click', function (hooks) {
       assert.verifySteps(['mousedown', 'mouseup', 'click']);
     });
   });
+
+  module('focusable and non-focusable elements interaction', function () {
+    test('clicking on non-focusable element triggers blur on active element', async function (assert) {
+      element = document.createElement('div');
+
+      insertElement(element);
+
+      const focusableElement = buildInstrumentedElement('input');
+
+      await click(focusableElement);
+      await click(element);
+
+      assert.verifySteps(['mousedown', 'focus', 'focusin', 'mouseup', 'click', 'blur', 'focusout']);
+    });
+
+    test('clicking on focusable element triggers blur on active element', async function (assert) {
+      element = document.createElement('input');
+
+      insertElement(element);
+
+      const focusableElement = buildInstrumentedElement('input');
+
+      await click(focusableElement);
+      await click(element);
+
+      assert.verifySteps(['mousedown', 'focus', 'focusin', 'mouseup', 'click', 'blur', 'focusout']);
+    });
+
+    test('clicking on non-focusable element does not trigger blur on non-focusable active element', async function (assert) {
+      element = document.createElement('div');
+
+      insertElement(element);
+
+      const nonFocusableElement = buildInstrumentedElement('div');
+
+      await click(nonFocusableElement);
+      await click(element);
+
+      assert.verifySteps(['mousedown', 'mouseup', 'click']);
+    });
+  });
 });
 
 module('DOM Helper: click with window', function () {

--- a/tests/unit/dom/double-click-test.js
+++ b/tests/unit/dom/double-click-test.js
@@ -277,6 +277,79 @@ module('DOM Helper: doubleClick', function (hooks) {
       ]);
     });
   });
+
+  module('focusable and non-focusable elements interaction', function () {
+    test('cdouble-licking on non-focusable element triggers blur on active element', async function (assert) {
+      element = document.createElement('div');
+
+      insertElement(element);
+
+      const focusableElement = buildInstrumentedElement('input');
+
+      await doubleClick(focusableElement);
+      await doubleClick(element);
+
+      assert.verifySteps([
+        'mousedown',
+        'focus',
+        'focusin',
+        'mouseup',
+        'click',
+        'mousedown',
+        'mouseup',
+        'click',
+        'dblclick',
+        'blur',
+        'focusout',
+      ]);
+    });
+
+    test('double-clicking on focusable element triggers blur on active element', async function (assert) {
+      element = document.createElement('input');
+
+      insertElement(element);
+
+      const focusableElement = buildInstrumentedElement('input');
+
+      await doubleClick(focusableElement);
+      await doubleClick(element);
+
+      assert.verifySteps([
+        'mousedown',
+        'focus',
+        'focusin',
+        'mouseup',
+        'click',
+        'mousedown',
+        'mouseup',
+        'click',
+        'dblclick',
+        'blur',
+        'focusout',
+      ]);
+    });
+
+    test('double-clicking on non-focusable element does not trigger blur on non-focusable active element', async function (assert) {
+      element = document.createElement('div');
+
+      insertElement(element);
+
+      const nonFocusableElement = buildInstrumentedElement('div');
+
+      await doubleClick(nonFocusableElement);
+      await doubleClick(element);
+
+      assert.verifySteps([
+        'mousedown',
+        'mouseup',
+        'click',
+        'mousedown',
+        'mouseup',
+        'click',
+        'dblclick',
+      ]);
+    });
+  });
 });
 
 module('DOM Helper: doubleClick with window', function () {

--- a/tests/unit/dom/tap-test.js
+++ b/tests/unit/dom/tap-test.js
@@ -181,4 +181,65 @@ module('DOM Helper: tap', function (hooks) {
       assert.rejects(tap(element), new Error('Can not `tap` disabled [object HTMLInputElement]'));
     });
   });
+
+  module('focusable and non-focusable elements interaction', function () {
+    test('tapping on non-focusable element triggers blur on active element', async function (assert) {
+      element = document.createElement('div');
+
+      insertElement(element);
+
+      const focusableElement = buildInstrumentedElement('input');
+
+      await tap(focusableElement);
+      await tap(element);
+
+      assert.verifySteps([
+        'touchstart',
+        'touchend',
+        'mousedown',
+        'focus',
+        'focusin',
+        'mouseup',
+        'click',
+        'blur',
+        'focusout',
+      ]);
+    });
+
+    test('tapping on focusable element triggers blur on active element', async function (assert) {
+      element = document.createElement('input');
+
+      insertElement(element);
+
+      const focusableElement = buildInstrumentedElement('input');
+
+      await tap(focusableElement);
+      await tap(element);
+
+      assert.verifySteps([
+        'touchstart',
+        'touchend',
+        'mousedown',
+        'focus',
+        'focusin',
+        'mouseup',
+        'click',
+        'blur',
+        'focusout',
+      ]);
+    });
+
+    test('tapping on non-focusable element does not trigger blur on non-focusable active element', async function (assert) {
+      element = document.createElement('div');
+
+      insertElement(element);
+
+      const nonFocusableElement = buildInstrumentedElement('div');
+
+      await tap(nonFocusableElement);
+      await tap(element);
+
+      assert.verifySteps(['touchstart', 'touchend', 'mousedown', 'mouseup', 'click']);
+    });
+  });
 });


### PR DESCRIPTION
The root cause of the issue is that the blur event is not triggered on
the current active element in the click helper in case if the clicked
element is not focusable.

If the clicked element is focusable the previous active element gets
blur event trough the __focus__ helper.

A call to __blur__ was added for the case when the clicked element
is not focusable.