### PR TITLE
Preserve focus when default is prevented on mousedown

### DIFF
--- a/addon-test-support/@ember/test-helpers/dom/click.ts
+++ b/addon-test-support/@ember/test-helpers/dom/click.ts
@@ -34,9 +34,9 @@ export function __click__(
   element: Element | Document | Window,
   options: MouseEventInit
 ): void {
-  fireEvent(element, 'mousedown', options);
+  let mouseDownEvent = fireEvent(element, 'mousedown', options);
 
-  if (!isWindow(element)) {
+  if (!isWindow(element) && !mouseDownEvent?.defaultPrevented) {
     __focus__(element);
   }
 

--- a/addon-test-support/@ember/test-helpers/dom/double-click.ts
+++ b/addon-test-support/@ember/test-helpers/dom/double-click.ts
@@ -23,9 +23,9 @@ export function __doubleClick__(
   element: Element | Document | Window,
   options: MouseEventInit
 ): void {
-  fireEvent(element, 'mousedown', options);
+  let mouseDownEvent = fireEvent(element, 'mousedown', options);
 
-  if (!isWindow(element)) {
+  if (!isWindow(element) && !mouseDownEvent?.defaultPrevented) {
     __focus__(element);
   }
 

--- a/tests/unit/dom/click-test.js
+++ b/tests/unit/dom/click-test.js
@@ -327,6 +327,30 @@ module('DOM Helper: click', function (hooks) {
 
       assert.verifySteps(['mousedown', 'mouseup', 'click']);
     });
+
+    test('preventDefault() on the mousedown event prevents triggering focus/blur events', async function (assert) {
+      element = document.createElement('input');
+
+      let preventDefault = (e) => e.preventDefault();
+      element.addEventListener('mousedown', preventDefault);
+
+      insertElement(element);
+
+      const focusableElement = buildInstrumentedElement('input');
+      focusableElement.addEventListener('blur', () => {
+        console.log('blur');
+      });
+
+      await click(focusableElement);
+      await click(element);
+
+      assert.verifySteps(['mousedown', 'focus', 'focusin', 'mouseup', 'click']);
+
+      element.removeEventListener('mousedown', preventDefault);
+      await click(element);
+
+      assert.verifySteps(['blur', 'focusout']);
+    });
   });
 });
 

--- a/tests/unit/dom/double-click-test.js
+++ b/tests/unit/dom/double-click-test.js
@@ -375,6 +375,37 @@ module('DOM Helper: doubleClick', function (hooks) {
         'dblclick',
       ]);
     });
+
+    test('preventDefault() on the mousedown event prevents triggering focus/blur events', async function (assert) {
+      element = document.createElement('input');
+
+      let preventDefault = (e) => e.preventDefault();
+      element.addEventListener('mousedown', preventDefault);
+
+      insertElement(element);
+
+      const focusableElement = buildInstrumentedElement('input');
+
+      await doubleClick(focusableElement);
+      await doubleClick(element);
+
+      assert.verifySteps([
+        'mousedown',
+        'focus',
+        'focusin',
+        'mouseup',
+        'click',
+        'mousedown',
+        'mouseup',
+        'click',
+        'dblclick',
+      ]);
+
+      element.removeEventListener('mousedown', preventDefault);
+      await doubleClick(element);
+
+      assert.verifySteps(['blur', 'focusout']);
+    });
   });
 });
 


### PR DESCRIPTION
Preventing default on a mousedown event prevents the focus from changing, so implement that behavior in the click and dblclick DOM helpers