### PR TITLE
doc: fix various typos in the repo

### DIFF
--- a/API.md
+++ b/API.md
@@ -843,7 +843,7 @@ Returns **[Promise][66]<[Object][72]>** resolves with the context that was setup
 
 ### getContext
 
-Retrive the "global testing context" as stored by `setContext`.
+Retrieve the "global testing context" as stored by `setContext`.
 
 Returns **[Object][72]** the previously stored testing context
 
@@ -1050,7 +1050,7 @@ Returns **[Promise][66]\<void>** a promise which fulfills when rendering has com
 
 ## getDeprecations
 
-Returns deprecations which have occured so far for a the current test context
+Returns deprecations which have occurred so far for a the current test context
 
 ### Examples
 
@@ -1063,7 +1063,7 @@ module('awesome-sauce', function(hooks) {
   setupRenderingTest(hooks);
 
   test('does something awesome', function(assert) {
-const deprecations = getDeprecations() // => returns deprecations which have occured so far in this test
+const deprecations = getDeprecations() // => returns deprecations which have occurred so far in this test
   });
 });
 ```
@@ -1072,7 +1072,7 @@ Returns **[Array][70]\<DeprecationFailure>** An array of deprecation messages
 
 ## getDeprecationsDuringCallback
 
-Returns deprecations which have occured so far for a the current test context
+Returns deprecations which have occurred so far for a the current test context
 
 ### Parameters
 
@@ -1092,14 +1092,14 @@ module('awesome-sauce', function(hooks) {
     const deprecations = getDeprecationsDuringCallback(() => {
       // code that might emit some deprecations
 
-    }); // => returns deprecations which occured while the callback was invoked
+    }); // => returns deprecations which occurred while the callback was invoked
   });
 
 
   test('does something awesome', async function(assert) {
     const deprecations = await getDeprecationsDuringCallback(async () => {
       // awaited code that might emit some deprecations
-    }); // => returns deprecations which occured while the callback was invoked
+    }); // => returns deprecations which occurred while the callback was invoked
   });
 });
 ```
