### PR TITLE
fix: add functional HACK for triggering React change event

### DIFF
--- a/tests/unit/dom/fill-in-test.js
+++ b/tests/unit/dom/fill-in-test.js
@@ -347,4 +347,32 @@ module('DOM Helper: fillIn', function (hooks) {
       )
     );
   });
+
+  ['input', 'textarea'].forEach((elementType) => {
+    test(`filling in a psuedo React ${elementType} changes its value tracker`, async function (assert) {
+      element = buildInstrumentedElement(elementType);
+      element._valueTracker = {
+        currentValue: 'foo',
+        getValue() {
+          return this.currentValue;
+        },
+        setValue(value) {
+          this.currentValue = '' + value;
+        },
+      };
+      element.value = 'foo';
+
+      await setupContext(context);
+
+      await fillIn(element, 'bar');
+
+      assert.verifySteps(clickSteps);
+      assert.equal(element.value, 'bar', 'value updated');
+      assert.equal(
+        element._valueTracker.getValue(),
+        '',
+        'value tracker updated'
+      );
+    });
+  });
 });

--- a/tests/unit/dom/type-in-test.js
+++ b/tests/unit/dom/type-in-test.js
@@ -361,4 +361,32 @@ module('DOM Helper: typeIn', function (hooks) {
       new Error("Can not `typeIn` with text: 'fo' that exceeds maxlength: '1'.")
     );
   });
+
+  ['input', 'textarea'].forEach((elementType) => {
+    test(`filling in a psuedo React ${elementType} changes its value tracker`, async function (assert) {
+      element = buildInstrumentedElement(elementType);
+      element._valueTracker = {
+        currentValue: 'foo',
+        getValue() {
+          return this.currentValue;
+        },
+        setValue(value) {
+          this.currentValue = '' + value;
+        },
+      };
+      element.value = 'foo';
+
+      await setupContext(context);
+
+      await typeIn(element, 'bar');
+
+      assert.verifySteps(expectedEvents);
+      assert.equal(element.value, 'foobar', 'value updated');
+      assert.equal(
+        element._valueTracker.getValue(),
+        '',
+        'value tracker updated'
+      );
+    });
+  });
 });


### PR DESCRIPTION
## Change

Add a functional hack when working with React-in-Ember apps or addons.

My team is using https://github.com/rewardops/ember-react-components (which is a modernization of https://github.com/alexlafroscia/ember-react-components) in order to bake React components into our Ember apps and addons. As you can see in the JSDoc in my changes, this hack is necessary for preparing React `<input />` elements for `change` events. Without this preparation, `<input />`s ignore the simulated event following `fillIn` and `typeIn` actions.

Further background on this issue can be read by following the links in the JSDoc. (Note that this a problem for folks in the Selenium ecosystem as well.)

## Rationale

We realize that this addition to the `test-helpers` library is rather niche. Normally, we would have forked this library, published our own version and gone on our merry way. However, much of the Ember testing ecosystem (e.g., https://github.com/emberjs/ember-qunit, https://github.com/san650/ember-cli-page-object) presupposes the use of `@ember/test-helpers` and has that dependency baked right in. As a result of this fairly tight coupling, leveraging our own forked (and renamed) library causes all sort of errors during testing, and so precludes us from going that direction — unless we also want to fork every other library that relies on this one.

As a temporary measure, we've added a `tar.gz` pack in our forked repo (see https://github.com/rewardops/ember-test-helpers/releases/tag/v2.6.0), but we hope this is not a long-term solution. Instead, we're hoping that the fix we propose here is negligible enough to warrant inclusion in the origin library. We're certainly open to feedback! 🙂 