### PR TITLE
[DOC] Swap `find` and `findAll` examples

### DIFF
--- a/API.md
+++ b/API.md
@@ -834,7 +834,7 @@ Responsible for:
 
 #### Parameters
 
-*   `context` **[Object][72]** the context to setup
+*   `base` **[Object][72]** the context to setup
 *   `options` **[Object][72]?** options used to override defaults (optional, default `{}`)
 
     *   `options.resolver` **Resolver?** a resolver to use for customizing normal resolution

--- a/API.md
+++ b/API.md
@@ -495,10 +495,10 @@ Find the first element matched by the given selector. Equivalent to calling
 
 #### Examples
 
-Find all of the elements matching '.my-selector'.
+Finding the first element with id 'foo'
 
 ```javascript
-findAll('.my-selector');
+find('#foo');
 ```
 
 Returns **([Element][65] | null)** matched element or null
@@ -515,10 +515,10 @@ of a `NodeList`.
 
 #### Examples
 
-Finding the first element with id 'foo'
+Find all of the elements matching '.my-selector'.
 
 ```javascript
-find('#foo');
+findAll('.my-selector');
 ```
 
 Returns **[Array][70]** array of matched elements

--- a/addon-test-support/@ember/test-helpers/dom/find-all.ts
+++ b/addon-test-support/@ember/test-helpers/dom/find-all.ts
@@ -25,9 +25,9 @@ export default function findAll(selector: string): Element[];
 
   @example
   <caption>
-    Finding the first element with id 'foo'
+    Find all of the elements matching '.my-selector'.
   </caption>
-  find('#foo');
+  findAll('.my-selector');
 */
 export default function findAll(selector: string): Element[] {
   if (!selector) {

--- a/addon-test-support/@ember/test-helpers/dom/find.ts
+++ b/addon-test-support/@ember/test-helpers/dom/find.ts
@@ -21,10 +21,9 @@ export default function find(selector: string): Element | null;
 
   @example
   <caption>
-    Find all of the elements matching '.my-selector'.
+    Finding the first element with id 'foo'
   </caption>
-  findAll('.my-selector');
-
+  find('#foo');
 */
 export default function find(selector: string): Element | null {
   if (!selector) {


### PR DESCRIPTION
The findAll example shows up in the section of the API docs for the find helper and vice versa. We should swap these to make the docs as clear as possible.

While we're here, `Commit: cba01bea` updated `setupContext`, renaming its first param from `context` to `base` in the process. It did not regenerate out the docs as part of the changeset, so building the docs results in this change locally.

Let's fixup that commit here so that we can build the docs without creating any local changes.

This closes https://github.com/emberjs/ember-test-helpers/issues/1317.