### PR TITLE
Use sibling import for logging so that these files are rollup compatible

### DIFF
--- a/addon/addon-test-support/@ember/test-helpers/dom/blur.ts
+++ b/addon/addon-test-support/@ember/test-helpers/dom/blur.ts
@@ -2,7 +2,7 @@ import getElement from './-get-element';
 import fireEvent from './fire-event';
 import settled from '../settled';
 import Target from './-target';
-import { log } from '@ember/test-helpers/dom/-logging';
+import { log } from './-logging';
 import isFocusable from './-is-focusable';
 import { runHooks, registerHook } from '../helper-hooks';
 

--- a/addon/addon-test-support/@ember/test-helpers/dom/click.ts
+++ b/addon/addon-test-support/@ember/test-helpers/dom/click.ts
@@ -4,7 +4,7 @@ import { __focus__ } from './focus';
 import settled from '../settled';
 import isFormControl from './-is-form-control';
 import Target, { isWindow } from './-target';
-import { log } from '@ember/test-helpers/dom/-logging';
+import { log } from './-logging';
 import { runHooks, registerHook } from '../helper-hooks';
 
 const PRIMARY_BUTTON = 1;

--- a/addon/addon-test-support/@ember/test-helpers/dom/double-click.ts
+++ b/addon/addon-test-support/@ember/test-helpers/dom/double-click.ts
@@ -4,7 +4,7 @@ import { __focus__ } from './focus';
 import settled from '../settled';
 import { DEFAULT_CLICK_OPTIONS } from './click';
 import Target, { isWindow } from './-target';
-import { log } from '@ember/test-helpers/dom/-logging';
+import { log } from './-logging';
 import isFormControl from './-is-form-control';
 import { runHooks, registerHook } from '../helper-hooks';
 

--- a/addon/addon-test-support/@ember/test-helpers/dom/fill-in.ts
+++ b/addon/addon-test-support/@ember/test-helpers/dom/fill-in.ts
@@ -5,7 +5,7 @@ import { __focus__ } from './focus';
 import settled from '../settled';
 import fireEvent from './fire-event';
 import Target, { isContentEditable } from './-target';
-import { log } from '@ember/test-helpers/dom/-logging';
+import { log } from './-logging';
 import { runHooks, registerHook } from '../helper-hooks';
 
 registerHook('fillIn', 'start', (target: Target, text: string) => {

--- a/addon/addon-test-support/@ember/test-helpers/dom/fire-event.ts
+++ b/addon/addon-test-support/@ember/test-helpers/dom/fire-event.ts
@@ -1,7 +1,7 @@
 import { isDocument, isElement } from './-target';
 import tuple from '../-tuple';
 import Target from './-target';
-import { log } from '@ember/test-helpers/dom/-logging';
+import { log } from './-logging';
 import { runHooks, registerHook } from '../helper-hooks';
 
 registerHook('fireEvent', 'start', (target: Target) => {

--- a/addon/addon-test-support/@ember/test-helpers/dom/focus.ts
+++ b/addon/addon-test-support/@ember/test-helpers/dom/focus.ts
@@ -3,7 +3,7 @@ import fireEvent from './fire-event';
 import settled from '../settled';
 import isFocusable from './-is-focusable';
 import Target, { isDocument } from './-target';
-import { log } from '@ember/test-helpers/dom/-logging';
+import { log } from './-logging';
 import { runHooks, registerHook } from '../helper-hooks';
 import { __blur__ } from './blur';
 

--- a/addon/addon-test-support/@ember/test-helpers/dom/tap.ts
+++ b/addon/addon-test-support/@ember/test-helpers/dom/tap.ts
@@ -3,7 +3,7 @@ import fireEvent from './fire-event';
 import { __click__ } from './click';
 import settled from '../settled';
 import Target from './-target';
-import { log } from '@ember/test-helpers/dom/-logging';
+import { log } from './-logging';
 import isFormControl from './-is-form-control';
 import { runHooks, registerHook } from '../helper-hooks';
 

--- a/addon/addon-test-support/@ember/test-helpers/dom/trigger-event.ts
+++ b/addon/addon-test-support/@ember/test-helpers/dom/trigger-event.ts
@@ -2,7 +2,7 @@ import { getWindowOrElement } from './-get-window-or-element';
 import fireEvent from './fire-event';
 import settled from '../settled';
 import Target from './-target';
-import { log } from '@ember/test-helpers/dom/-logging';
+import { log } from './-logging';
 import isFormControl from './-is-form-control';
 import { runHooks, registerHook } from '../helper-hooks';
 

--- a/addon/addon-test-support/@ember/test-helpers/dom/trigger-key-event.ts
+++ b/addon/addon-test-support/@ember/test-helpers/dom/trigger-key-event.ts
@@ -8,7 +8,7 @@ import {
 } from './fire-event';
 import { isNumeric } from '../-utils';
 import Target from './-target';
-import { log } from '@ember/test-helpers/dom/-logging';
+import { log } from './-logging';
 import isFormControl from './-is-form-control';
 import { runHooks, registerHook } from '../helper-hooks';
 

--- a/addon/addon-test-support/@ember/test-helpers/dom/type-in.ts
+++ b/addon/addon-test-support/@ember/test-helpers/dom/type-in.ts
@@ -10,7 +10,7 @@ import Target, {
   HTMLElementContentEditable,
 } from './-target';
 import { __triggerKeyEvent__ } from './trigger-key-event';
-import { log } from '@ember/test-helpers/dom/-logging';
+import { log } from './-logging';
 import { runHooks, registerHook } from '../helper-hooks';
 
 export interface Options {


### PR DESCRIPTION
This change is mostly a no-op, but a require change as our recommend v2 addon rollup config does not support "self-imports" (though it can be added with extra config).

However, importing from ./module is much easier and less typing than using the full path.