### PR TITLE
set ember version for `renderSettled` 

### DIFF
--- a/addon-test-support/@ember/test-helpers/-internal/render-settled.ts
+++ b/addon-test-support/@ember/test-helpers/-internal/render-settled.ts
@@ -7,8 +7,7 @@ import {
 
 let renderSettled: () => Promise<void>;
 
-// TODO need to add the actual version `@ember/renderer` landed once we know it
-if (macroCondition(dependencySatisfies('ember-source', '>=4.9999999.0'))) {
+if (macroCondition(dependencySatisfies('ember-source', '>=4.5.0-beta.1'))) {
   //@ts-ignore
   renderSettled = importSync('@ember/renderer').renderSettled;
 } else if (


### PR DESCRIPTION
Now that https://github.com/emberjs/ember.js/pull/20053 is merged, we can actually specify the version number for importing `renderSettled` from `@ember/renderer`.