### PR TITLE
Sync with the v2.x branch

### DIFF
--- a/addon/CHANGELOG.md
+++ b/addon/CHANGELOG.md
@@ -1,5 +1,16 @@
 # CHANGELOG
 
+## v2.9.2 (2022-12-21)
+
+#### :bug: Bug Fix
+* [#1302](https://github.com/emberjs/ember-test-helpers/pull/1302) [backport] Remove the index signature from `TestContext` ([@chriskrycho](https://github.com/chriskrycho))
+    * Backporting [#1301](https://github.com/emberjs/ember-test-helpers/pull/1301) Remove the index signature from `TestContext` ([@dfreeman](https://github.com/dfreeman))
+* [#1303](https://github.com/emberjs/ember-test-helpers/pull/1303) `TestContext.resumeTest()` returns `void`, not `Promise<void>` ([@chriskrycho](https://github.com/chriskrycho))
+
+#### Committers: 1
+- Chris Krycho ([@chriskrycho](https://github.com/chriskrycho))
+- Dan Freeman ([@dfreeman](https://github.com/dfreeman))
+
 ## v2.9.1 (2022-12-16)
 
 ***Note:** these were all back-ported from master since they could go out on 2.9. This will be the last 2.9 release unless there are critical bug fixes here!*

--- a/addon/CHANGELOG.md
+++ b/addon/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## v2.9.3 (2022-12-21)
+
+#### :bug: Bug Fix
+* [#1305](https://github.com/emberjs/ember-test-helpers/pull/1305) [backport] Avoid unnecessary dependencies on `@glimmer` types ([@dfreeman](https://github.com/dfreeman))
+
+#### Committers: 1
+- Dan Freeman ([@dfreeman](https://github.com/dfreeman))
+
 ## v2.9.2 (2022-12-21)
 
 #### :bug: Bug Fix

--- a/addon/package.json
+++ b/addon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ember/test-helpers",
-  "version": "2.9.2",
+  "version": "2.9.3",
   "description": "Helpers for testing Ember.js applications",
   "keywords": [
     "ember-addon"

--- a/addon/package.json
+++ b/addon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ember/test-helpers",
-  "version": "2.9.0",
+  "version": "2.9.2",
   "description": "Helpers for testing Ember.js applications",
   "keywords": [
     "ember-addon"


### PR DESCRIPTION
Some confusing comparisons:
 - https://github.com/emberjs/ember-test-helpers/compare/master...v2.9.3
 - https://github.com/emberjs/ember-test-helpers/compare/v2-x
 
I reviewed the code with the following commits, starting with the first one I did not see in my skim of the t`git log` on `master`:
 - https://github.com/emberjs/ember-test-helpers/commit/1d22a8e8c6b54bf02e9cf34a2c6867be1c94ea25
 - https://github.com/emberjs/ember-test-helpers/commit/a34c29b71d88cb16a876900ce657366916da08ba
 - https://github.com/emberjs/ember-test-helpers/commit/e3f1cb845d27e762ffc15983675086beece2c787
 - https://github.com/emberjs/ember-test-helpers/commit/421d2a03c9f20ee40e8d6eb1ec19e9febaa5bb8f
 - https://github.com/emberjs/ember-test-helpers/commit/20c6cf9a6a8303b683ab28cba9c2c29b6fc7a5d9
 - https://github.com/emberjs/ember-test-helpers/commit/51804d70be134de6fa9fd0421ae10d8de1863074
 
 the only changes missing that I could find that was missing (from looking at the diff of each commit and checking if the code on `master` matched) was the changelog / package.json changes.