### PR TITLE
feat: add `'before-fire-event'` hook to helpers with side-effects

### DIFF
--- a/addon-test-support/@ember/test-helpers/dom/fill-in.ts
+++ b/addon-test-support/@ember/test-helpers/dom/fill-in.ts
@@ -72,6 +72,13 @@ export default function fillIn(target: Target, text: string): Promise<void> {
           '`fillIn` is only usable on form controls or contenteditable elements.'
         );
       }
+
+      return settled();
+    })
+    .then(() => runHooks('fillIn', 'before-fire-event', target, text))
+    .then(() => {
+      let element = getElement(target) as Element | HTMLElement;
+
       fireEvent(element, 'input');
       fireEvent(element, 'change');
 

--- a/addon-test-support/@ember/test-helpers/dom/scroll-to.ts
+++ b/addon-test-support/@ember/test-helpers/dom/scroll-to.ts
@@ -53,6 +53,12 @@ export default function scrollTo(
       element.scrollTop = y;
       element.scrollLeft = x;
 
+      return settled();
+    })
+    .then(() => runHooks('scrollTo', 'before-fire-event', target))
+    .then(() => {
+      let element = getElement(target) as Element;
+
       fireEvent(element, 'scroll');
 
       return settled();

--- a/addon-test-support/@ember/test-helpers/dom/select.ts
+++ b/addon-test-support/@ember/test-helpers/dom/select.ts
@@ -90,6 +90,20 @@ export default function select(
         }
       }
 
+      return settled();
+    })
+    .then(() =>
+      runHooks(
+        'select',
+        'before-fire-event',
+        target,
+        options,
+        keepPreviouslySelected
+      )
+    )
+    .then(() => {
+      const element = getElement(target) as Element;
+
       fireEvent(element, 'input');
       fireEvent(element, 'change');
 

--- a/addon-test-support/@ember/test-helpers/dom/type-in.ts
+++ b/addon-test-support/@ember/test-helpers/dom/type-in.ts
@@ -96,11 +96,12 @@ export default function typeIn(
       let { delay = 50 } = options;
 
       return fillOut(element, text, delay)
+        .then(() =>
+          runHooks('typeIn', 'before-fire-event', target, text, options)
+        )
         .then(() => fireEvent(element, 'change'))
         .then(settled)
-        .then(() => {
-          return runHooks('typeIn', 'end', target, text, options);
-        });
+        .then(() => runHooks('typeIn', 'end', target, text, options));
     });
 }
 

