### PR TITLE
README update: Because @ember/test-helpers is still a v1 addon, we need to declare o…

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Compatibility
 
 - Ember.js v4 or above
 - Ember CLI v4 or above
-- Node.js v14 or above
+- Node.js v16 or above
 - TypeScript 4.7, 4.8, and 4.9
   - SemVer policy: [simple majors](https://www.semver-ts.org/#simple-majors)
   - the public API is defined by [API.md](./API.md).


### PR DESCRIPTION
…ur engines.node version for compatibility (something we don't have to do for v2 addons, because node is irrelevant for consumers of browser-only libraries)