### PR TITLE
Avoid using `Ember.assign` (prevents deprecations on newer Ember versions)

### DIFF
--- a/addon-test-support/@ember/test-helpers/-internal/debug-info.ts
+++ b/addon-test-support/@ember/test-helpers/-internal/debug-info.ts
@@ -5,7 +5,6 @@ import {
   DeferredActionQueues,
 } from '@ember/runloop';
 import { DebugInfoHelper, debugInfoHelpers } from './debug-info-helpers';
-import { assign } from '@ember/polyfills';
 import {
   getPendingWaiterState,
   PendingWaiterState,
@@ -95,7 +94,7 @@ export class TestDebugInfo implements DebugInfo {
 
   get summary(): SummaryInfo {
     if (!this._summaryInfo) {
-      this._summaryInfo = assign(<SummaryInfo>{}, this._settledState);
+      this._summaryInfo = { ...(this._settledState as SummaryInfo) };
 
       if (this._debugInfo) {
         this._summaryInfo.autorunStackTrace =

--- a/addon-test-support/@ember/test-helpers/dom/blur.ts
+++ b/addon-test-support/@ember/test-helpers/dom/blur.ts
@@ -1,4 +1,3 @@
-import { assign } from '@ember/polyfills';
 import getElement from './-get-element';
 import fireEvent from './fire-event';
 import settled from '../settled';
@@ -39,7 +38,7 @@ export function __blur__(
   // fire `blur` event via native event.
   if (browserIsNotFocused || needsCustomEventOptions) {
     let options = { relatedTarget };
-    fireEvent(element, 'blur', assign({ bubbles: false }, options));
+    fireEvent(element, 'blur', { bubbles: false, ...options });
     fireEvent(element, 'focusout', options);
   }
 }

--- a/addon-test-support/@ember/test-helpers/dom/click.ts
+++ b/addon-test-support/@ember/test-helpers/dom/click.ts
@@ -1,4 +1,3 @@
-import { assign } from '@ember/polyfills';
 import { getWindowOrElement } from './-get-window-or-element';
 import fireEvent from './fire-event';
 import { __focus__ } from './focus';
@@ -93,7 +92,7 @@ export default function click(
   target: Target,
   _options: MouseEventInit = {}
 ): Promise<void> {
-  let options = assign({}, DEFAULT_CLICK_OPTIONS, _options);
+  let options = { ...DEFAULT_CLICK_OPTIONS, ..._options };
 
   return Promise.resolve()
     .then(() => runHooks('click', 'start', target, _options))

--- a/addon-test-support/@ember/test-helpers/dom/double-click.ts
+++ b/addon-test-support/@ember/test-helpers/dom/double-click.ts
@@ -1,4 +1,3 @@
-import { assign } from '@ember/polyfills';
 import { getWindowOrElement } from './-get-window-or-element';
 import fireEvent from './fire-event';
 import { __focus__ } from './focus';
@@ -94,7 +93,7 @@ export default function doubleClick(
   target: Target,
   _options: MouseEventInit = {}
 ): Promise<void> {
-  let options = assign({}, DEFAULT_CLICK_OPTIONS, _options);
+  let options = { ...DEFAULT_CLICK_OPTIONS, ..._options };
 
   return Promise.resolve()
     .then(() => runHooks('doubleClick', 'start', target, _options))

--- a/addon-test-support/@ember/test-helpers/dom/fire-event.ts
+++ b/addon-test-support/@ember/test-helpers/dom/fire-event.ts
@@ -1,4 +1,3 @@
-import { assign } from '@ember/polyfills';
 import { isDocument, isElement } from './-target';
 import tuple from '../-tuple';
 
@@ -116,9 +115,10 @@ function fireEvent(
       screenY: y + 95, // They're just to make the screenX/Y be different of clientX/Y..
       clientX: x,
       clientY: y,
+      ...options,
     };
 
-    event = buildMouseEvent(eventType, assign(simulatedCoordinates, options));
+    event = buildMouseEvent(eventType, simulatedCoordinates);
   } else if (
     isFileSelectionEventType(eventType) &&
     isFileSelectionInput(element)
@@ -147,14 +147,16 @@ function buildBasicEvent(type: string, options: any = {}): Event {
   // bubbles and cancelable are readonly, so they can be
   // set when initializing event
   event.initEvent(type, bubbles, cancelable);
-  assign(event, options);
+  for (let prop in options) {
+    (event as any)[prop] = options[prop];
+  }
   return event;
 }
 
 // eslint-disable-next-line require-jsdoc
 function buildMouseEvent(type: MouseEventType, options: any = {}) {
   let event;
-  let eventOpts: any = assign({ view: window }, DEFAULT_EVENT_OPTIONS, options);
+  let eventOpts: any = { view: window, ...DEFAULT_EVENT_OPTIONS, ...options };
   if (MOUSE_EVENT_CONSTRUCTOR) {
     event = new MouseEvent(type, eventOpts);
   } else {
@@ -191,7 +193,7 @@ export function _buildKeyboardEvent(
   type: KeyboardEventType,
   options: any = {}
 ) {
-  let eventOpts: any = assign({}, DEFAULT_EVENT_OPTIONS, options);
+  let eventOpts: any = { ...DEFAULT_EVENT_OPTIONS, ...options };
   let event: Event | undefined;
   let eventMethodName: 'initKeyboardEvent' | 'initKeyEvent' | undefined;
 

--- a/addon-test-support/@ember/test-helpers/dom/trigger-key-event.ts
+++ b/addon-test-support/@ember/test-helpers/dom/trigger-key-event.ts
@@ -1,4 +1,3 @@
-import { assign } from '@ember/polyfills';
 import getElement from './-get-element';
 import fireEvent from './fire-event';
 import settled from '../settled';
@@ -154,6 +153,7 @@ export function __triggerKeyEvent__(
       keyCode: key,
       which: key,
       key: keyFromKeyCodeAndModifiers(key, modifiers),
+      ...modifiers,
     };
   } else if (typeof key === 'string' && key.length !== 0) {
     let firstCharacter = key[0];
@@ -170,16 +170,14 @@ export function __triggerKeyEvent__(
     }
 
     let keyCode = keyCodeFromKey(key);
-    props = { keyCode, which: keyCode, key };
+    props = { keyCode, which: keyCode, key, ...modifiers };
   } else {
     throw new Error(
       `Must provide a \`key\` or \`keyCode\` to \`triggerKeyEvent\``
     );
   }
 
-  let options = assign(props, modifiers);
-
-  fireEvent(element, eventType, options);
+  fireEvent(element, eventType, props);
 }
 
 /**

--- a/tests/helpers/resolver.js
+++ b/tests/helpers/resolver.js
@@ -1,11 +1,10 @@
-import { assign } from '@ember/polyfills';
 import { setRegistry } from '../../resolver';
 import { setResolver, setApplication } from '@ember/test-helpers';
 import require from 'require';
 import App from '../../app';
 import config from '../../config/environment';
 
-const AppConfig = assign({ autoboot: false }, config.APP);
+const AppConfig = { autoboot: false, ...config.APP };
 export const application = App.create(AppConfig);
 export const resolver = application.Resolver.create({
   namespace: application,


### PR DESCRIPTION
This supersedes #1114.

We don't need any special polyfill for IE11 because Babel will handle that for us if instead we use object spread.