### PR TITLE
Use export type for public API

### DIFF
--- a/addon-test-support/@ember/test-helpers/index.ts
+++ b/addon-test-support/@ember/test-helpers/index.ts
@@ -6,6 +6,12 @@ import {
 export { setResolver, getResolver } from './resolver';
 export { getApplication, setApplication } from './application';
 export { default as hasEmberVersion } from './has-ember-version';
+export type {
+  BaseContext,
+  DeprecationFailure,
+  TestContext,
+  Warning,
+} from './setup-context';
 export {
   default as setupContext,
   getContext,
@@ -15,12 +21,8 @@ export {
   resumeTest,
   getDeprecations,
   getDeprecationsDuringCallback,
-  DeprecationFailure,
   getWarnings,
   getWarningsDuringCallback,
-  Warning,
-  BaseContext,
-  TestContext,
 } from './setup-context';
 export { default as teardownContext } from './teardown-context';
 export {
@@ -39,9 +41,11 @@ export { default as settled, isSettled, getSettledState } from './settled';
 export { default as waitUntil } from './wait-until';
 export { default as validateErrorHandler } from './validate-error-handler';
 export { default as setupOnerror, resetOnerror } from './setup-onerror';
-export { getDebugInfo, default as DebugInfo } from './-internal/debug-info';
+export type { default as DebugInfo } from './-internal/debug-info';
+export { getDebugInfo } from './-internal/debug-info';
 export { default as registerDebugInfoHelper } from './-internal/debug-info-helpers';
-export { default as getTestMetadata, TestMetadata } from './test-metadata';
+export type { TestMetadata } from './test-metadata';
+export { default as getTestMetadata } from './test-metadata';
 export {
   registerHook as _registerHook,
   runHooks as _runHooks,


### PR DESCRIPTION
Without this I get lots of warnings when building a project that uses the current @ember/test-helpers master:

```
WARNING in ./node_modules/@ember/test-helpers/index.js 4:0-262
export 'DeprecationFailure' (reexported as 'DeprecationFailure') was not found in './setup-context' (possible exports: ComponentRenderMap, SetUsage, default, getContext, getDeprecations, getDeprecationsDuringCallback, getWarnings, getWarningsDuringCallback, isTestContext, pauseTest, resumeTest, setContext, unsetContext)
 @ ./assets/test.js 143:13-65

WARNING in ./node_modules/@ember/test-helpers/index.js 4:0-262
export 'Warning' (reexported as 'Warning') was not found in './setup-context' (possible exports: ComponentRenderMap, SetUsage, default, getContext, getDeprecations, getDeprecationsDuringCallback, getWarnings, getWarningsDuringCallback, isTestContext, pauseTest, resumeTest, setContext, unsetContext)
 @ ./assets/test.js 143:13-65

WARNING in ./node_modules/@ember/test-helpers/index.js 4:0-262
export 'BaseContext' (reexported as 'BaseContext') was not found in './setup-context' (possible exports: ComponentRenderMap, SetUsage, default, getContext, getDeprecations, getDeprecationsDuringCallback, getWarnings, getWarningsDuringCallback, isTestContext, pauseTest, resumeTest, setContext, unsetContext)
 @ ./assets/test.js 143:13-65

WARNING in ./node_modules/@ember/test-helpers/index.js 4:0-262
export 'TestContext' (reexported as 'TestContext') was not found in './setup-context' (possible exports: ComponentRenderMap, SetUsage, default, getContext, getDeprecations, getDeprecationsDuringCallback, getWarnings, getWarningsDuringCallback, isTestContext, pauseTest, resumeTest, setContext, unsetContext)
 @ ./assets/test.js 143:13-65

WARNING in ./node_modules/@ember/test-helpers/index.js 13:0-76
export 'default' (reexported as 'DebugInfo') was not found in './-internal/debug-info' (possible exports: TestDebugInfo, backburnerDebugInfoAvailable, getDebugInfo)
 @ ./assets/test.js 143:13-65

WARNING in ./node_modules/@ember/test-helpers/index.js 15:0-75
export 'TestMetadata' (reexported as 'TestMetadata') was not found in './test-metadata' (possible exports: __TestMetadata, default)
 @ ./assets/test.js 143:13-65
```

We should consider adding this lint rule: https://typescript-eslint.io/rules/consistent-type-exports/