### PR TITLE
Port some conveniences from @types/ember__test-helpers package

### DIFF
--- a/addon-test-support/@ember/test-helpers/dom/-get-element.ts
+++ b/addon-test-support/@ember/test-helpers/dom/-get-element.ts
@@ -1,7 +1,13 @@
 import getRootElement from './get-root-element';
 import Target, { isDocument, isElement } from './-target';
 
-function getElement(target: string): Element | null;
+function getElement<K extends keyof HTMLElementTagNameMap>(
+  target: K
+): HTMLElementTagNameMap[K] | null;
+function getElement<K extends keyof SVGElementTagNameMap>(
+  target: K
+): SVGElementTagNameMap[K] | null;
+function getElement<E extends Element = Element>(target: string): E | null;
 function getElement(target: Element): Element;
 function getElement(target: Document): Document;
 function getElement(target: Window): Document;

--- a/addon-test-support/@ember/test-helpers/dom/-get-element.ts
+++ b/addon-test-support/@ember/test-helpers/dom/-get-element.ts
@@ -1,13 +1,16 @@
 import getRootElement from './get-root-element';
 import Target, { isDocument, isElement } from './-target';
 
+function getElement<
+  K extends keyof (HTMLElementTagNameMap | SVGElementTagNameMap)
+>(target: K): (HTMLElementTagNameMap | SVGElementTagNameMap)[K] | null;
 function getElement<K extends keyof HTMLElementTagNameMap>(
   target: K
 ): HTMLElementTagNameMap[K] | null;
 function getElement<K extends keyof SVGElementTagNameMap>(
   target: K
 ): SVGElementTagNameMap[K] | null;
-function getElement<E extends Element = Element>(target: string): E | null;
+function getElement(target: string): Element | null;
 function getElement(target: Element): Element;
 function getElement(target: Document): Document;
 function getElement(target: Window): Document;

--- a/addon-test-support/@ember/test-helpers/dom/-get-element.ts
+++ b/addon-test-support/@ember/test-helpers/dom/-get-element.ts
@@ -3,7 +3,7 @@ import Target, { isDocument, isElement } from './-target';
 
 function getElement<
   K extends keyof (HTMLElementTagNameMap | SVGElementTagNameMap)
->(target: K): (HTMLElementTagNameMap | SVGElementTagNameMap)[K] | null;
+>(target: K): (HTMLElementTagNameMap[K] | SVGElementTagNameMap[K]) | null;
 function getElement<K extends keyof HTMLElementTagNameMap>(
   target: K
 ): HTMLElementTagNameMap[K] | null;

--- a/addon-test-support/@ember/test-helpers/dom/find-all.ts
+++ b/addon-test-support/@ember/test-helpers/dom/find-all.ts
@@ -5,6 +5,9 @@ import { toArray } from '../ie-11-polyfills';
 // would simply be defined as a tweaked re-export as `querySelector` is, but it
 // is non-trivial (to say the least!) to preserve overloads like this while also
 // changing the return type (from `NodeListOf` to `Array`).
+export default function findAll<
+  K extends keyof (HTMLElementTagNameMap | SVGElementTagNameMap)
+>(selector: K): Array<(HTMLElementTagNameMap | SVGElementTagNameMap)[K]>;
 export default function findAll<K extends keyof HTMLElementTagNameMap>(
   selector: K
 ): Array<HTMLElementTagNameMap[K]>;

--- a/addon-test-support/@ember/test-helpers/dom/find-all.ts
+++ b/addon-test-support/@ember/test-helpers/dom/find-all.ts
@@ -7,7 +7,7 @@ import { toArray } from '../ie-11-polyfills';
 // changing the return type (from `NodeListOf` to `Array`).
 export default function findAll<
   K extends keyof (HTMLElementTagNameMap | SVGElementTagNameMap)
->(selector: K): Array<(HTMLElementTagNameMap | SVGElementTagNameMap)[K]>;
+>(selector: K): Array<HTMLElementTagNameMap[K] | SVGElementTagNameMap[K]>;
 export default function findAll<K extends keyof HTMLElementTagNameMap>(
   selector: K
 ): Array<HTMLElementTagNameMap[K]>;

