### PR TITLE
Remove ember-data from test harness

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",
     "@types/ember": "^3.16.4",
-    "@types/ember-data": "^3.16.13",
     "@types/ember-testing-helpers": "^0.0.4",
     "@types/rsvp": "^4.0.3",
     "@typescript-eslint/eslint-plugin": "^4.28.1",
@@ -60,7 +59,6 @@
     "ember-cli-shims": "^1.2.0",
     "ember-cli-test-loader": "^3.0.0",
     "ember-cli-typescript": "^1.5.0",
-    "ember-data": "~3.20.0",
     "ember-disable-prototype-extensions": "^1.1.3",
     "ember-fetch": "^8.1.0",
     "ember-in-element-polyfill": "^1.0.1",

--- a/types/ember-data/types/registries/model.d.ts
+++ b/types/ember-data/types/registries/model.d.ts
@@ -1,6 +1,0 @@
-/**
- * Catch-all for ember-data.
- */
-export default interface ModelRegistry {
-  [key: string]: any;
-}

--- a/yarn.lock
+++ b/yarn.lock
@@ -962,126 +962,10 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@ember-data/adapter@3.20.5":
-  version "3.20.5"
-  resolved "https://registry.yarnpkg.com/@ember-data/adapter/-/adapter-3.20.5.tgz#2348cc0a6a46d5b25f6e356802f05ce0db5c75a0"
-  integrity sha512-J/tyinlUW+lQCcHomJkPpiu4PHEqDiVzsrQ8AgKPk6UgPTz4h1oTo8bxJvfC8xfCRGGBSZ/sTT8mrOtyIn0GWg==
-  dependencies:
-    "@ember-data/private-build-infra" "3.20.5"
-    "@ember-data/store" "3.20.5"
-    "@ember/edition-utils" "^1.2.0"
-    ember-cli-babel "^7.18.0"
-    ember-cli-test-info "^1.0.0"
-    ember-cli-typescript "^3.1.3"
-
-"@ember-data/canary-features@3.20.5":
-  version "3.20.5"
-  resolved "https://registry.yarnpkg.com/@ember-data/canary-features/-/canary-features-3.20.5.tgz#7856b84498498b3fed32ddbe7ac5e59a7ce4c70d"
-  integrity sha512-UGAojn6uAr1yVHiTQ3Zy9W3pfrib+c8BXx7pZ2j1y71ztIMAJ6kNB8h6Gl+Ms1OxEMElnjBEJrfaoV8U1MLY2A==
-  dependencies:
-    ember-cli-babel "^7.18.0"
-    ember-cli-typescript "^3.1.3"
-
-"@ember-data/debug@3.20.5":
-  version "3.20.5"
-  resolved "https://registry.yarnpkg.com/@ember-data/debug/-/debug-3.20.5.tgz#a3af700f82ba01a40290db706ce607e51ecf5141"
-  integrity sha512-psG8y6CgWTehelWXp14XOc4dOEJmrnbF+E7Myy/eHXTv7Hyri0iLw0R2WrlO0QjTC8RehgRO4LhRpa0i3VxIlw==
-  dependencies:
-    "@ember-data/private-build-infra" "3.20.5"
-    "@ember/edition-utils" "^1.2.0"
-    ember-cli-babel "^7.18.0"
-    ember-cli-test-info "^1.0.0"
-    ember-cli-typescript "^3.1.3"
-
-"@ember-data/model@3.20.5":
-  version "3.20.5"
-  resolved "https://registry.yarnpkg.com/@ember-data/model/-/model-3.20.5.tgz#522008a6b3c6334792cb3674cd19c8972d5bbbf9"
-  integrity sha512-d5FToKjtjkSKnoOAqFS/IWtyGxag2RDsOk/j+VNQPFQITlrcDV/j2LeF82laXpF04SfCWyenvXxjqCIEsbeZVQ==
-  dependencies:
-    "@ember-data/canary-features" "3.20.5"
-    "@ember-data/private-build-infra" "3.20.5"
-    "@ember-data/store" "3.20.5"
-    "@ember/edition-utils" "^1.2.0"
-    ember-cli-babel "^7.18.0"
-    ember-cli-string-utils "^1.1.0"
-    ember-cli-test-info "^1.0.0"
-    ember-cli-typescript "^3.1.3"
-    ember-compatibility-helpers "^1.2.0"
-    inflection "1.12.0"
-
-"@ember-data/private-build-infra@3.20.5":
-  version "3.20.5"
-  resolved "https://registry.yarnpkg.com/@ember-data/private-build-infra/-/private-build-infra-3.20.5.tgz#92d52dfcc35c25a3c0fad7d27a4f8d2a9cf04451"
-  integrity sha512-9qS8VC2ZQwN/aD6RGO9FNWzdVHFUvjNgXfk1PYPo6QDmLwU/3m+WqXO0ZkhQx6hjHjGWi5HOu+vjUwdO8nghfg==
-  dependencies:
-    "@babel/plugin-transform-block-scoping" "^7.8.3"
-    "@ember-data/canary-features" "3.20.5"
-    "@ember/edition-utils" "^1.2.0"
-    babel-plugin-debug-macros "^0.3.3"
-    babel-plugin-filter-imports "^4.0.0"
-    babel6-plugin-strip-class-callcheck "^6.0.0"
-    broccoli-debug "^0.6.5"
-    broccoli-file-creator "^2.1.1"
-    broccoli-funnel "^2.0.2"
-    broccoli-merge-trees "^4.2.0"
-    broccoli-rollup "^4.1.1"
-    calculate-cache-key-for-tree "^2.0.0"
-    chalk "^4.0.0"
-    ember-cli-babel "^7.18.0"
-    ember-cli-path-utils "^1.0.0"
-    ember-cli-string-utils "^1.1.0"
-    ember-cli-typescript "^3.1.3"
-    ember-cli-version-checker "^5.1.1"
-    esm "^3.2.25"
-    git-repo-info "^2.1.1"
-    glob "^7.1.6"
-    npm-git-info "^1.0.3"
-    rimraf "^3.0.2"
-    rsvp "^4.8.5"
-    semver "^7.1.3"
-    silent-error "^1.1.1"
-
-"@ember-data/record-data@3.20.5":
-  version "3.20.5"
-  resolved "https://registry.yarnpkg.com/@ember-data/record-data/-/record-data-3.20.5.tgz#c4a27226449d7be01bdf5752518cd5c01dd7a0a9"
-  integrity sha512-lYkfptsbMc/FAvMKH3M6mMq6DLXUTNFIOBejC76EKNa9+Alxl84QiNxO4kpZdAsZGzT9gJLsWQ/0TXQlk44gyQ==
-  dependencies:
-    "@ember-data/canary-features" "3.20.5"
-    "@ember-data/private-build-infra" "3.20.5"
-    "@ember-data/store" "3.20.5"
-    "@ember/edition-utils" "^1.2.0"
-    "@ember/ordered-set" "^2.0.3"
-    ember-cli-babel "^7.18.0"
-    ember-cli-test-info "^1.0.0"
-    ember-cli-typescript "^3.1.3"
-
 "@ember-data/rfc395-data@^0.0.4":
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/@ember-data/rfc395-data/-/rfc395-data-0.0.4.tgz#ecb86efdf5d7733a76ff14ea651a1b0ed1f8a843"
   integrity sha512-tGRdvgC9/QMQSuSuJV45xoyhI0Pzjm7A9o/MVVA3HakXIImJbbzx/k/6dO9CUEQXIyS2y0fW6C1XaYOG7rY0FQ==
