### PR TITLE
Get ember-canary passing

### DIFF
--- a/addon/tests/dummy/config/ember-try.js
+++ b/addon/tests/dummy/config/ember-try.js
@@ -78,6 +78,8 @@ module.exports = async function () {
         npm: {
           devDependencies: {
             'ember-source': await getChannelURL('canary'),
+            'ember-resolver': '10.0.0',
+            '@ember/string': '3.0.1',
           },
         },
       },

--- a/addon/tests/helpers/start-app.js
+++ b/addon/tests/helpers/start-app.js
@@ -1,12 +1,11 @@
 import Application from '../../app';
 import config from '../../config/environment';
-import { assign } from '@ember/polyfills';
 import { run } from '@ember/runloop';
 
 export default function startApp(attrs) {
-  let attributes = assign({}, config.APP);
+  let attributes = Object.assign({}, config.APP);
   attributes.autoboot = true;
-  attributes = assign(attributes, attrs); // use defaults, but you can override;
+  attributes = Object.assign(attributes, attrs); // use defaults, but you can override;
 
   return run(() => {
     let application = Application.create(attributes);

--- a/addon/tests/unit/setup-context-test.js
+++ b/addon/tests/unit/setup-context-test.js
@@ -24,7 +24,6 @@ import {
   application,
   resolver,
 } from '../helpers/resolver';
-import { assign } from '@ember/polyfills';
 import App from '../../app';
 import config from '../../config/environment';
 import Ember from 'ember';
@@ -849,7 +848,7 @@ module('setupContext', function (hooks) {
     let isolatedApp;
 
     hooks.beforeEach(function () {
-      const AppConfig = assign({ autoboot: false }, config.APP);
+      const AppConfig = Object.assign({ autoboot: false }, config.APP);
       // .extend() because initializers are stored in the constructor, and we
       // don't want to pollute other tests using an application created from the
       // same constructor.


### PR DESCRIPTION
Per: https://github.com/emberjs/ember.js/issues/20418

Canary tests were hanging,
Locally:
```
Died on test #1: Could not find module `@ember/polyfills` imported from `dummy/tests/unit/setup-context-test`
    at TestLoader.moduleLoadFailure (http://localhost:4202/assets/tests.js:1184:22)
    at TestLoader.require (http://localhost:4202/assets/test-support.js:6931:14)
    at TestLoader.loadModules (http://localhost:4202/assets/test-support.js:6923:14)
```    

-------------

To fix, I had to remove `@ember/polyfills` -- which would be a breaking change -- but that's fine, as we're preparing for v3 anyway