### PR TITLE
Update volta-cli/action to v4

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: volta-cli/action@v1
+      - uses: volta-cli/action@v4
       - run: yarn install --frozen-lockfile --ignore-engines
       - run: yarn lint
       - run: yarn test
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: volta-cli/action@v1
+      - uses: volta-cli/action@v4
       - run: yarn install --no-lockfile
       - run: yarn test
 
@@ -59,7 +59,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: volta-cli/action@v1
+      - uses: volta-cli/action@v4
       - name: install dependencies
         run: yarn install --frozen-lockfile
       - name: test
@@ -79,7 +79,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: volta-cli/action@v1
+      - uses: volta-cli/action@v4
       - name: install dependencies
         run: yarn install --frozen-lockfile
       - name: install TS version


### PR DESCRIPTION
Should help a bit with reliability (prior versions sometimes failed to
determine the latest version of Volta, and crashed the CI run).
