### PR TITLE
DOCS: API: add routing helper examples

### DIFF
--- a/API.md
+++ b/API.md
@@ -494,13 +494,32 @@ Navigate the application to the provided URL.
 *   `url` **[string][62]** The URL to visit (e.g. `/posts`)
 *   `options` **[object][70]** app boot options
 
+#### Examples
+
+```javascript
+await visit('/posts/1');
+await visit('/', { rootElement: '#container' });
+```
+
 Returns **[Promise][64]\<void>** resolves when settled
 
 ### currentRouteName
 
+#### Examples
+
+```javascript
+assert.equal(currentRouteName(), 'posts.index');
+```
+
 Returns **[string][62]** the currently active route name
 
 ### currentURL
+
+#### Examples
+
+```javascript
+assert.equal(currentURL(), '/posts/1');
+```
 
 Returns **[string][62]** the applications current url
 


### PR DESCRIPTION
Let's add an example usage of all of the routing helpers (visit, currentRouteName, currentURL) to the API docs. This can close out the checkbox "Routing Helpers" in https://github.com/emberjs/ember-test-helpers/issues/378.