### PR TITLE
Fix typesVersions path

### DIFF
--- a/package.json
+++ b/package.json
@@ -160,7 +160,7 @@
   "typesVersions": {
     "*": {
       "*": [
-        "public-types/*"
+        "public-types/addon-test-support/@ember/test-helpers/*"
       ]
     }
   }


### PR DESCRIPTION
It was incorrect previously, causing consumers to see "Cannot find module '@ember/test-helpers' or its corresponding type declarations."