### PR TITLE
`TestContext.resumeTest()` returns `void`, not `Promise<void>`

### DIFF
--- a/addon-test-support/@ember/test-helpers/setup-context.ts
+++ b/addon-test-support/@ember/test-helpers/setup-context.ts
@@ -80,7 +80,7 @@ export interface TestContext extends BaseContext {
   getProperties(...args: string[]): Pick<BaseContext, string>;
 
   pauseTest(): Promise<void>;
-  resumeTest(): Promise<void>;
+  resumeTest(): void;
 }
 
 // eslint-disable-next-line require-jsdoc


### PR DESCRIPTION
This error has been around for a very long time, but fixing type type of the `BaseContext` (#1301, #1302) flagged it up as missed in the back-porting work I did last week.