### PR TITLE
ensureSafeComponent is not needed on Ember > 3.25

### DIFF
--- a/addon/addon-test-support/@ember/test-helpers/setup-rendering-context.ts
+++ b/addon/addon-test-support/@ember/test-helpers/setup-rendering-context.ts
@@ -19,7 +19,6 @@ import hasEmberVersion from './has-ember-version';
 import isComponent from './-internal/is-component';
 import { macroCondition, dependencySatisfies } from '@embroider/macros';
 import { ComponentRenderMap, SetUsage } from './setup-context';
-import { ensureSafeComponent } from '@embroider/util';
 
 const OUTLET_TEMPLATE = hbs`{{outlet}}`;
 const EMPTY_TEMPLATE = hbs``;
@@ -166,13 +165,8 @@ export function render(
             );
           }
 
-          let ProvidedComponent = ensureSafeComponent(
-            templateOrComponent,
-            context
-          );
-
           context = {
-            ProvidedComponent,
+            ProvidedComponent: templateOrComponent,
           };
           templateOrComponent = INVOKE_PROVIDED_COMPONENT;
         } else {

--- a/addon/package.json
+++ b/addon/package.json
@@ -47,7 +47,6 @@
   "dependencies": {
     "@ember/test-waiters": "^3.0.2",
     "@embroider/macros": "^1.10.0",
-    "@embroider/util": "^1.9.0",
     "broccoli-debug": "^0.6.5",
     "broccoli-funnel": "^3.0.8",
     "ember-auto-import": "^2.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1101,15 +1101,6 @@
     semver "^7.3.5"
     typescript-memoize "^1.0.1"
 
-"@embroider/util@^1.9.0":
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/@embroider/util/-/util-1.10.0.tgz#8320d73651e7f5d48dac1b71fb9e6d21cac7c803"
-  integrity sha512-utAFKoq6ajI27jyqjvX3PiGL4m+ZyGVlVNbSbE/nOqi2llRyAkh5ltH1WkIK7jhdwQFJouo1NpOSj9J3/HDa3A==
-  dependencies:
-    "@embroider/macros" "^1.10.0"
-    broccoli-funnel "^3.0.5"
-    ember-cli-babel "^7.26.11"
-
 "@eslint/eslintrc@^0.4.3":
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-0.4.3.tgz#9e42981ef035beb3dd49add17acb96e8ff6f394c"
@@ -3479,7 +3470,7 @@ broccoli-funnel@^2.0.0, broccoli-funnel@^2.0.1, broccoli-funnel@^2.0.2:
     symlink-or-copy "^1.0.0"
     walk-sync "^0.3.1"
 
-broccoli-funnel@^3.0.5, broccoli-funnel@^3.0.8:
+broccoli-funnel@^3.0.8:
   version "3.0.8"
   resolved "https://registry.yarnpkg.com/broccoli-funnel/-/broccoli-funnel-3.0.8.tgz#f5b62e2763c3918026a15a3c833edc889971279b"
   integrity sha512-ng4eIhPYiXqMw6SyGoxPHR3YAwEd2lr9FgBI1CyTbspl4txZovOsmzFkMkGAlu88xyvYXJqHiM2crfLa65T1BQ==


### PR DESCRIPTION
This usage of `ensureSafeComponent` is a no-op on all the versions of ember supported by this addon.