### PR TITLE
Add types/ to npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -49,6 +49,7 @@
 /.github/
 /documentation.yml
 /server/
+/types/
 
 # typescript
 #


### PR DESCRIPTION
Since this package builds types to `public-types/` for publishing, it should not also be publishing the internal-focused `types/` directory. Adding it to npmignore to remove it from the published package.