### PR TITLE
Move `ember-cli-htmlbars` to `devDependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "broccoli-debug": "^0.6.5",
     "broccoli-funnel": "^3.0.8",
     "ember-cli-babel": "^7.26.6",
-    "ember-cli-htmlbars": "^5.7.1",
     "ember-destroyable-polyfill": "^2.0.3"
   },
   "devDependencies": {
@@ -59,6 +58,7 @@
     "ember-auto-import": "^2.2.0",
     "ember-cli": "~3.28.3",
     "ember-cli-dependency-checker": "^3.2.0",
+    "ember-cli-htmlbars": "^5.7.1",
     "ember-cli-inject-live-reload": "^2.1.0",
     "ember-cli-test-loader": "^3.0.0",
     "ember-disable-prototype-extensions": "^1.1.3",


### PR DESCRIPTION
As addon does not ship any hbs templates, there is no need to have `ember-cli-htmlbars` in `dependencies`