-
-"@ember-data/serializer@3.20.5":
-  version "3.20.5"
-  resolved "https://registry.yarnpkg.com/@ember-data/serializer/-/serializer-3.20.5.tgz#7977ee5178a377f30743460f29d973aa17656ff4"
-  integrity sha512-eNxw9vPSFfiA97I4yURteUM5WgtRjrDVNRPhVDEU7OOHDAa6Q9P/7ASJCTp7SNxI+pqAWgobRWyDH7tE7LMRRg==
-  dependencies:
-    "@ember-data/private-build-infra" "3.20.5"
-    "@ember-data/store" "3.20.5"
-    ember-cli-babel "^7.18.0"
-    ember-cli-test-info "^1.0.0"
-    ember-cli-typescript "^3.1.3"
-
-"@ember-data/store@3.20.5":
-  version "3.20.5"
-  resolved "https://registry.yarnpkg.com/@ember-data/store/-/store-3.20.5.tgz#9855ac3ac24c780a05941b2ecf47c0be4f52ebdc"
-  integrity sha512-Ti5npYeORvis5TzsIIhSlXi5tbFaRixVad3BpI6PRZn4hXskrIBAVlLIAd0vbpj+kIprFrwe5NsMJTR11jU/Pw==
-  dependencies:
-    "@ember-data/canary-features" "3.20.5"
-    "@ember-data/private-build-infra" "3.20.5"
-    ember-cli-babel "^7.18.0"
-    ember-cli-path-utils "^1.0.0"
-    ember-cli-typescript "^3.1.3"
-    heimdalljs "^0.3.0"
 
 "@ember/edition-utils@^1.2.0":
   version "1.2.0"
