### PR TITLE
Fix ember-canary related issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 
 A test-framework-agnostic set of helpers for testing Ember.js applications
 
-
 Compatibility
 ------------------------------------------------------------------------------
 

--- a/addon-test-support/@ember/test-helpers/-internal/build-registry.ts
+++ b/addon-test-support/@ember/test-helpers/-internal/build-registry.ts
@@ -1,4 +1,4 @@
-import Resolver from '@ember/application/resolver';
+import type Resolver from '@ember/application/resolver';
 import ApplicationInstance from '@ember/application/instance';
 import Application from '@ember/application';
 import EmberObject from '@ember/object';

--- a/addon-test-support/@ember/test-helpers/build-owner.ts
+++ b/addon-test-support/@ember/test-helpers/build-owner.ts
@@ -1,5 +1,5 @@
 import Application from '@ember/application';
-import Resolver from '@ember/application/resolver';
+import type Resolver from '@ember/application/resolver';
 
 import { Promise } from './-utils';
 

--- a/addon-test-support/@ember/test-helpers/resolver.ts
+++ b/addon-test-support/@ember/test-helpers/resolver.ts
@@ -1,4 +1,4 @@
-import Resolver from '@ember/application/resolver';
+import type Resolver from '@ember/application/resolver';
 
 let __resolver__: Resolver | undefined;
 

--- a/addon-test-support/@ember/test-helpers/setup-context.ts
+++ b/addon-test-support/@ember/test-helpers/setup-context.ts
@@ -1,6 +1,6 @@
 import { _backburner, run } from '@ember/runloop';
 import { set, setProperties, get, getProperties } from '@ember/object';
-import Resolver from '@ember/application/resolver';
+import type Resolver from '@ember/application/resolver';
 import { setOwner } from '@ember/application';
 
 import buildOwner, { Owner } from './build-owner';

--- a/tests/helpers/resolver.js
+++ b/tests/helpers/resolver.js
@@ -35,17 +35,11 @@ export function createCustomResolver(registry) {
     registry['event-dispatcher:main'] = require('ember-native-dom-event-dispatcher').default;
   }
 
-  var Resolver = Ember.DefaultResolver.extend({
-    registry: null,
-
+  return {
+    registry,
     resolve(fullName) {
       return this.registry[fullName];
     },
 
-    normalize(fullName) {
-      return dasherize(fullName);
-    },
-  });
-
-  return Resolver.create({ registry, namespace: {} });
+  }
 }

--- a/tests/helpers/resolver.js
+++ b/tests/helpers/resolver.js
@@ -1,5 +1,3 @@
-import Ember from 'ember';
-import { dasherize } from '@ember/string';
 import { assign } from '@ember/polyfills';
 import { setRegistry } from '../../resolver';
 import { setResolver, setApplication } from '@ember/test-helpers';
@@ -40,6 +38,5 @@ export function createCustomResolver(registry) {
     resolve(fullName) {
       return this.registry[fullName];
     },
-
-  }
+  };
 }


### PR DESCRIPTION
Ember.DefaultResolver is no more, so rather trying to use it, we will simply rely on the basic resolver protocol. That way, not concrete object is needed, and we are future proof until such time as that changes.