--- a/tests/integration/dom/scroll-to-test.js
+++ b/tests/integration/dom/scroll-to-test.js
@@ -25,11 +25,18 @@ module('DOM Helper: scroll-to', function (hooks) {
   });
 
   test('it executes registered scrollTo hooks', async function (assert) {
-    assert.expect(3);
+    assert.expect(4);
 
     let startHook = _registerHook('scrollTo', 'start', () => {
       assert.step('scrollTo:start');
     });
+    let beforeFireEventHook = _registerHook(
+      'scrollTo',
+      'before-fire-event',
+      () => {
+        assert.step('scrollTo:before-fire-event');
+      }
+    );
     let endHook = _registerHook('scrollTo', 'end', () => {
       assert.step('scrollTo:end');
     });
@@ -51,9 +58,14 @@ module('DOM Helper: scroll-to', function (hooks) {
 
     await scrollTo('.container', 0, 50);
 
-    assert.verifySteps(['scrollTo:start', 'scrollTo:end']);
+    assert.verifySteps([
+      'scrollTo:start',
+      'scrollTo:before-fire-event',
+      'scrollTo:end',
+    ]);
 
     startHook.unregister();
+    beforeFireEventHook.unregister();
     endHook.unregister();
   });
 

--- a/tests/unit/dom/fill-in-test.js
+++ b/tests/unit/dom/fill-in-test.js
@@ -41,7 +41,7 @@ module('DOM Helper: fillIn', function (hooks) {
   });
 
   test('it executes registered fillIn hooks', async function (assert) {
-    assert.expect(3);
+    assert.expect(4);
 
     element = document.createElement('input');
     insertElement(element);
@@ -49,6 +49,13 @@ module('DOM Helper: fillIn', function (hooks) {
     let startHook = _registerHook('fillIn', 'start', () => {
       assert.step('fillIn:start');
     });
+    let beforeFireEventHook = _registerHook(
+      'fillIn',
+      'before-fire-event',
+      () => {
+        assert.step('fillIn:before-fire-event');
+      }
+    );
     let endHook = _registerHook('fillIn', 'end', () => {
       assert.step('fillIn:end');
     });
@@ -56,9 +63,14 @@ module('DOM Helper: fillIn', function (hooks) {
     try {
       await fillIn(element, 'foo');
 
-      assert.verifySteps(['fillIn:start', 'fillIn:end']);
+      assert.verifySteps([
+        'fillIn:start',
+        'fillIn:before-fire-event',
+        'fillIn:end',
+      ]);
     } finally {
       startHook.unregister();
+      beforeFireEventHook.unregister();
       endHook.unregister();
     }
   });

--- a/tests/unit/dom/select-test.js
+++ b/tests/unit/dom/select-test.js
@@ -35,7 +35,7 @@ module('DOM Helper: select', function (hooks) {
   });
 
   test('it executes registered select hooks', async function (assert) {
-    assert.expect(3);
+    assert.expect(4);
 
     element = document.createElement('select');
     insertElement(element);
@@ -43,6 +43,13 @@ module('DOM Helper: select', function (hooks) {
     let startHook = _registerHook('select', 'start', () => {
       assert.step('select:start');
     });
+    let beforeFireEventHook = _registerHook(
+      'select',
+      'before-fire-event',
+      () => {
+        assert.step('select:before-fire-event');
+      }
+    );
     let endHook = _registerHook('select', 'end', () => {
       assert.step('select:end');
     });
@@ -50,9 +57,14 @@ module('DOM Helper: select', function (hooks) {
     try {
       await select(element, 'apple');
 
-      assert.verifySteps(['select:start', 'select:end']);
+      assert.verifySteps([
+        'select:start',
+        'select:before-fire-event',
+        'select:end',
+      ]);
     } finally {
       startHook.unregister();
+      beforeFireEventHook.unregister();
       endHook.unregister();
     }
   });

--- a/tests/unit/dom/type-in-test.js
+++ b/tests/unit/dom/type-in-test.js
@@ -77,7 +77,7 @@ module('DOM Helper: typeIn', function (hooks) {
   });
 
   test('it executes registered typeIn hooks', async function (assert) {
-    assert.expect(3);
+    assert.expect(4);
 
     element = document.createElement('input');
     insertElement(element);
@@ -85,6 +85,13 @@ module('DOM Helper: typeIn', function (hooks) {
     let startHook = _registerHook('typeIn', 'start', () => {
       assert.step('typeIn:start');
     });
+    let beforeFireEventHook = _registerHook(
+      'typeIn',
+      'before-fire-event',
+      () => {
+        assert.step('typeIn:before-fire-event');
+      }
+    );
     let endHook = _registerHook('typeIn', 'end', () => {
       assert.step('typeIn:end');
     });
@@ -92,9 +99,14 @@ module('DOM Helper: typeIn', function (hooks) {
     try {
       await typeIn(element, 'foo');
 
-      assert.verifySteps(['typeIn:start', 'typeIn:end']);
+      assert.verifySteps([
+        'typeIn:start',
+        'typeIn:before-fire-event',
+        'typeIn:end',
+      ]);
     } finally {
       startHook.unregister();
+      beforeFireEventHook.unregister();
       endHook.unregister();
     }
   });


### PR DESCRIPTION
A `'before-fire-event'` hook is added to any helper that involves side-effects — i.e. scrolls or changes values in the DOM prior to firing a `change` event. These hooks allow better control of the DOM in cases where code needs to be executed _after_ a helper affects the DOM as well as _before_ an event is fired.

This PR follows from my conversation in #1182, and should serve to resolve an issue I have following @rwjblue's suggestion therein.