@@ -1099,14 +983,6 @@
     inquirer "^7.3.3"
     mkdirp "^1.0.4"
     silent-error "^1.1.1"
-
-"@ember/ordered-set@^2.0.3":
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/@ember/ordered-set/-/ordered-set-2.0.3.tgz#2ac1ca73b3bd116063cae814898832ef434a57f9"
-  integrity sha512-F4yfVk6WMc4AUHxeZsC3CaKyTvO0qSZJy7WWHCFTlVDQw6vubn+FvnGdhzpN1F00EiXMI4Tv1tJdSquHcCnYrA==
-  dependencies:
-    ember-cli-babel "^6.16.0"
-    ember-compatibility-helpers "^1.1.1"
 
 "@ember/test-waiters@^2.4.4":
   version "2.4.4"
@@ -1195,11 +1071,6 @@
   dependencies:
     "@glimmer/interfaces" "^0.42.2"
     "@glimmer/vm" "^0.42.2"
-
-"@glimmer/env@^0.1.7":
-  version "0.1.7"
-  resolved "https://registry.yarnpkg.com/@glimmer/env/-/env-0.1.7.tgz#fd2d2b55a9029c6b37a6c935e8c8871ae70dfa07"
-  integrity sha1-/S0rVakCnGs3psk16MiHGucN+gc=
 
 "@glimmer/interfaces@^0.42.2":
   version "0.42.2"
@@ -1461,11 +1332,6 @@
     "@types/connect" "*"
     "@types/node" "*"
 
-"@types/broccoli-plugin@^1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@types/broccoli-plugin/-/broccoli-plugin-1.3.0.tgz#38f8462fecaebc4e09a32e4d4ed1b9808f75bbca"
-  integrity sha512-SLk4/hFc2kGvgwNFrpn2O1juxFOllcHAywvlo7VwxfExLzoz1GGJ0oIZCwj5fwSpvHw4AWpZjJ1fUvb62PDayQ==
-
 "@types/cacheable-request@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/@types/cacheable-request/-/cacheable-request-6.0.1.tgz#5d22f3dded1fd3a84c0bbeb5039a7419c2c91976"
@@ -1495,15 +1361,6 @@
   dependencies:
     "@types/node" "*"
 
