### PR TITLE
Prevent leaking application instances when jQuery integration is enabled

### DIFF
--- a/addon-test-support/@ember/test-helpers/settled.ts
+++ b/addon-test-support/@ember/test-helpers/settled.ts
@@ -46,20 +46,18 @@ if (typeof jQuery !== 'undefined' && _internalPendingRequests) {
     willDestroy(...args: any[]) {
       const internalPendingRequests = _internalPendingRequests();
 
-      if (internalPendingRequests === 0) {
-        return;
+      if (internalPendingRequests !== 0) {
+        jQuery(document).off(
+          'ajaxSend',
+          internalPendingRequests.incrementPendingRequests
+        );
+        jQuery(document).off(
+          'ajaxComplete',
+          internalPendingRequests.decrementPendingRequests
+        );
+
+        internalPendingRequests.clearPendingRequests();
       }
-
-      jQuery(document).off(
-        'ajaxSend',
-        internalPendingRequests.incrementPendingRequests
-      );
-      jQuery(document).off(
-        'ajaxComplete',
-        internalPendingRequests.decrementPendingRequests
-      );
-
-      internalPendingRequests.clearPendingRequests();
 
       this._super(...args);
     },

--- a/tests/unit/teardown-context-test.js
+++ b/tests/unit/teardown-context-test.js
@@ -89,6 +89,17 @@ module('teardownContext', function (hooks) {
     assert.ok(context.owner.isDestroyed);
   });
 
+  test('the application instance is destroyed and unwatched', async function (assert) {
+    let instance = context.owner.lookup('-application-instance:main');
+    await teardownContext(context);
+
+    assert.equal(instance.isDestroyed, true);
+    assert.equal(
+      instance.application._applicationInstances.has(instance),
+      false
+    );
+  });
+
   if (hasjQuery()) {
     test('out of balance xhr semaphores are cleaned up on teardown', async function (assert) {
       this.pretender.unhandledRequest = function (/* verb, path, request */) {


### PR DESCRIPTION
The AJAX listener cleanup code wasn't always calling this._super(), so with jQuery integration enabled, lots of application instances were leaking