@@ -1108,7 +1108,7 @@ Returns **([Array][70]\<DeprecationFailure> | [Promise][66]<[Array][70]\<Depreca
 
 ## getWarnings
 
-Returns warnings which have occured so far for a the current test context
+Returns warnings which have occurred so far for a the current test context
 
 ### Examples
 
@@ -1121,7 +1121,7 @@ module('awesome-sauce', function(hooks) {
   setupRenderingTest(hooks);
 
   test('does something awesome', function(assert) {
-const warnings = getWarnings() // => returns warnings which have occured so far in this test
+const warnings = getWarnings() // => returns warnings which have occurred so far in this test
   });
 });
 ```
@@ -1130,7 +1130,7 @@ Returns **[Array][70]\<Warning>** An array of warnings
 
 ## getWarningsDuringCallback
 
-Returns warnings which have occured so far for a the current test context
+Returns warnings which have occurred so far for a the current test context
 
 ### Parameters
 
@@ -1151,7 +1151,7 @@ module('awesome-sauce', function(hooks) {
     const warnings = getWarningsDuringCallback(() => {
     warn('some warning');
 
-    }); // => returns warnings which occured while the callback was invoked
+    }); // => returns warnings which occurred while the callback was invoked
   });
 
   test('does something awesome', async function(assert) {
@@ -1159,7 +1159,7 @@ module('awesome-sauce', function(hooks) {
 
     const warnings = await getWarningsDuringCallback(async () => {
       warn('some other warning');
-    }); // => returns warnings which occured while the callback was invoked
+    }); // => returns warnings which occurred while the callback was invoked
   });
 });
 ```

--- a/addon-test-support/@ember/test-helpers/-internal/deprecations.ts
+++ b/addon-test-support/@ember/test-helpers/-internal/deprecations.ts
@@ -48,13 +48,13 @@ export function getDeprecationsForContext(
 /**
  *
  * Provides the list of deprecation failures associated with a given base
- * context which occure while a callback is executed. This callback can be
- * synchonous, or it can be an async function.
+ * context which occur while a callback is executed. This callback can be
+ * synchronous, or it can be an async function.
  *
  * @private
  * @param {BaseContext} [context] the test context
  * @param {Function} [callback] The callback that when executed will have its DeprecationFailure recorded
- * @return {Array<DeprecationFailure>} The Deprecation Failures associated with the corresponding baseContext which occured while the CallbackFunction was executed
+ * @return {Array<DeprecationFailure>} The Deprecation Failures associated with the corresponding baseContext which occurred while the CallbackFunction was executed
  */
 export function getDeprecationsDuringCallbackForContext(
   context: BaseContext,

--- a/addon-test-support/@ember/test-helpers/-internal/warnings.ts
+++ b/addon-test-support/@ember/test-helpers/-internal/warnings.ts
@@ -12,7 +12,7 @@ export interface Warning {
 }
 
 // the WARNINGS data structure which is used to weakly associated warnings with
-// the test context their occured within
+// the test context their occurred within
 const WARNINGS = new WeakMap<BaseContext, Array<Warning>>();
 
 /**
@@ -43,13 +43,13 @@ export function getWarningsForContext(context: BaseContext): Array<Warning> {
 /**
  *
  * Provides the list of warnings associated with a given test context which
- * occured only while a the provided callback is executed. This callback can be
- * synchonous, or it can be an async function.
+ * occurred only while a the provided callback is executed. This callback can be
+ * synchronous, or it can be an async function.
  *
  * @private
  * @param {BaseContext} [context] the test context
  * @param {Function} [callback] The callback that when executed will have its warnings recorded
- * @return {Array<Warning>} The warnings associated with the corresponding baseContext which occured while the CallbackFunction was executed
+ * @return {Array<Warning>} The warnings associated with the corresponding baseContext which occurred while the CallbackFunction was executed
  */
 export function getWarningsDuringCallbackForContext(
   context: BaseContext,

--- a/addon-test-support/@ember/test-helpers/dom/click.ts
+++ b/addon-test-support/@ember/test-helpers/dom/click.ts
@@ -69,7 +69,7 @@ export function __click__(
   to continue to emulate how actual browsers handle clicking a given element.
 
   Use the `options` hash to change the parameters of the [MouseEvents](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/MouseEvent).
-  You can use this to specifiy modifier keys as well.
+  You can use this to specify modifier keys as well.
 
   @public
   @param {string|Element} target the element or selector to click on

--- a/addon-test-support/@ember/test-helpers/setup-application-context.ts
+++ b/addon-test-support/@ember/test-helpers/setup-application-context.ts
@@ -31,7 +31,7 @@ export function isApplicationTestContext(
 }
 
 /**
-  Determines if we have any pending router transtions (used to determine `settled` state)
+  Determines if we have any pending router transitions (used to determine `settled` state)
 
   @public
   @returns {(boolean|null)} if there are pending transitions
@@ -198,7 +198,7 @@ export function currentRouteName(): string {
   let router = context.owner.lookup('router:main');
   let currentRouteName = get(router, 'currentRouteName');
   assert(
-    'currentRouteName shoudl be a string',
+    'currentRouteName should be a string',
     typeof currentRouteName === 'string'
   );
   return currentRouteName;

--- a/addon-test-support/@ember/test-helpers/setup-context.ts
+++ b/addon-test-support/@ember/test-helpers/setup-context.ts
@@ -110,7 +110,7 @@ export function setContext(context: BaseContext): void {
 }
 
 /**
-  Retrive the "global testing context" as stored by `setContext`.
+  Retrieve the "global testing context" as stored by `setContext`.
 
   @public
   @returns {Object} the previously stored testing context
@@ -207,7 +207,7 @@ function cleanup(context: BaseContext) {
 }
 
 /**
- * Returns deprecations which have occured so far for a the current test context
+ * Returns deprecations which have occurred so far for a the current test context
  *
  * @public
  * @returns {Array<DeprecationFailure>} An array of deprecation messages
@@ -219,7 +219,7 @@ function cleanup(context: BaseContext) {
  *   setupRenderingTest(hooks);
  *
  *   test('does something awesome', function(assert) {
-       const deprecations = getDeprecations() // => returns deprecations which have occured so far in this test
+       const deprecations = getDeprecations() // => returns deprecations which have occurred so far in this test
  *   });
  * });
  */
@@ -238,7 +238,7 @@ export function getDeprecations(): Array<DeprecationFailure> {
 export type { DeprecationFailure };
 
 /**
- * Returns deprecations which have occured so far for a the current test context
+ * Returns deprecations which have occurred so far for a the current test context
  *
  * @public
  * @param {Function} [callback] The callback that when executed will have its DeprecationFailure recorded
@@ -254,14 +254,14 @@ export type { DeprecationFailure };
  *     const deprecations = getDeprecationsDuringCallback(() => {
  *       // code that might emit some deprecations
  *
- *     }); // => returns deprecations which occured while the callback was invoked
+ *     }); // => returns deprecations which occurred while the callback was invoked
  *   });
  *
  *
  *   test('does something awesome', async function(assert) {
  *     const deprecations = await getDeprecationsDuringCallback(async () => {
  *       // awaited code that might emit some deprecations
- *     }); // => returns deprecations which occured while the callback was invoked
+ *     }); // => returns deprecations which occurred while the callback was invoked
  *   });
  * });
  */
@@ -280,7 +280,7 @@ export function getDeprecationsDuringCallback(
 }
 
 /**
- * Returns warnings which have occured so far for a the current test context
+ * Returns warnings which have occurred so far for a the current test context
  *
  * @public
  * @returns {Array<Warning>} An array of warnings
@@ -292,7 +292,7 @@ export function getDeprecationsDuringCallback(
  *   setupRenderingTest(hooks);
  *
  *   test('does something awesome', function(assert) {
-       const warnings = getWarnings() // => returns warnings which have occured so far in this test
+       const warnings = getWarnings() // => returns warnings which have occurred so far in this test
  *   });
  * });
  */
@@ -311,7 +311,7 @@ export function getWarnings(): Array<Warning> {
 export type { Warning };
 
 /**
- * Returns warnings which have occured so far for a the current test context
+ * Returns warnings which have occurred so far for a the current test context
  *
  * @public
  * @param {Function} [callback] The callback that when executed will have its warnings recorded
@@ -328,7 +328,7 @@ export type { Warning };
  *     const warnings = getWarningsDuringCallback(() => {
  *     warn('some warning');
  *
- *     }); // => returns warnings which occured while the callback was invoked
+ *     }); // => returns warnings which occurred while the callback was invoked
  *   });
  *
  *   test('does something awesome', async function(assert) {
@@ -336,7 +336,7 @@ export type { Warning };
  *
  *     const warnings = await getWarningsDuringCallback(async () => {
  *       warn('some other warning');
- *     }); // => returns warnings which occured while the callback was invoked
+ *     }); // => returns warnings which occurred while the callback was invoked
  *   });
  * });
  */
@@ -406,7 +406,7 @@ export default function setupContext<T extends object>(
     .then(() => {
       let { resolver } = options;
 
-      // This handles precendence, specifying a specific option of
+      // This handles precedence, specifying a specific option of
       // resolver always trumps whatever is auto-detected, then we fallback to
       // the suite-wide registrations
       //

--- a/tests/helpers/qunit-test-adapter.js
+++ b/tests/helpers/qunit-test-adapter.js
@@ -17,7 +17,7 @@ function unhandledRejectionAssertion(current, error) {
     message = error;
     source = 'unknown source';
   } else {
-    message = 'unhandledRejection occured, but it had no message';
+    message = 'unhandledRejection occurred, but it had no message';
     source = 'unknown source';
   }
 

--- a/tests/unit/dom/blur-test.js
+++ b/tests/unit/dom/blur-test.js
@@ -97,7 +97,7 @@ module('DOM Helper: blur', function (hooks) {
     );
   });
 
-  test('bluring via selector with context set', async function (assert) {
+  test('blurring via selector with context set', async function (assert) {
     await setupContext(context);
     await blur(`#${elementWithFocus.id}`);
 
@@ -109,7 +109,7 @@ module('DOM Helper: blur', function (hooks) {
     );
   });
 
-  test('bluring via selector without context set', function (assert) {
+  test('blurring via selector without context set', function (assert) {
     elementWithFocus.setAttribute('data-skip-steps', true);
 
     assert.rejects(
@@ -118,7 +118,7 @@ module('DOM Helper: blur', function (hooks) {
     );
   });
 
-  test('bluring via element with context set', async function (assert) {
+  test('blurring via element with context set', async function (assert) {
     await setupContext(context);
     await blur(elementWithFocus);
 
@@ -130,7 +130,7 @@ module('DOM Helper: blur', function (hooks) {
     );
   });
 
-  test('bluring via element without context set', async function (assert) {
+  test('blurring via element without context set', async function (assert) {
     await blur(elementWithFocus);
 
     assert.verifySteps(blurSteps);

--- a/tests/unit/dom/tab-test.js
+++ b/tests/unit/dom/tab-test.js
@@ -112,7 +112,7 @@ module('DOM Helper: tab', function (hooks) {
     ]);
   });
 
-  test('tabs between foucsable elements', async function (assert) {
+  test('tabs between focusable elements', async function (assert) {
     elements = [
       buildInstrumentedElement('input', ['target.className']),
       buildInstrumentedElement('input', ['target.className']),

--- a/tests/unit/dom/type-in-test.js
+++ b/tests/unit/dom/type-in-test.js
@@ -190,7 +190,7 @@ module('DOM Helper: typeIn', function (hooks) {
     assert.equal(element.innerHTML, 'foo');
   });
 
-  test('typing in a non-typable element', async function (assert) {
+  test('typing in a non-typeable element', async function (assert) {
     element = buildInstrumentedElement('div');
 
     await setupContext(context);
@@ -275,9 +275,9 @@ module('DOM Helper: typeIn', function (hooks) {
   test('does not wait for other promises to settle', async function (assert) {
     element = buildInstrumentedElement('input');
 
-    let runcount = 0;
+    let runCount = 0;
     let onInput = function () {
-      return Promise.resolve().then(() => runcount++);
+      return Promise.resolve().then(() => runCount++);
     };
 
     element.oninput = function () {
@@ -288,7 +288,7 @@ module('DOM Helper: typeIn', function (hooks) {
     await typeIn(element, 'foo');
 
     assert.verifySteps(expectedEvents);
-    assert.equal(runcount, 1, 'debounced function only called once');
+    assert.equal(runCount, 1, 'debounced function only called once');
   });
 
   test('typing in an input with a maxlength with suitable value', async function (assert) {

--- a/tests/unit/setup-context-test.js
+++ b/tests/unit/setup-context-test.js
@@ -158,7 +158,7 @@ module('setupContext', function (hooks) {
         assert.deepEqual(testMetadata.setupTypes, ['setupContext']);
       });
 
-      test('it retutns false for isRendering/isApplication in non-rendering/application tests', function (assert) {
+      test('it returns false for isRendering/isApplication in non-rendering/application tests', function (assert) {
         let testMetadata = getTestMetadata(this);
 
         assert.ok(!testMetadata.isRendering);


### PR DESCRIPTION
Just fixing a few typos throughout the repo.

The one in `setup-application-context` is user-facing. It showed up in my work project, which inspired me to make this PR 😄 