-"@types/ember-data@^3.16.13":
-  version "3.16.13"
-  resolved "https://registry.yarnpkg.com/@types/ember-data/-/ember-data-3.16.13.tgz#df8727f6246b948ae1fb6dfaf21b29e6d1505367"
-  integrity sha512-kABRQygJ5ZRicIPgO0lA7ENnz8MRoHOpgKHrGRmAgiTJgk6cTPnTKWKPZ6KerJm08NYYu0ffNK5xWh3adozTvg==
-  dependencies:
-    "@types/ember" "*"
-    "@types/ember__object" "*"
-    "@types/rsvp" "*"
-
 "@types/ember-testing-helpers@^0.0.4":
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/@types/ember-testing-helpers/-/ember-testing-helpers-0.0.4.tgz#d305b418d477c6f84fcd4dcb851a3efadbc4a2bd"
@@ -1512,7 +1369,7 @@
     "@types/jquery" "*"
     "@types/rsvp" "*"
 
-"@types/ember@*", "@types/ember@^3.16.4":
+"@types/ember@^3.16.4":
   version "3.16.4"
   resolved "https://registry.yarnpkg.com/@types/ember/-/ember-3.16.4.tgz#bfccd8ed198ca7bee09878a3423ca6e1a9caac17"
   integrity sha512-kCZNxuCofZN2sYUltfUmPegqAr1wvZ4b6aH0i8AsG+AsUiaWCDzVfCayMfr4CRUOhUiQ2VA9AOgnZT+JgBvjXQ==
@@ -2178,7 +2035,7 @@ acorn@^6.4.1:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.4.2.tgz#35866fd710528e92de10cf06016498e47e39e1e6"
   integrity sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==
 
-acorn@^7.0.0, acorn@^7.1.0, acorn@^7.1.1, acorn@^7.4.0:
+acorn@^7.0.0, acorn@^7.1.1, acorn@^7.4.0:
   version "7.4.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
   integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
@@ -3248,11 +3105,6 @@ babel-types@^6.19.0, babel-types@^6.24.1, babel-types@^6.26.0:
     lodash "^4.17.4"
     to-fast-properties "^1.0.3"
 
-babel6-plugin-strip-class-callcheck@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/babel6-plugin-strip-class-callcheck/-/babel6-plugin-strip-class-callcheck-6.0.0.tgz#de841c1abebbd39f78de0affb2c9a52ee228fddf"
-  integrity sha1-3oQcGr6705943gr/ssmlLuIo/d8=
-
 babelify@^10.0.0:
   version "10.0.0"
   resolved "https://registry.yarnpkg.com/babelify/-/babelify-10.0.0.tgz#fe73b1a22583f06680d8d072e25a1e0d1d1d7fb5"
@@ -3625,14 +3477,6 @@ broccoli-file-creator@^1.1.1:
     broccoli-plugin "^1.1.0"
     mkdirp "^0.5.1"
 
-broccoli-file-creator@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/broccoli-file-creator/-/broccoli-file-creator-2.1.1.tgz#7351dd2496c762cfce7736ce9b49e3fce0c7b7db"
-  integrity sha512-YpjOExWr92C5vhnK0kmD81kM7U09kdIRZk9w4ZDCDHuHXW+VE/x6AGEOQQW3loBQQ6Jk+k+TSm8dESy4uZsnjw==
-  dependencies:
-    broccoli-plugin "^1.1.0"
-    mkdirp "^0.5.1"
-
 broccoli-funnel-reducer@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/broccoli-funnel-reducer/-/broccoli-funnel-reducer-1.0.0.tgz#11365b2a785aec9b17972a36df87eef24c5cc0ea"
@@ -3822,7 +3666,7 @@ broccoli-plugin@^1.0.0, broccoli-plugin@^1.1.0, broccoli-plugin@^1.2.0, broccoli
     rimraf "^2.3.4"
     symlink-or-copy "^1.1.8"
 
