### PR TITLE
Expose _registerHook/_runHooks argument and return types

### DIFF
--- a/addon-test-support/@ember/test-helpers/-internal/helper-hooks.ts
+++ b/addon-test-support/@ember/test-helpers/-internal/helper-hooks.ts
@@ -1,6 +1,6 @@
-type Hook = (...args: any[]) => void | Promise<void>;
+export type Hook = (...args: unknown[]) => void | Promise<void>;
 type HookLabel = 'start' | 'end' | string;
-type HookUnregister = {
+export type HookUnregister = {
   unregister: () => void;
 };
 
@@ -56,13 +56,13 @@ export function registerHook(
  * @param {string} helperName  The name of the test helper.
  * @param {string} label A label to help identify the hook. Built-in labels are `start` and `end`,
  *                       designating the start of the helper invocation and the end.
- * @param {any[]} args Any arguments originally passed to the test helper.
+ * @param {unknown[]} args Any arguments originally passed to the test helper.
  * @returns {Promise<void>} A promise representing the serial invocation of the hooks.
  */
 export function runHooks(
   helperName: string,
   label: HookLabel,
-  ...args: any[]
+  ...args: unknown[]
 ): Promise<void> {
   let hooks =
     registeredHooks.get(getHelperKey(helperName, label)) || new Set<Hook>();

--- a/addon-test-support/@ember/test-helpers/index.ts
+++ b/addon-test-support/@ember/test-helpers/index.ts
@@ -53,6 +53,7 @@ export {
   registerHook as _registerHook,
   runHooks as _runHooks,
 } from './-internal/helper-hooks';
+export type { Hook, HookUnregister } from './-internal/helper-hooks';
 
 // DOM Helpers
 export { default as click } from './dom/click';

--- a/type-tests/api.ts
+++ b/type-tests/api.ts
@@ -67,6 +67,11 @@ import {
   DeprecationFailure,
   Warning,
   Target,
+  // Hooks
+  _registerHook,
+  _runHooks,
+  Hook,
+  HookUnregister,
 } from '@ember/test-helpers';
 import { ComponentInstance } from '@glimmer/interfaces';
 import { Owner } from '@ember/test-helpers/build-owner';
@@ -264,4 +269,15 @@ expectTypeOf(getDeprecationsDuringCallback).toEqualTypeOf<
 expectTypeOf(getWarnings).toEqualTypeOf<() => Array<Warning>>();
 expectTypeOf(getWarningsDuringCallback).toEqualTypeOf<
   (callback: () => void) => Array<Warning> | Promise<Array<Warning>>
+>();
+
+// Hooks
+expectTypeOf(_registerHook).toEqualTypeOf<
+  (helperName: string, label: string, hook: Hook) => HookUnregister
+>();
+expectTypeOf<{ unregister: () => void }>().toEqualTypeOf<HookUnregister>();
+expectTypeOf<(...args: unknown[]) => void>().toMatchTypeOf<Hook>();
+expectTypeOf<(...args: unknown[]) => Promise<void>>().toMatchTypeOf<Hook>();
+expectTypeOf(_runHooks).toEqualTypeOf<
+  (helperName: string, label: string, ...args: unknown[]) => Promise<void>
 >();


### PR DESCRIPTION
Unblocks https://github.com/ember-a11y/ember-a11y-testing/issues/498

AFAICT these types should be public (or at least "intimate") API, per https://github.com/emberjs/ember-test-helpers/pull/878