### PR TITLE
Drop support for Ember 3.x

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -45,15 +45,12 @@ jobs:
       fail-fast: false
       matrix:
         ember-try-scenario:
-          - ember-lts-3.28
           - ember-lts-4.4
           - ember-lts-4.8
           - ember-release
           - ember-beta
           - ember-canary
-          - ember-classic
           - ember-default
-          - with-jquery
           - embroider-safe
           # - embroider-optimized # see comments in ember-try.js
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ A test-framework-agnostic set of helpers for testing Ember.js applications
 Compatibility
 ------------------------------------------------------------------------------
 
-- Ember.js v3.28 or above
-- Ember CLI v3.28 or above
+- Ember.js v4 or above
+- Ember CLI v4 or above
 - Node.js v14 or above
 - TypeScript 4.7
   - SemVer policy: [simple majors](https://www.semver-ts.org/#simple-majors)

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "test:all": "ember try:each"
   },
   "peerDependencies": {
-    "ember-source": "^3.28.0 || ^4.0.0"
+    "ember-source": "^4.0.0"
   },
   "dependencies": {
     "@ember/test-waiters": "^3.0.0",

--- a/tests/dummy/config/ember-try.js
+++ b/tests/dummy/config/ember-try.js
@@ -42,14 +42,6 @@ module.exports = async function () {
     useYarn: true,
     scenarios: [
       {
-        name: 'ember-lts-3.28',
-        npm: {
-          devDependencies: {
-            'ember-source': '~3.28.0',
-          },
-        },
-      },
-      {
         name: 'ember-lts-4.4',
         npm: {
           devDependencies: {
@@ -86,39 +78,6 @@ module.exports = async function () {
         npm: {
           devDependencies: {
             'ember-source': await getChannelURL('canary'),
-          },
-        },
-      },
-      {
-        name: 'with-jquery',
-        env: {
-          EMBER_OPTIONAL_FEATURES: JSON.stringify({
-            'jquery-integration': true,
-          }),
-        },
-        npm: {
-          devDependencies: {
-            'ember-source': '~3.28.0',
-            '@ember/jquery': '^0.6.0',
-            'ember-fetch': null,
-          },
-        },
-      },
-      {
-        name: 'ember-classic',
-        env: {
-          EMBER_OPTIONAL_FEATURES: JSON.stringify({
-            'application-template-wrapper': true,
-            'default-async-observers': false,
-            'template-only-glimmer-components': false,
-          }),
-        },
-        npm: {
-          devDependencies: {
-            'ember-source': '~3.28.0',
-          },
-          ember: {
-            edition: 'classic',
           },
         },
       },


### PR DESCRIPTION
Now that the last Ember LTS of v3 is out of support range, we can drop support here.