-broccoli-plugin@^2.0.0, broccoli-plugin@^2.1.0:
+broccoli-plugin@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/broccoli-plugin/-/broccoli-plugin-2.1.0.tgz#2fab6c578219cfcc64f773e9616073313fc8b334"
   integrity sha512-ElE4caljW4slapyEhSD9jU9Uayc8SoSABWdmY9SqbV8DHNxU6xg1jJsPcMm+cXOvggR3+G+OXAYQeFjWVnznaw==
@@ -3861,21 +3705,6 @@ broccoli-rollup@^2.1.1:
     rollup "^0.57.1"
     symlink-or-copy "^1.1.8"
     walk-sync "^0.3.1"
-
-broccoli-rollup@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/broccoli-rollup/-/broccoli-rollup-4.1.1.tgz#7531a24d88ddab9f1bace1c6ee6e6ca74a38d36f"
-  integrity sha512-hkp0dB5chiemi32t6hLe5bJvxuTOm1TU+SryFlZIs95KT9+94uj0C8w6k6CsZ2HuIdIZg6D252t4gwOlcTXrpA==
-  dependencies:
-    "@types/broccoli-plugin" "^1.3.0"
-    broccoli-plugin "^2.0.0"
-    fs-tree-diff "^2.0.1"
-    heimdalljs "^0.2.6"
-    node-modules-path "^1.0.1"
-    rollup "^1.12.0"
-    rollup-pluginutils "^2.8.1"
-    symlink-or-copy "^1.2.0"
-    walk-sync "^1.1.3"
 
 broccoli-slow-trees@^3.0.1, broccoli-slow-trees@^3.1.0:
   version "3.1.0"
@@ -5760,7 +5589,7 @@ ember-cli-babel-plugin-helpers@^1.0.0, ember-cli-babel-plugin-helpers@^1.1.1:
   resolved "https://registry.yarnpkg.com/ember-cli-babel-plugin-helpers/-/ember-cli-babel-plugin-helpers-1.1.1.tgz#5016b80cdef37036c4282eef2d863e1d73576879"
   integrity sha512-sKvOiPNHr5F/60NLd7SFzMpYPte/nnGkq/tMIfXejfKHIhaiIkYFqX8Z9UFTKWLLn+V7NOaby6niNPZUdvKCRw==
 
-ember-cli-babel@^6.16.0, ember-cli-babel@^6.6.0:
+ember-cli-babel@^6.6.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-6.18.0.tgz#3f6435fd275172edeff2b634ee7b29ce74318957"
   integrity sha512-7ceC8joNYxY2wES16iIBlbPSxwKDBhYwC8drU3ZEvuPDMwVv1KzxCNu1fvxyFEBWhwaRNTUxSCsEVoTd9nosGA==
@@ -5779,7 +5608,7 @@ ember-cli-babel@^6.16.0, ember-cli-babel@^6.6.0:
     ember-cli-version-checker "^2.1.2"
     semver "^5.5.0"
 
-ember-cli-babel@^7.0.0, ember-cli-babel@^7.13.0, ember-cli-babel@^7.13.2, ember-cli-babel@^7.18.0, ember-cli-babel@^7.22.1, ember-cli-babel@^7.23.0, ember-cli-babel@^7.23.1, ember-cli-babel@^7.26.2, ember-cli-babel@^7.26.6:
+ember-cli-babel@^7.0.0, ember-cli-babel@^7.13.0, ember-cli-babel@^7.13.2, ember-cli-babel@^7.22.1, ember-cli-babel@^7.23.0, ember-cli-babel@^7.23.1, ember-cli-babel@^7.26.2, ember-cli-babel@^7.26.6:
   version "7.26.6"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-7.26.6.tgz#322fbbd3baad9dd99e3276ff05bc6faef5e54b39"
   integrity sha512-040svtfj2RC35j/WMwdWJFusZaXmNoytLAMyBDGLMSlRvznudTxZjGlPV6UupmtTBApy58cEF8Fq4a+COWoEmQ==
