### PR TITLE
Include event.detail in click and dblclick events

### DIFF
--- a/addon-test-support/@ember/test-helpers/dom/click.ts
+++ b/addon-test-support/@ember/test-helpers/dom/click.ts
@@ -33,6 +33,7 @@ export function __click__(
   element: Element | Document | Window,
   options: MouseEventInit
 ): void {
+  options = { ...options, detail: 1 };
   let mouseDownEvent = fireEvent(element, 'mousedown', options);
 
   if (!isWindow(element) && !mouseDownEvent?.defaultPrevented) {

--- a/addon-test-support/@ember/test-helpers/dom/double-click.ts
+++ b/addon-test-support/@ember/test-helpers/dom/double-click.ts
@@ -22,6 +22,7 @@ export function __doubleClick__(
   element: Element | Document | Window,
   options: MouseEventInit
 ): void {
+  options = { ...options, detail: 1 };
   let mouseDownEvent = fireEvent(element, 'mousedown', options);
 
   if (!isWindow(element) && !mouseDownEvent?.defaultPrevented) {
@@ -30,6 +31,8 @@ export function __doubleClick__(
 
   fireEvent(element, 'mouseup', options);
   fireEvent(element, 'click', options);
+
+  options = { ...options, detail: 2 };
   fireEvent(element, 'mousedown', options);
   fireEvent(element, 'mouseup', options);
   fireEvent(element, 'click', options);

--- a/tests/unit/dom/click-test.js
+++ b/tests/unit/dom/click-test.js
@@ -142,14 +142,15 @@ module('DOM Helper: click', function (hooks) {
         'clientY',
         'button',
         'buttons',
+        'detail',
       ]);
 
       await click(element, { clientX: 13, clientY: 17, button: 2 });
 
       assert.verifySteps([
-        'mousedown 13 17 2 1',
-        'mouseup 13 17 2 1',
-        'click 13 17 2 1',
+        'mousedown 13 17 2 1 1',
+        'mouseup 13 17 2 1 1',
+        'click 13 17 2 1 1',
       ]);
     });
 

--- a/tests/unit/dom/double-click-test.js
+++ b/tests/unit/dom/double-click-test.js
@@ -185,18 +185,19 @@ module('DOM Helper: doubleClick', function (hooks) {
         'clientY',
         'button',
         'buttons',
+        'detail',
       ]);
 
       await doubleClick(element, { clientX: 13, clientY: 17, button: 1 });
 
       assert.verifySteps([
-        'mousedown 13 17 1 1',
-        'mouseup 13 17 1 1',
-        'click 13 17 1 1',
-        'mousedown 13 17 1 1',
-        'mouseup 13 17 1 1',
-        'click 13 17 1 1',
-        'dblclick 13 17 1 1',
+        'mousedown 13 17 1 1 1',
+        'mouseup 13 17 1 1 1',
+        'click 13 17 1 1 1',
+        'mousedown 13 17 1 1 2',
+        'mouseup 13 17 1 1 2',
+        'click 13 17 1 1 2',
+        'dblclick 13 17 1 1 2',
       ]);
     });
   });


### PR DESCRIPTION
This change updates UIEvent.detail (https://developer.mozilla.org/en-US/docs/Web/API/UIEvent/detail) on `click` and `dblclick` events.