### PR TITLE
Correctly import deprecate from `@ember/debug`

### DIFF
--- a/addon-test-support/@ember/test-helpers/setup-rendering-context.ts
+++ b/addon-test-support/@ember/test-helpers/setup-rendering-context.ts
@@ -9,7 +9,7 @@ import { hbs, TemplateFactory } from 'ember-cli-htmlbars';
 import getRootElement from './dom/get-root-element';
 import { Owner } from './build-owner';
 import getTestMetadata, { ITestMetadata } from './test-metadata';
-import { deprecate } from '@ember/application/deprecations';
+import { deprecate } from '@ember/debug';
 import { runHooks } from './-internal/helper-hooks';
 import hasEmberVersion from './has-ember-version';
 


### PR DESCRIPTION
This was incorrectly imported from `@ember/application/deprecations`, which seemed to work, but does not work in current canary - I got this error in an addon testing on canary:

```js
Global error: Uncaught Error: Could not find module `@ember/application/deprecations` 
imported from `@ember/test-helpers/setup-rendering-context`
```

Anyway, even if this might/should be fixed in canary, the import is wrong and can be updated to the correct place.