### PR TITLE
Fix issues with `embroider-optimized` scenarios.

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   "dependencies": {
     "@ember/test-waiters": "^3.0.0",
     "@embroider/macros": "^1.6.0",
+    "@embroider/util": "^1.6.0",
     "broccoli-debug": "^0.6.5",
     "broccoli-funnel": "^3.0.8",
     "ember-cli-babel": "^7.26.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1810,7 +1810,7 @@
     ember-cli-version-checker "^5.1.2"
     semver "^7.3.5"
 
-"@embroider/macros@^1.6.0":
+"@embroider/macros@1.6.0", "@embroider/macros@^1.6.0":
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/@embroider/macros/-/macros-1.6.0.tgz#2b764f965c645fdcfbf05897c88195368b046ba1"
   integrity sha512-yUEXJGJGP3rjtxorxrbkdxriBFEwnmzOrNk4zK64IXKBfyRjiDZFUHV9DSTrbaYLS29Mw5yK73ZIwi8L13C4Zw==
@@ -1850,6 +1850,15 @@
     resolve-package-path "^1.2.2"
     semver "^7.3.2"
     typescript-memoize "^1.0.0-alpha.3"
+
+"@embroider/util@^1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@embroider/util/-/util-1.6.0.tgz#6a817dfd5192afaab41e80ebce623d5812b30985"
+  integrity sha512-oUQDAMiAATHsiNwEMH/SzNSQ/Z5wDr9f6NImsDIFLvDT6T34/p7cqR4wyfrfMRtcc1EB6PbwhZ6bXYsJ6QPWRA==
+  dependencies:
+    "@embroider/macros" "1.6.0"
+    broccoli-funnel "^3.0.5"
+    ember-cli-babel "^7.23.1"
 
 "@eslint/eslintrc@^0.4.3":
   version "0.4.3"
@@ -6587,9 +6596,9 @@ ember-source-channel-url@^3.0.0:
     node-fetch "^2.6.0"
 
 ember-source@~3.28.4:
-  version "3.28.4"
-  resolved "https://registry.yarnpkg.com/ember-source/-/ember-source-3.28.4.tgz#b6ac2b1e369ef533d05164c65078b4ceafdb6390"
-  integrity sha512-s7kVy0E08erAHUTI/8SZZvXt3an/xb2g5K+m4Rybvo8Tr/noMk3lIdtyQkSvmgMZ/BbvoW8spS630sO0/JN4Eg==
+  version "3.28.9"
+  resolved "https://registry.yarnpkg.com/ember-source/-/ember-source-3.28.9.tgz#804c56b2d71d3cc3decff15a3273bb35d668300a"
+  integrity sha512-Fy7V3yvj+3oyo2+ke52aaihKMcFnnF7Oj9ixj547yzh2faqRfqouB5ZSiwXFH8rxw22rKaM8DiuQO4JN2Ay6xQ==
   dependencies:
     "@babel/helper-module-imports" "^7.8.3"
     "@babel/plugin-transform-block-scoping" "^7.8.3"


### PR DESCRIPTION
Leverage `ensureSafeComponent` from `@embroider/util` to support rendering a component class via `<this.Foo />` even on Ember < 3.25 (works back a loooong ways).


Fixes https://github.com/emberjs/ember-test-helpers/issues/1220
