### PR TITLE
Fix focus behavior when ancestor is focusable

### DIFF
--- a/tests/unit/dom/click-test.js
+++ b/tests/unit/dom/click-test.js
@@ -253,6 +253,21 @@ module('DOM Helper: click', function (hooks) {
         new Error('Can not `click` disabled [object HTMLInputElement]')
       );
     });
+
+    test('clicking an un-focusable element inside a focus-able one', async function (assert) {
+      element = buildInstrumentedElement('button');
+      let child = document.createElement('span');
+      element.append(child);
+
+      await click(child);
+
+      assert.verifySteps(clickSteps);
+      assert.strictEqual(
+        document.activeElement,
+        element,
+        'activeElement updated'
+      );
+    });
   });
 
   module('elements in different realms', function () {
@@ -291,6 +306,28 @@ module('DOM Helper: click', function (hooks) {
         'click',
         'blur',
         'focusout',
+      ]);
+    });
+
+    test('clicking on non-focusable element inside active element does not trigger blur on active element', async function (assert) {
+      element = buildInstrumentedElement('button');
+      let child = document.createElement('div');
+      element.append(child);
+
+      insertElement(element);
+
+      await click(element);
+      await click(child);
+
+      assert.verifySteps([
+        'mousedown',
+        'focus',
+        'focusin',
+        'mouseup',
+        'click',
+        'mousedown',
+        'mouseup',
+        'click',
       ]);
     });
 

--- a/tests/unit/dom/double-click-test.js
+++ b/tests/unit/dom/double-click-test.js
@@ -277,6 +277,21 @@ module('DOM Helper: doubleClick', function (hooks) {
         /Must setup rendering context before attempting to interact with elements/
       );
     });
+
+    test('double-clicking an un-focusable element inside a focus-able one', async function (assert) {
+      element = buildInstrumentedElement('button');
+      let child = document.createElement('span');
+      element.append(child);
+
+      await doubleClick(child);
+
+      assert.verifySteps(clickSteps);
+      assert.strictEqual(
+        document.activeElement,
+        element,
+        'activeElement updated'
+      );
+    });
   });
 
   module('elements in different realms', function () {
@@ -305,7 +320,7 @@ module('DOM Helper: doubleClick', function (hooks) {
   });
 
   module('focusable and non-focusable elements interaction', function () {
-    test('cdouble-licking on non-focusable element triggers blur on active element', async function (assert) {
+    test('double-clicking on non-focusable element triggers blur on active element', async function (assert) {
       element = document.createElement('div');
 
       insertElement(element);
@@ -327,6 +342,36 @@ module('DOM Helper: doubleClick', function (hooks) {
         'dblclick',
         'blur',
         'focusout',
+      ]);
+    });
+
+    test('double-clicking on non-focusable element inside active element does not trigger blur on active element', async function (assert) {
+      element = buildInstrumentedElement('button');
+      let child = document.createElement('div');
+      element.append(child);
+
+      insertElement(element);
+
+      await doubleClick(element);
+      await doubleClick(child);
+
+      assert.verifySteps([
+        'mousedown',
+        'focus',
+        'focusin',
+        'mouseup',
+        'click',
+        'mousedown',
+        'mouseup',
+        'click',
+        'dblclick',
+        'mousedown',
+        'mouseup',
+        'click',
+        'mousedown',
+        'mouseup',
+        'click',
+        'dblclick',
       ]);
     });
 


### PR DESCRIPTION
When clicking/double-clicking on an un-focusable element with a focusable ancestor, the __focus__ helper was not noticing that there was a focusable ancestor, and blurring the active element without focusing the focusable ancestor (or leaving focus alone of the focusable ancestor was already focused).