### PR TITLE
[backport] Avoid unnecessary dependencies on `@glimmer` types

### DIFF
--- a/addon-test-support/@ember/test-helpers/-internal/get-component-manager.ts
+++ b/addon-test-support/@ember/test-helpers/-internal/get-component-manager.ts
@@ -4,12 +4,8 @@ import {
   importSync,
   dependencySatisfies,
 } from '@embroider/macros';
-import type { InternalComponentManager } from '@glimmer/interfaces';
 
-let getComponentManager: (
-  definition: object,
-  owner: object
-) => InternalComponentManager | null;
+let getComponentManager: (definition: object, owner: object) => unknown;
 
 if (macroCondition(dependencySatisfies('ember-source', '>=3.27.0-alpha.1'))) {
   let _getComponentManager =

--- a/addon-test-support/@ember/test-helpers/setup-rendering-context.ts
+++ b/addon-test-support/@ember/test-helpers/setup-rendering-context.ts
@@ -10,7 +10,7 @@ import {
 } from './setup-context';
 import { Promise } from './-utils';
 import settled from './settled';
-import { hbs, TemplateFactory } from 'ember-cli-htmlbars';
+import { hbs } from 'ember-cli-htmlbars';
 import getRootElement from './dom/get-root-element';
 import { Owner } from './build-owner';
 import getTestMetadata from './test-metadata';
@@ -21,14 +21,13 @@ import isComponent from './-internal/is-component';
 import { macroCondition, dependencySatisfies } from '@embroider/macros';
 import { ComponentRenderMap, SetUsage } from './setup-context';
 import { ensureSafeComponent } from '@embroider/util';
-import type { ComponentInstance } from '@glimmer/interfaces';
 
 const OUTLET_TEMPLATE = hbs`{{outlet}}`;
 const EMPTY_TEMPLATE = hbs``;
 const INVOKE_PROVIDED_COMPONENT = hbs`<this.ProvidedComponent />`;
 
 export interface RenderingTestContext extends TestContext {
-  render(template: TemplateFactory): Promise<void>;
+  render(template: object): Promise<void>;
   clearRender(): Promise<void>;
 
   element: Element | Document;
@@ -100,7 +99,7 @@ export interface RenderOptions {
   await render(hbs`<div class="container"></div>`);
 */
 export function render(
-  templateOrComponent: TemplateFactory | ComponentInstance,
+  templateOrComponent: object,
   options?: RenderOptions
 ): Promise<void> {
   let context = getContext();
@@ -298,7 +297,7 @@ export default function setupRenderingContext(
     .then(() => {
       let { owner } = context;
 
-      let renderDeprecationWrapper = function (template: TemplateFactory) {
+      let renderDeprecationWrapper = function (template: object) {
         deprecate(
           'Using this.render has been deprecated, consider using `render` imported from `@ember/test-helpers`.',
           false,

--- a/type-tests/api.ts
+++ b/type-tests/api.ts
@@ -156,10 +156,7 @@ expectTypeOf(currentURL).toEqualTypeOf<() => string>();
 
 // Rendering Helpers
 expectTypeOf(render).toMatchTypeOf<
-  (
-    templateOrComponent: TemplateFactory | ComponentInstance,
-    options?: { owner?: Owner }
-  ) => Promise<void>
+  (templateOrComponent: object, options?: { owner?: Owner }) => Promise<void>
 >();
 expectTypeOf(clearRender).toEqualTypeOf<() => Promise<void>>();
 


### PR DESCRIPTION
This is a backport of #1304 for v2