### PR TITLE
perf: Remove excessive destroy call

### DIFF
--- a/addon-test-support/@ember/test-helpers/setup-context.ts
+++ b/addon-test-support/@ember/test-helpers/setup-context.ts
@@ -200,12 +200,6 @@ function cleanup(context: BaseContext) {
   (Ember as any).testing = false;
 
   unsetContext();
-
-  if (isTestContext(context)) {
-    // this should not be required, but until https://github.com/emberjs/ember.js/pull/19106
-    // lands in a 3.20 patch release
-    context.owner.destroy();
-  }
 }
 
 /**


### PR DESCRIPTION
I noticed while migrating some things away from EmberObject (which debounces destroy) that destroy was being triggered more than once due to this. It appears the upstream change has long-since landed and we can remove this and speed up everyone's tests <3