--- a/addon-test-support/@ember/test-helpers/dom/find-all.ts
+++ b/addon-test-support/@ember/test-helpers/dom/find-all.ts
@@ -1,6 +1,17 @@
 import getElements from './-get-elements';
 import { toArray } from '../ie-11-polyfills';
 
+// Derived, with modification, from the types for `querySelectorAll`. These
+// would simply be defined as a tweaked re-export as `querySelector` is, but it
+// is non-trivial (to say the least!) to preserve overloads like this while also
+// changing the return type (from `NodeListOf` to `Array`).
+export default function findAll<K extends keyof HTMLElementTagNameMap>(
+  selector: K
+): Array<HTMLElementTagNameMap[K]>;
+export default function findAll<K extends keyof SVGElementTagNameMap>(
+  selector: K
+): Array<SVGElementTagNameMap[K]>;
+export default function findAll(selector: string): Element[];
 /**
   Find all elements matched by the given selector. Similar to calling
   `querySelectorAll()` on the test root element, but returns an array instead

--- a/addon-test-support/@ember/test-helpers/dom/find.ts
+++ b/addon-test-support/@ember/test-helpers/dom/find.ts
@@ -1,15 +1,16 @@
 import getElement from './-get-element';
 
 // Derived from `querySelector` types.
+export default function find<
+  K extends keyof (HTMLElementTagNameMap | SVGElementTagNameMap)
+>(selector: K): (HTMLElementTagNameMap | SVGElementTagNameMap)[K] | null;
 export default function find<K extends keyof HTMLElementTagNameMap>(
   selector: K
 ): HTMLElementTagNameMap[K] | null;
 export default function find<K extends keyof SVGElementTagNameMap>(
   selector: K
 ): SVGElementTagNameMap[K] | null;
-export default function find<E extends Element = Element>(
-  selector: string
-): E | null;
+export default function find(selector: string): Element | null;
 /**
   Find the first element matched by the given selector. Equivalent to calling
   `querySelector()` on the test root element.

--- a/addon-test-support/@ember/test-helpers/dom/find.ts
+++ b/addon-test-support/@ember/test-helpers/dom/find.ts
@@ -1,12 +1,22 @@
 import getElement from './-get-element';
 
+// Derived from `querySelector` types.
+export default function find<K extends keyof HTMLElementTagNameMap>(
+  selector: K
+): HTMLElementTagNameMap[K] | null;
+export default function find<K extends keyof SVGElementTagNameMap>(
+  selector: K
+): SVGElementTagNameMap[K] | null;
+export default function find<E extends Element = Element>(
+  selector: string
+): E | null;
 /**
   Find the first element matched by the given selector. Equivalent to calling
   `querySelector()` on the test root element.
 
   @public
   @param {string} selector the selector to search for
-  @return {Element} matched element or null
+  @return {Element | null} matched element or null
 */
 export default function find(selector: string): Element | null {
   if (!selector) {

--- a/addon-test-support/@ember/test-helpers/dom/find.ts
+++ b/addon-test-support/@ember/test-helpers/dom/find.ts
@@ -3,7 +3,7 @@ import getElement from './-get-element';
 // Derived from `querySelector` types.
 export default function find<
   K extends keyof (HTMLElementTagNameMap | SVGElementTagNameMap)
->(selector: K): (HTMLElementTagNameMap | SVGElementTagNameMap)[K] | null;
+>(selector: K): HTMLElementTagNameMap[K] | SVGElementTagNameMap[K] | null;
 export default function find<K extends keyof HTMLElementTagNameMap>(
   selector: K
 ): HTMLElementTagNameMap[K] | null;

--- a/addon-test-support/@ember/test-helpers/dom/trigger-event.ts
+++ b/addon-test-support/@ember/test-helpers/dom/trigger-event.ts
@@ -57,7 +57,7 @@ registerHook('triggerEvent', 'start', (target: Target, eventType: string) => {
 export default function triggerEvent(
   target: Target,
   eventType: string,
-  options?: object
+  options?: Record<string, unknown>
 ): Promise<void> {
   return Promise.resolve()
     .then(() => {

--- a/addon-test-support/@ember/test-helpers/index.ts
+++ b/addon-test-support/@ember/test-helpers/index.ts
@@ -29,8 +29,8 @@ export {
   default as setupRenderingContext,
   render,
   clearRender,
-  RenderingTestContext,
 } from './setup-rendering-context';
+export type { RenderingTestContext } from './setup-rendering-context';
 export { default as rerender } from './rerender';
 export {
   default as setupApplicationContext,

--- a/addon-test-support/@ember/test-helpers/index.ts
+++ b/addon-test-support/@ember/test-helpers/index.ts
@@ -29,6 +29,7 @@ export {
   default as setupRenderingContext,
   render,
   clearRender,
+  RenderingTestContext,
 } from './setup-rendering-context';
 export { default as rerender } from './rerender';
 export {

--- a/addon-test-support/@ember/test-helpers/settled.ts
+++ b/addon-test-support/@ember/test-helpers/settled.ts
@@ -193,7 +193,7 @@ export interface SettledState {
   hasPendingTransitions: boolean | null;
   isRenderPending: boolean;
   pendingRequestCount: number;
-  debugInfo?: DebugInfo;
+  debugInfo: DebugInfo;
 }
 
 /**

--- a/addon-test-support/@ember/test-helpers/setup-context.ts
+++ b/addon-test-support/@ember/test-helpers/setup-context.ts
@@ -80,7 +80,7 @@ export interface TestContext extends BaseContext {
   getProperties(...args: string[]): Pick<BaseContext, string>;
 
   pauseTest(): Promise<void>;
-  resumeTest(): Promise<void>;
+  resumeTest(): void;
 }
 
 // eslint-disable-next-line require-jsdoc

--- a/type-tests/api.ts
+++ b/type-tests/api.ts
@@ -46,11 +46,7 @@ import {
   unsetContext,
   teardownContext,
   setupRenderingContext,
-  BaseContext,
-  TestContext,
   RenderingTestContext,
-  TestMetadata,
-  DebugInfo as InternalDebugInfo,
   getApplication,
   setApplication,
   setupApplicationContext,
@@ -63,6 +59,10 @@ import {
   getDeprecationsDuringCallback,
   getWarnings,
   getWarningsDuringCallback,
+  BaseContext,
+  TestContext,
+  TestMetadata,
+  DebugInfo as InternalDebugInfo,
   DeprecationFailure,
   Warning,
 } from '@ember/test-helpers';
@@ -132,11 +132,13 @@ expectTypeOf(typeIn).toEqualTypeOf<
 
 // DOM Query Helpers
 expectTypeOf(find).toEqualTypeOf<Document['querySelector']>();
-expectTypeOf(find('a')).toEqualTypeOf<HTMLAnchorElement | null>();
+expectTypeOf(find('a')).toEqualTypeOf<HTMLAnchorElement | SVGAElement | null>();
+expectTypeOf(find('div')).toEqualTypeOf<HTMLDivElement | null>();
 expectTypeOf(find('circle')).toEqualTypeOf<SVGCircleElement | null>();
 expectTypeOf(find('.corkscrew')).toEqualTypeOf<Element | null>();
 expectTypeOf(findAll).toEqualTypeOf<(selector: string) => Array<Element>>();
-expectTypeOf(findAll('a')).toEqualTypeOf<HTMLAnchorElement[]>();
+expectTypeOf(findAll('a')).toEqualTypeOf<(HTMLAnchorElement | SVGAElement)[]>();
+expectTypeOf(findAll('div')).toEqualTypeOf<HTMLDivElement[]>();
 expectTypeOf(findAll('circle')).toEqualTypeOf<SVGCircleElement[]>();
 expectTypeOf(findAll('.corkscrew')).toEqualTypeOf<Element[]>();
 expectTypeOf(getRootElement).toEqualTypeOf<() => Element | Document>();

--- a/type-tests/api.ts
+++ b/type-tests/api.ts
@@ -23,6 +23,7 @@ import {
   currentURL,
   // Rendering Helpers
   render,
+  rerender,
   clearRender,
   // Wait Helpers
   waitFor,
@@ -45,6 +46,11 @@ import {
   unsetContext,
   teardownContext,
   setupRenderingContext,
+  BaseContext,
+  TestContext,
+  RenderingTestContext,
+  TestMetadata,
+  DebugInfo as InternalDebugInfo,
   getApplication,
   setApplication,
   setupApplicationContext,
@@ -57,10 +63,6 @@ import {
   getDeprecationsDuringCallback,
   getWarnings,
   getWarningsDuringCallback,
-  BaseContext,
-  TestContext,
-  TestMetadata,
-  DebugInfo as InternalDebugInfo,
   DeprecationFailure,
   Warning,
 } from '@ember/test-helpers';
@@ -99,7 +101,11 @@ expectTypeOf(tap).toEqualTypeOf<
   (target: Target, options?: TouchEventInit) => Promise<void>
 >();
 expectTypeOf(triggerEvent).toEqualTypeOf<
-  (target: Target, eventType: string, options?: object) => Promise<void>
+  (
+    target: Target,
+    eventType: string,
+    options?: Record<string, unknown>
+  ) => Promise<void>
 >();
 expectTypeOf(triggerKeyEvent).toEqualTypeOf<
   (
@@ -125,8 +131,14 @@ expectTypeOf(typeIn).toEqualTypeOf<
 >();
 
 // DOM Query Helpers
-expectTypeOf(find).toEqualTypeOf<(selector: string) => Element | null>();
+expectTypeOf(find).toEqualTypeOf<Document['querySelector']>();
+expectTypeOf(find('a')).toEqualTypeOf<HTMLAnchorElement | null>();
+expectTypeOf(find('circle')).toEqualTypeOf<SVGCircleElement | null>();
+expectTypeOf(find('.corkscrew')).toEqualTypeOf<Element | null>();
 expectTypeOf(findAll).toEqualTypeOf<(selector: string) => Array<Element>>();
+expectTypeOf(findAll('a')).toEqualTypeOf<HTMLAnchorElement[]>();
+expectTypeOf(findAll('circle')).toEqualTypeOf<SVGCircleElement[]>();
+expectTypeOf(findAll('.corkscrew')).toEqualTypeOf<Element[]>();
 expectTypeOf(getRootElement).toEqualTypeOf<() => Element | Document>();
 
 // Routing Helpers
@@ -143,6 +155,7 @@ expectTypeOf(render).toMatchTypeOf<
     options?: { owner?: Owner }
   ) => Promise<void>
 >();
+expectTypeOf(rerender).toMatchTypeOf<() => Promise<void>>();
 expectTypeOf(clearRender).toEqualTypeOf<() => Promise<void>>();
 
 // Wait Helpers
@@ -176,7 +189,7 @@ expectTypeOf(getSettledState).toEqualTypeOf<
     hasPendingTransitions: boolean | null;
     isRenderPending: boolean;
     pendingRequestCount: number;
-    debugInfo?: InternalDebugInfo;
+    debugInfo: InternalDebugInfo;
   }
 >();
 
@@ -209,7 +222,7 @@ expectTypeOf(teardownContext).toEqualTypeOf<
   ) => Promise<void>
 >();
 expectTypeOf(setupRenderingContext).toEqualTypeOf<
-  (context: TestContext) => Promise<void>
+  (context: TestContext) => Promise<RenderingTestContext>
 >();
 expectTypeOf(getApplication).toEqualTypeOf<() => Application | undefined>();
 expectTypeOf(setApplication).toEqualTypeOf<


### PR DESCRIPTION
I compared the `@types/ember__test-helpers` package to the public API of this package to ensure we were:
1. exporting the same things (aside from some of the missing exports I put in other PRs)
2. not losing useful type info (e.g. the `find` overloads)

In the process I noticed a couple of minor issues w/ the types and fixed those as well.

LMK if you'd prefer I broke this up.