### PR TITLE
Use node 16 for development instead of node 14

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "webpack": "^5.75.0"
   },
   "engines": {
-    "node": "14.* || 16.* || >= 18"
+    "node": "16.* || >= 18"
   },
   "publishConfig": {
     "access": "public",
@@ -141,7 +141,7 @@
     }
   },
   "volta": {
-    "node": "14.21.1",
+    "node": "16.19.0",
     "yarn": "1.22.19"
   },
   "typesVersions": {


### PR DESCRIPTION
Pre-req for converting to a v2 addon.

~~According to @chriskrycho, we're preparing for a major anyway: https://github.com/emberjs/ember-test-helpers/pull/1249#issuecomment-1354062379~~


Requirement stems from: https://github.com/wessberg/rollup-plugin-ts/issues/202