### PR TITLE
Correctly handle special char keyCodes with Shift

### DIFF
--- a/addon-test-support/@ember/test-helpers/dom/trigger-key-event.ts
+++ b/addon-test-support/@ember/test-helpers/dom/trigger-key-event.ts
@@ -100,6 +100,29 @@ const keyFromKeyCode: { [key: number]: string } = {
   222: "'",
 };
 
+const keyFromKeyCodeWithShift: { [key: number]: string } = {
+  48: ')',
+  49: '!',
+  50: '@',
+  51: '#',
+  52: '$',
+  53: '%',
+  54: '^',
+  55: '&',
+  56: '*',
+  57: '(',
+  186: ':',
+  187: '+',
+  188: '<',
+  189: '_',
+  190: '>',
+  191: '?',
+  219: '{',
+  220: '|',
+  221: '}',
+  222: '"',
+};
+
 /**
   Calculates the value of KeyboardEvent#key given a keycode and the modifiers.
   Note that this works if the key is pressed in combination with the shift key, but it cannot
@@ -119,10 +142,11 @@ function keyFromKeyCodeAndModifiers(
       return String.fromCharCode(keycode).toLocaleLowerCase();
     }
   }
-  let key = keyFromKeyCode[keycode];
-  if (key) {
-    return key;
-  }
+
+  return (
+    (modifiers.shiftKey && keyFromKeyCodeWithShift[keycode]) ||
+    keyFromKeyCode[keycode]
+  );
 }
 
 /**

--- a/tests/unit/dom/trigger-key-event-test.js
+++ b/tests/unit/dom/trigger-key-event-test.js
@@ -241,6 +241,12 @@ module('DOM Helper: triggerKeyEvent', function (hooks) {
     await checkKey(90, 'z');
     await checkKey(65, 'A', { shiftKey: true });
     await checkKey(90, 'Z', { shiftKey: true });
+    await checkKey(49, '!', { shiftKey: true });
+    await checkKey(187, '+', { shiftKey: true });
+    await checkKey(38, 'ArrowUp', { shiftKey: true });
+
+    // an invalid keyCode
+    await checkKey(999, '');
   });
 
   test('The value of the `event.keyCode` is properly inferred from the given key', async function (assert) {


### PR DESCRIPTION
Previously, calling `triggerKeyEvent()` with `shiftKey: true` option would trigger an event with an incorrect `key`.

E.g. `triggerKeyEvent(element, 'keydown', 197, { shiftKey: true })` would have a `=` key, instead of `+`.