### PR TITLE
[FIX] This fixes ember-canary

### DIFF
--- a/addon-test-support/@ember/test-helpers/setup-rendering-context.ts
+++ b/addon-test-support/@ember/test-helpers/setup-rendering-context.ts
@@ -263,7 +263,14 @@ export default function setupRenderingContext(
       let OutletView = owner.factoryFor
         ? owner.factoryFor('view:-outlet')
         : owner._lookupFactory!('view:-outlet');
-      let toplevelView = OutletView.create();
+
+      let environment = owner.lookup('-environment:main');
+      let template = owner.lookup('template:-outlet');
+
+      let toplevelView = OutletView.create({
+        template,
+        environment,
+      });
 
       owner.register('-top-level-view:main', {
         create() {


### PR DESCRIPTION
ember-canary requires `template` + `environment` be provided to the view. This seems like a reasonable change, but does require “low level” libraries such as `@ember/test-helpers` to make some changes.

(Ember PR https://github.com/emberjs/ember.js/pull/19680)

---

** note: no additional tests required, as ember-canary scenario is broken prior to this changes... in-other words required tests are already part of the test suite  **