### PR TITLE
[BREAKING?] fix(settled, waitUntil): reject with error thrown in run loop

### DIFF
--- a/API.md
+++ b/API.md
@@ -568,6 +568,7 @@ while *not* settled (e.g. "loading" or "pending" states).
 
     *   `options.timeout` **[number][67]** the maximum amount of time to wait (optional, default `1000`)
     *   `options.timeoutMessage` **[string][62]** the message to use in the reject on timeout (optional, default `'waitUntil timed out'`)
+    *   `options.rejectOnError` **[boolean][69]** reject when an operation in a run loop has failed (optional, default `true`, if the test context has been setup for usage with [`setupOnerror`][49])
 
 #### Examples
 

--- a/API.md
+++ b/API.md
@@ -589,6 +589,14 @@ a definition of "settled state").
 
 Returns **[Promise][64]\<void>** resolves when settled
 
+#### Parameters
+
+*   `options` **[Object][70]?** options passed to [`waitUntil`][26] (optional, default `{}`)
+
+    *   `options.timeout` **[number][67]** the maximum amount of time to wait (optional, default `Infinity`)
+    *   `options.timeoutMessage` **[string][62]** the message to use in the reject on timeout (optional, default `'settled timed out'`)
+    *   `options.rejectOnError` **[boolean][69]** reject when an operation in a run loop has failed (optional, default `true`, if the test context has been setup for usage with [`setupOnerror`][49])
+
 ### isSettled
 
 Checks various settledness metrics (via `getSettledState()`) to determine if things are settled or not.

--- a/addon-test-support/@ember/test-helpers/settled.ts
+++ b/addon-test-support/@ember/test-helpers/settled.ts
@@ -5,7 +5,9 @@ import Ember from 'ember';
 import EmberApplicationInstance from '@ember/application/instance';
 
 import { nextTick } from './-utils';
-import waitUntil from './wait-until';
+import waitUntil, { Options } from './wait-until';
+// @ts-ignore Referenced in DocBlock.
+import type { setupOnerror } from './setup-onerror';
 import { hasPendingTransitions } from './setup-application-context';
 import { hasPendingWaiters } from '@ember/test-waiters';
 import DebugInfo, { TestDebugInfo } from './-internal/debug-info';
@@ -281,8 +283,18 @@ export function isSettled(): boolean {
   a definition of "settled state").
 
   @public
+  @param {Object} [options] options passed to {@link waitUntil}
+  @param {number} [options.timeout=Infinity] the maximum amount of time to wait
+  @param {string} [options.timeoutMessage='settled timed out'] the message to
+use in the reject on timeout
+  @param {boolean} [options.rejectOnError] reject when an operation in a run
+loop has failed; defaults to `true`, if the test context has been setup for usage with {@link setupOnerror}
   @returns {Promise<void>} resolves when settled
 */
-export default function settled(): Promise<void> {
-  return waitUntil(isSettled, { timeout: Infinity }).then(() => {});
+export default function settled(options?: Options): Promise<void> {
+  return waitUntil(isSettled, {
+    timeout: Infinity,
+    timeoutMessage: 'settled timed out',
+    ...options,
+  }).then(() => {});
 }

--- a/tests/unit/dom/click-test.js
+++ b/tests/unit/dom/click-test.js
@@ -5,6 +5,7 @@ import {
   teardownContext,
   _registerHook,
 } from '@ember/test-helpers';
+import { later } from '@ember/runloop';
 import {
   buildInstrumentedElement,
   instrumentElement,
@@ -58,6 +59,20 @@ module('DOM Helper: click', function (hooks) {
       startHook.unregister();
       endHook.unregister();
     }
+  });
+
+  test('rejects with error thrown inside the run loop', async function (assert) {
+    element = document.createElement('div');
+    insertElement(element);
+
+    element.addEventListener('click', () =>
+      later(() => {
+        throw new Error('bazinga');
+      }, 10)
+    );
+
+    await setupContext(context);
+    await assert.rejects(click(element), /bazinga/);
   });
 
   module('non-focusable element types', function () {

--- a/tests/unit/setup-rendering-context-test.js
+++ b/tests/unit/setup-rendering-context-test.js
@@ -156,6 +156,13 @@ module('setupRenderingContext', function (hooks) {
       assert.ok(isSettled(), 'should be settled');
     });
 
+    test('`render` rejects with error thrown inside the run loop', async function (assert) {
+      await assert.rejects(
+        render(hbs`<UnknownComponent />`),
+        /unknown-component/
+      );
+    });
+
     overwriteTest('element');
 
     test('it sets up test metadata', function (assert) {

--- a/tests/unit/wait-until-test.js
+++ b/tests/unit/wait-until-test.js
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
 import { Promise } from 'rsvp';
-import { waitUntil } from '@ember/test-helpers';
+import { waitUntil, setupContext, teardownContext } from '@ember/test-helpers';
+import { later } from '@ember/runloop';
 
 module('DOM helper: waitUntil', function () {
   test('waits until the provided function returns true', async function (assert) {
@@ -88,5 +89,21 @@ module('DOM helper: waitUntil', function () {
     }
 
     await new Promise((resolve) => setTimeout(resolve, 100));
+  });
+
+  test('rejects when run loop throws', async function (assert) {
+    const context = await setupContext({});
+
+    later(() => {
+      throw new Error('error goes here');
+    }, 10);
+
+    await assert.rejects(
+      waitUntil(() => false, { rejectOnError: true }),
+      /error goes here/,
+      'valid error was thrown'
+    );
+
+    await teardownContext(context);
   });
 });


### PR DESCRIPTION

This PR is currently still WIP and failing some tests, but I'd like to receive feedback on the implementation and course-correct, where necessary.

---

The goal of this PR is to fix the longstanding issue of test helpers not propagating run loop errors thrown during their execution, but instead causing an out of band "global failure" that fails the test. For example:

```ts
await render(hbs`<UnknownComponent />`);
// or
await click('.element-throws-on-click');
```

Fixes #310. Fixes #453. Relates to #440, #1128, [ember-qunit#592](https://github.com/emberjs/ember-qunit/issues/592)

---

This PR adds an `rejectOnError` option to `waitUntil`. It defaults to `true`, if the test context is set up correctly for use with `setupOnerror`.

If enabled, `waitUntil` will reject when an error propagates to `Ember.onerror`, using `setupOnerror` under the hood. As such, (a/sync) errors thrown in a run loop will cause `waitUntil` to fail.

Almost all test helpers end with a call to `settled`, which just calls `waitUntil`. Therefore they'll all automatically benefit from this change and reject, if an error is thrown during their execution.