### PR TITLE
Avoid unnecessary dependencies on `@glimmer` types

### DIFF
--- a/addon-test-support/@ember/test-helpers/-internal/get-component-manager.ts
+++ b/addon-test-support/@ember/test-helpers/-internal/get-component-manager.ts
@@ -4,12 +4,8 @@ import {
   importSync,
   dependencySatisfies,
 } from '@embroider/macros';
-import type { InternalComponentManager } from '@glimmer/interfaces';
 
-let getComponentManager: (
-  definition: object,
-  owner: object
-) => InternalComponentManager | null;
+let getComponentManager: (definition: object, owner: object) => unknown;
 
 if (macroCondition(dependencySatisfies('ember-source', '>=3.27.0-alpha.1'))) {
   let _getComponentManager =

--- a/addon-test-support/@ember/test-helpers/setup-rendering-context.ts
+++ b/addon-test-support/@ember/test-helpers/setup-rendering-context.ts
@@ -9,7 +9,7 @@ import {
   getContext,
 } from './setup-context';
 import settled from './settled';
-import { hbs, TemplateFactory } from 'ember-cli-htmlbars';
+import { hbs } from 'ember-cli-htmlbars';
 import getRootElement from './dom/get-root-element';
 import { Owner } from './build-owner';
 import getTestMetadata from './test-metadata';
@@ -20,7 +20,6 @@ import isComponent from './-internal/is-component';
 import { macroCondition, dependencySatisfies } from '@embroider/macros';
 import { ComponentRenderMap, SetUsage } from './setup-context';
 import { ensureSafeComponent } from '@embroider/util';
-import type { ComponentInstance } from '@glimmer/interfaces';
 
 const OUTLET_TEMPLATE = hbs`{{outlet}}`;
 const EMPTY_TEMPLATE = hbs``;
@@ -102,7 +101,7 @@ export interface RenderOptions {
   await render(hbs`<div class="container"></div>`);
 */
 export function render(
-  templateOrComponent: TemplateFactory | ComponentInstance,
+  templateOrComponent: object,
   options?: RenderOptions
 ): Promise<void> {
   let context = getContext();

--- a/type-tests/api.ts
+++ b/type-tests/api.ts
@@ -161,10 +161,7 @@ expectTypeOf(currentURL).toEqualTypeOf<() => string>();
 
 // Rendering Helpers
 expectTypeOf(render).toMatchTypeOf<
-  (
-    templateOrComponent: TemplateFactory | ComponentInstance,
-    options?: { owner?: Owner }
-  ) => Promise<void>
+  (templateOrComponent: object, options?: { owner?: Owner }) => Promise<void>
 >();
 expectTypeOf(rerender).toMatchTypeOf<() => Promise<void>>();
 expectTypeOf(clearRender).toEqualTypeOf<() => Promise<void>>();


### PR DESCRIPTION
The published types from this package rely on `@glimmer/interfaces` in two places:
 - in the signature of `render()` to represent that it can accept a component
 - in the signature of the internal `getComponentManager` helper

This PR updates the signature of `render()` to simply accept any `object` as its first parameter. This is actually more accurate than the current type—at runtime, `render()` only requires that the object it receives is either a template or is some object with a component manager, but "has a component manager" isn't something we're able to model in the TS type system.

It also updates the return type of the `getComponentManager` utility to `unknown`, as we never actually interact with the manager, we only check for its existence. (In reality this change is likely unnecessary since this `.d.ts` file won't end up in the import path for consumers using public APIs, but updating this removes references to `@glimmer/interfaces` in the built types directory entirely.)

