### PR TITLE
Fix usage of `owner.unregister` within `ember-engines` tests

### DIFF
--- a/addon-test-support/@ember/test-helpers/-internal/build-registry.ts
+++ b/addon-test-support/@ember/test-helpers/-internal/build-registry.ts
@@ -44,6 +44,24 @@ const ContainerProxyMixin = (Ember as any)._ContainerProxyMixin;
 
 const Owner = EmberObject.extend(RegistryProxyMixin, ContainerProxyMixin, {
   _emberTestHelpersMockOwner: true,
+
+  /**
+   * Unregister a factory and its instance.
+   *
+   * Overrides `RegistryProxy#unregister` in order to clear any cached instances
+   * of the unregistered factory.
+   *
+   * @param {string} fullName Name of the factory to unregister.
+   *
+   * @see {@link https://github.com/emberjs/ember.js/pull/12680}
+   * @see {@link https://github.com/emberjs/ember.js/blob/v4.5.0-alpha.5/packages/%40ember/engine/instance.ts#L152-L167}
+   */
+  unregister(fullName: string) {
+    this.__container__.reset(fullName);
+
+    // We overwrote this method from RegistryProxyMixin.
+    this.__registry__.unregister(fullName);
+  },
 });
 
 /**


### PR DESCRIPTION
When [`buildOwner`](https://github.com/emberjs/ember-test-helpers/blob/master/addon-test-support/%40ember/test-helpers/build-owner.ts#L22-L60) is used with a `resolver` instead of an `application`, a custom owner is constructed via [`-internal/build-registry.ts`](https://github.com/emberjs/ember-test-helpers/blob/master/addon-test-support/%40ember/test-helpers/-internal/build-registry.ts) and used instead of an `ApplicationInstance`.

This custom owner misses the `unregister` patch that was added in https://github.com/emberjs/ember.js/pull/12680 to fix https://github.com/emberjs/ember.js/issues/11173#issuecomment-124897632. It is now on the [`EngineInstance`](https://github.com/emberjs/ember.js/blob/v4.5.0-alpha.5/packages/%40ember/engine/instance.ts#L152-L167).

Fixes https://github.com/buschtoens/ember-link/issues/714.