### PR TITLE
[v2 backport] Pass owner instead of registry to ember-data's setupContainer

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -17,9 +17,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: volta-cli/action@v1
-        with:
-          node-version: 10.x
+      - uses: volta-cli/action@v4
       - run: yarn install --frozen-lockfile --ignore-engines
       - run: yarn lint
       - run: yarn test
@@ -31,9 +29,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: volta-cli/action@v1
-        with:
-          node-version: 12.x
+      - uses: volta-cli/action@v4
       - run: yarn install --no-lockfile
       - run: yarn test
 
@@ -64,9 +60,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: volta-cli/action@v1
-        with:
-          node-version: 12.x
+      - uses: volta-cli/action@v4
       - name: install dependencies
         run: yarn install --frozen-lockfile
       - name: test
@@ -74,7 +68,7 @@ jobs:
 
   types:
     runs-on: ubuntu-latest
-      
+
     needs: test
 
     strategy:
@@ -86,9 +80,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: volta-cli/action@v1
-        with:
-          node-version: 12.x
+      - uses: volta-cli/action@v4
       - name: install dependencies
         run: yarn install --frozen-lockfile
       - name: install TS version

--- a/addon-test-support/@ember/test-helpers/-internal/build-registry.ts
+++ b/addon-test-support/@ember/test-helpers/-internal/build-registry.ts
@@ -118,7 +118,7 @@ export default function (resolver: Resolver) {
     // correctly for the tests; that's why we import and call setupContainer
     // here; also see https://github.com/emberjs/data/issues/4071 for context
     let setupContainer = require('ember-data/setup-container')['default'];
-    setupContainer(registry || container);
+    setupContainer(owner);
   }
 
   return {

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -100,6 +100,7 @@ module.exports = async function () {
         npm: {
           devDependencies: {
             'ember-source': await getChannelURL('release'),
+            '@ember/string': '3.1.1',
           },
         },
       },
@@ -108,6 +109,7 @@ module.exports = async function () {
         npm: {
           devDependencies: {
             'ember-source': await getChannelURL('beta'),
+            '@ember/string': '3.1.1',
           },
         },
       },
@@ -116,6 +118,7 @@ module.exports = async function () {
         npm: {
           devDependencies: {
             'ember-source': await getChannelURL('canary'),
+            '@ember/string': '3.1.1',
           },
         },
       },

--- a/package.json
+++ b/package.json
@@ -155,7 +155,7 @@
     }
   },
   "volta": {
-    "node": "12.22.4",
+    "node": "14.21.3",
     "yarn": "1.22.4"
   },
   "typesVersions": {


### PR DESCRIPTION
The `setupContainer` function of `ember-data` expects an application instance to be passed - in this case that is the faked owner object that we create when using a custom resolver in tests.

This behaviour previously worked because `ember-data` supported the usage of legacy function `optionsForType` which exists on the `registry` object. However, they removed that legacy fallback in v4 and replaced it with `registerOptionsForType` which does not exist on the registry but only on the owner.

Resolves #1386