### PR TITLE
Fix types versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -160,7 +160,7 @@
   "typesVersions": {
     "*": {
       "*": [
-        "public-types/*"
+        "public-types/@ember/test-helpers/*"
       ]
     }
   }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "build:js": "yarn babel --extensions '.ts' --presets @babel/preset-typescript addon-test-support --out-dir addon-test-support/ --ignore '**/*.d.ts'",
     "build": "concurrently \"npm:build:*\" --names \"build:\"",
     "prepack": "yarn build",
-    "postpack": "rimraf addon-test-support/**/*.js",
+    "postpack": "rimraf addon-test-support/**/*.js public-types",
     "clean": "git clean -x -f",
     "docs": "documentation build --document-exported \"addon-test-support/@ember/test-helpers/index.js\" --config documentation.yml --markdown-toc-max-depth 3 -f md -o API.md",
     "lint": "concurrently \"npm:lint:*(!fix)\" --names \"lint:\"",

--- a/package.json
+++ b/package.json
@@ -160,7 +160,7 @@
   "typesVersions": {
     "*": {
       "*": [
-        "public-types/addon-test-support/@ember/test-helpers/*"
+        "public-types/*"
       ]
     }
   }


### PR DESCRIPTION
Somehow the issue that resulted in us having to use this wonky "public-types/addon-test-support/@ember/test-helpers/*" path was resolved, so the "typesVersions" config is currently broken on master (and 2.9.0).

An issue with post-build cleanup led me astray here, so I fixed that as well.