@@ -6154,7 +5983,7 @@ ember-cli@~3.25.2:
     workerpool "^6.0.3"
     yam "^1.0.0"
 
-ember-compatibility-helpers@^1.1.1, ember-compatibility-helpers@^1.2.0, ember-compatibility-helpers@^1.2.1:
+ember-compatibility-helpers@^1.2.1:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/ember-compatibility-helpers/-/ember-compatibility-helpers-1.2.2.tgz#839e0c24190b7a2ec8c39b80e030811b1a95b6d3"
   integrity sha512-EKyCGOGBvKkBsk6wKfg3GhjTvTTkcEwzl/cv4VYvZM18cihmjGNpliR4BymWsKRWrv4VJLyq15Vhk3NHkSNBag==
@@ -6162,26 +5991,6 @@ ember-compatibility-helpers@^1.1.1, ember-compatibility-helpers@^1.2.0, ember-co
     babel-plugin-debug-macros "^0.2.0"
     ember-cli-version-checker "^5.1.1"
     semver "^5.4.1"
-
-ember-data@~3.20.0:
-  version "3.20.5"
-  resolved "https://registry.yarnpkg.com/ember-data/-/ember-data-3.20.5.tgz#1d0968983e1b6e71ba1539b623c1cd112c14ea20"
-  integrity sha512-rYcW7NkLT8bXec2Z1ODbrO9y/pdpk5ICn63aRA1UDL3nZ6hijowa9vNr+SnkzdLIDrfF40rP+f1N/oTkuqgwjw==
-  dependencies:
-    "@ember-data/adapter" "3.20.5"
-    "@ember-data/debug" "3.20.5"
-    "@ember-data/model" "3.20.5"
-    "@ember-data/private-build-infra" "3.20.5"
-    "@ember-data/record-data" "3.20.5"
-    "@ember-data/serializer" "3.20.5"
-    "@ember-data/store" "3.20.5"
-    "@ember/edition-utils" "^1.2.0"
-    "@ember/ordered-set" "^2.0.3"
-    "@glimmer/env" "^0.1.7"
-    broccoli-merge-trees "^4.2.0"
-    ember-cli-babel "^7.18.0"
-    ember-cli-typescript "^3.1.3"
-    ember-inflector "^3.0.1"
 
 ember-destroyable-polyfill@^2.0.3:
   version "2.0.3"
@@ -6226,13 +6035,6 @@ ember-in-element-polyfill@^1.0.1:
     ember-cli-babel "^7.23.1"
     ember-cli-htmlbars "^5.3.1"
     ember-cli-version-checker "^5.1.2"
-
-ember-inflector@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/ember-inflector/-/ember-inflector-3.0.1.tgz#04be6df4d7e4000f6d6bd70787cdc995f77be4ab"
-  integrity sha512-fngrwMsnhkBt51KZgwNwQYxgURwV4lxtoHdjxf7RueGZ5zM7frJLevhHw7pbQNGqXZ3N+MRkhfNOLkdDK9kFdA==
-  dependencies:
-    ember-cli-babel "^6.6.0"
 
 ember-load-initializers@^2.1.2:
   version "2.1.2"
@@ -6707,7 +6509,7 @@ eslint@^7.25.0:
     text-table "^0.2.0"
     v8-compile-cache "^2.0.3"
 
-esm@^3.2.25, esm@^3.2.4:
+esm@^3.2.4:
   version "3.2.25"
   resolved "https://registry.yarnpkg.com/esm/-/esm-3.2.25.tgz#342c18c29d56157688ba5ce31f8431fbb795cc10"
   integrity sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==
@@ -8271,13 +8073,6 @@ heimdalljs@^0.2.0, heimdalljs@^0.2.1, heimdalljs@^0.2.3, heimdalljs@^0.2.5, heim
   dependencies:
     rsvp "~3.2.1"
 
