### PR TITLE
Test `{{in-element}}` instead of deprecated `{{-in-element}}`

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "ember-data": "~3.20.0",
     "ember-disable-prototype-extensions": "^1.1.3",
     "ember-fetch": "^8.1.0",
+    "ember-in-element-polyfill": "^1.0.1",
     "ember-load-initializers": "^2.1.2",
     "ember-maybe-import-regenerator-for-testing": "^1.0.0",
     "ember-resolver": "^8.0.2",

--- a/tests/integration/setup-rendering-context-test.js
+++ b/tests/integration/setup-rendering-context-test.js
@@ -113,60 +113,57 @@ module('setupRenderingContext "real world"', function (hooks) {
     assert.equal(this.element.textContent, 'Yippie!', 'has fulfillment value');
   });
 
-  // uses `{{-in-element` which was only added in Ember 2.10
-  if (hasEmberVersion(2, 10)) {
-    if (EmberENV._APPLICATION_TEMPLATE_WRAPPER !== false) {
-      test('can click on a sibling element of the application template wrapper', async function (assert) {
-        let rootElement = document.getElementById('ember-testing');
+  if (EmberENV._APPLICATION_TEMPLATE_WRAPPER !== false) {
+    test('can click on a sibling element of the application template wrapper', async function (assert) {
+      let rootElement = document.getElementById('ember-testing');
 
-        assert.notEqual(
-          rootElement,
-          this.element,
-          'precond - confirm that the rootElement is different from this.element'
-        );
+      assert.notEqual(
+        rootElement,
+        this.element,
+        'precond - confirm that the rootElement is different from this.element'
+      );
 
-        this.set('rootElement', rootElement);
+      this.set('rootElement', rootElement);
 
-        await render(hbs`{{#-in-element rootElement}}{{click-me-button}}{{/-in-element}}`);
+      await render(hbs`{{#in-element rootElement}}{{click-me-button}}{{/in-element}}`);
 
-        assert.equal(this.element.textContent, '', 'no content is contained _within_ this.element');
-        assert.equal(
-          rootElement.textContent,
-          'Click Me!',
-          'the rootElement has the correct content after initial render'
-        );
+      assert.equal(this.element.textContent, '', 'no content is contained _within_ this.element');
+      assert.equal(
+        rootElement.textContent,
+        'Click Me!',
+        'the rootElement has the correct content after initial render'
+      );
 
-        await click('.click-me-button');
+      await click('.click-me-button');
 
-        assert.equal(
-          rootElement.textContent,
-          'Clicked!',
-          'the rootElement has the correct content after clicking'
-        );
-      });
-    } else {
-      test('can click on a sibling of the rendered content', async function (assert) {
-        let rootElement = document.getElementById('ember-testing');
-        this.set('rootElement', rootElement);
+      assert.equal(
+        rootElement.textContent,
+        'Clicked!',
+        'the rootElement has the correct content after clicking'
+      );
+    });
+  } else {
+    test('can click on a sibling of the rendered content', async function (assert) {
+      let rootElement = document.getElementById('ember-testing');
+      this.set('rootElement', rootElement);
 
-        assert.equal(rootElement.textContent, '', 'the rootElement is empty before rendering');
+      assert.equal(rootElement.textContent, '', 'the rootElement is empty before rendering');
 
-        await render(hbs`{{#-in-element rootElement}}{{click-me-button}}{{/-in-element}}`);
+      await render(hbs`{{#in-element rootElement}}{{click-me-button}}{{/in-element}}`);
 
-        assert.equal(
-          rootElement.textContent,
-          'Click Me!',
-          'the rootElement has the correct content after initial render'
-        );
+      assert.equal(
+        rootElement.textContent,
+        'Click Me!',
+        'the rootElement has the correct content after initial render'
+      );
 
-        await click('.click-me-button');
+      await click('.click-me-button');
 
-        assert.equal(
-          rootElement.textContent,
-          'Clicked!',
-          'the rootElement has the correct content after clicking'
-        );
-      });
-    }
+      assert.equal(
+        rootElement.textContent,
+        'Clicked!',
+        'the rootElement has the correct content after clicking'
+      );
+    });
   }
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -5828,7 +5828,7 @@ ember-cli-get-component-path-option@^1.0.0:
   resolved "https://registry.yarnpkg.com/ember-cli-get-component-path-option/-/ember-cli-get-component-path-option-1.0.0.tgz#0d7b595559e2f9050abed804f1d8eff1b08bc771"
   integrity sha1-DXtZVVni+QUKvtgE8djv8bCLx3E=
 
-ember-cli-htmlbars@^5.7.1:
+ember-cli-htmlbars@^5.3.1, ember-cli-htmlbars@^5.7.1:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/ember-cli-htmlbars/-/ember-cli-htmlbars-5.7.1.tgz#eb5b88c7d9083bc27665fb5447a9b7503b32ce4f"
   integrity sha512-9laCgL4tSy48orNoQgQKEHp93MaqAs9ZOl7or5q+8iyGGJHW6sVXIYrVv5/5O9HfV6Ts8/pW1rSoaeKyLUE+oA==
@@ -6216,6 +6216,16 @@ ember-fetch@^8.1.0:
     ember-cli-version-checker "^5.1.2"
     node-fetch "^2.6.1"
     whatwg-fetch "^3.6.2"
+
+ember-in-element-polyfill@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/ember-in-element-polyfill/-/ember-in-element-polyfill-1.0.1.tgz#143504445bb4301656a2eaad42644d684f5164dd"
+  integrity sha512-eHs+7D7PuQr8a1DPqsJTsEyo3FZ1XuH6WEZaEBPDa9s0xLlwByCNKl8hi1EbXOgvgEZNHHi9Rh0vjxyfakrlgg==
+  dependencies:
+    debug "^4.3.1"
+    ember-cli-babel "^7.23.1"
+    ember-cli-htmlbars "^5.3.1"
+    ember-cli-version-checker "^5.1.2"
 
 ember-inflector@^3.0.1:
   version "3.0.1"


### PR DESCRIPTION
This leads to failing tests on Canary, where `{{-in-element}}` is removed.

This updates the test to test the `{{in-element}}` helper on ember versions upwards of 3.20. I did not include an alternate branch to test `{{-in-element}}` on older versions because I figured that is kind of repetitive and we can assume they work the same.