### PR TITLE
remove has-ember-version

### DIFF
--- a/addon/addon-test-support/ember-test-helpers/has-ember-version.ts
+++ b/addon/addon-test-support/ember-test-helpers/has-ember-version.ts
@@ -1,1 +1,0 @@
-export { default } from '@ember/test-helpers/has-ember-version';


### PR DESCRIPTION
This is a breaking change, but one required for v2 conversion.

We do not need this utility, as we can use embroider/macros. 

(but also `hasEmberVersion` still exists in `@ember/test-helpers` (for now))