### PR TITLE
Re-export hasEmberVersion (and its type) from @ember/test-helpers

### DIFF
--- a/addon-test-support/@ember/test-helpers/index.ts
+++ b/addon-test-support/@ember/test-helpers/index.ts
@@ -5,6 +5,7 @@ import {
 
 export { setResolver, getResolver } from './resolver';
 export { getApplication, setApplication } from './application';
+export { default as hasEmberVersion } from './has-ember-version';
 export {
   default as setupContext,
   getContext,


### PR DESCRIPTION
This brings us one step closer to deprecating ye olde ember-test-helpers package.