-heimdalljs@^0.3.0:
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/heimdalljs/-/heimdalljs-0.3.3.tgz#e92d2c6f77fd46d5bf50b610d28ad31755054d0b"
-  integrity sha1-6S0sb3f9RtW/ULYQ0orTF1UFTQs=
-  dependencies:
-    rsvp "~3.2.1"
-
 highlight.js@^10.0.0, highlight.js@^10.7.2:
   version "10.7.2"
   resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.7.2.tgz#89319b861edc66c48854ed1e6da21ea89f847360"
@@ -8545,7 +8340,7 @@ infer-owner@^1.0.3, infer-owner@^1.0.4:
   resolved "https://registry.yarnpkg.com/infer-owner/-/infer-owner-1.0.4.tgz#c4cefcaa8e51051c2a40ba2ce8a3d27295af9467"
   integrity sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==
 
-inflection@1.12.0, inflection@^1.12.0:
+inflection@^1.12.0:
   version "1.12.0"
   resolved "https://registry.yarnpkg.com/inflection/-/inflection-1.12.0.tgz#a200935656d6f5f6bc4dc7502e1aecb703228416"
   integrity sha1-ogCTVlbW9fa8TcdQLhrstwMihBY=
@@ -10818,11 +10613,6 @@ now-and-later@^2.0.0:
   dependencies:
     once "^1.3.2"
 
-npm-git-info@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/npm-git-info/-/npm-git-info-1.0.3.tgz#a933c42ec321e80d3646e0d6e844afe94630e1d5"
-  integrity sha1-qTPELsMh6A02RuDW6ESv6UYw4dU=
-
 npm-package-arg@^8.1.0:
   version "8.1.2"
   resolved "https://registry.yarnpkg.com/npm-package-arg/-/npm-package-arg-8.1.2.tgz#b868016ae7de5619e729993fbd8d11dc3c52ab62"
@@ -12651,7 +12441,7 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
     hash-base "^3.0.0"
     inherits "^2.0.1"
 
-rollup-pluginutils@^2.0.1, rollup-pluginutils@^2.8.1:
+rollup-pluginutils@^2.0.1:
   version "2.8.2"
   resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz#72f2af0748b592364dbd3389e600e5a9444a351e"
   integrity sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==
@@ -12674,15 +12464,6 @@ rollup@^0.57.1:
     rollup-pluginutils "^2.0.1"
     signal-exit "^3.0.2"
     sourcemap-codec "^1.4.1"
-
-rollup@^1.12.0:
-  version "1.32.1"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-1.32.1.tgz#4480e52d9d9e2ae4b46ba0d9ddeaf3163940f9c4"
-  integrity sha512-/2HA0Ec70TvQnXdzynFffkjA6XN+1e2pEv/uKS5Ulca40g2L7KuOE3riasHoNVHOsFD5KKZgDsMk1CP3Tw9s+A==
-  dependencies:
-    "@types/estree" "*"
-    "@types/node" "*"
-    acorn "^7.1.0"
 
 route-recognizer@^0.3.3:
   version "0.3.4"
@@ -12821,7 +12602,7 @@ semver@7.0.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.0.0.tgz#5f3ca35761e47e05b206c6daff2cf814f0316b8e"
   integrity sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==
 
-semver@7.3.5, semver@^7.1.1, semver@^7.1.3, semver@^7.2.1, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5:
+semver@7.3.5, semver@^7.1.1, semver@^7.2.1, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5:
   version "7.3.5"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
   integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==


### PR DESCRIPTION
We no longer have `moduleForModel` tests (:tada:), so we don't need ember-data as a dependency any longer. This helps fix a number of issues with our test suite running against canary builds, where the older version of ember-data we were using was missing some required properties of the `deprecate` invocation (but upgrading to newer ember-data wasn't possible because of node engine support).
