### PR TITLE
Add a `triggerEvent` doc example

### DIFF
--- a/addon-test-support/@ember/test-helpers/dom/trigger-event.ts
+++ b/addon-test-support/@ember/test-helpers/dom/trigger-event.ts
@@ -59,8 +59,8 @@ registerHook('triggerEvent', 'start', (target: Target, eventType: string) => {
  * <caption>
  * Using `triggerEvent` to simulate a mouseleave event
  *
- * `triggerEvent` provides a way to to trigger any [Event](https://developer.mozilla.org/en-US/docs/Web/API/Event). 
- *  The `options` param can contain any sub set of properties from each of the Event sub-types.
+ * `triggerEvent` provides a way to to trigger any [Event](https://developer.mozilla.org/en-US/docs/Web/API/Event)
+ * The `options` param can contain any sub set of properties from each of the Event sub-types.
  * If supplied, the `options.relatedTarget` has to be an HTML `Element`.
  * </caption>
  *


### PR DESCRIPTION
My team and I have been struggling with the `triggerEvent` options parameter.

Our usecase is fixing [a Firefox bug](https://stackoverflow.com/questions/46831247/select-triggers-mouseleave-event-on-parent-element-in-mozilla-firefox) where the mouseleave event is triggered when hovering a select option even if the mouse is still hover the target element. We did some acceptance tests to trigger the event with or without a given `relatedTarget` element.

Hopefully this PR will help other users too 😄.