### PR TITLE
support invoking components with `render`

### DIFF
--- a/tests/integration/setup-rendering-context-test.js
+++ b/tests/integration/setup-rendering-context-test.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
 import { module, test } from 'qunit';
-import Component from '@ember/component';
+import Component, { setComponentTemplate } from '@ember/component';
+import templateOnly from '@ember/component/template-only';
 import { helper } from '@ember/component/helper';
 import { registerWaiter } from '@ember/test';
 import {
@@ -152,6 +153,17 @@ module('setupRenderingContext "real world"', function (hooks) {
             },
           })
         );
+
+        assert.equal(this.element.textContent, '4');
+      });
+    }
+  });
+
+  module('<template> transpilation support', function () {
+    if (hasEmberVersion(3, 25)) {
+      test('can render components', async function (assert) {
+        let myComponent = setComponentTemplate(hbs`4`, templateOnly());
+        await render(myComponent);
 
         assert.equal(this.element.textContent, '4');
       });


### PR DESCRIPTION
adds support for 
```jsx
await render(
  <template>
  
  </template>
);
```

or 
```js
await render(SomeComponent);
```

This usage only makes sense if the component takes no args.

_alternatively_, we could make ember-template-imports _not_ turn the `<template>` into a component within `render`, but I feel like that could get complicated when people define the `<template>` outside of render and then try to pass it render, and then we're back at the same problem.