### PR TITLE
Pass owner instead of registry to ember-data's setupContainer

### DIFF
--- a/addon/addon-test-support/@ember/test-helpers/-internal/build-registry.ts
+++ b/addon/addon-test-support/@ember/test-helpers/-internal/build-registry.ts
@@ -123,7 +123,7 @@ export default function (resolver: Resolver) {
     // correctly for the tests; that's why we import and call setupContainer
     // here; also see https://github.com/emberjs/data/issues/4071 for context
     let setupContainer = require('ember-data/setup-container')['default'];
-    setupContainer(registry || container);
+    setupContainer(owner);
   }
 
   return {


### PR DESCRIPTION
The `setupContainer` function of `ember-data` expects an application instance to be passed - in this case that is the faked owner object that we create when using a custom resolver in tests.

This behaviour previously worked because `ember-data` supported the usage of legacy function `optionsForType` which exists on the `registry` object. However, they removed that legacy fallback in v4 and replaced it with `registerOptionsForType` which does not exist on the registry but only on the owner.

Resolves #1386