### PR TITLE
fixing the release

### DIFF
--- a/addon/.npmignore
+++ b/addon/.npmignore
@@ -49,11 +49,4 @@
 /.github/
 /documentation.yml
 /server/
-
-# typescript
-#
-# avoid publishing .d.ts or .ts files
-# until they have become enforced "public" APIs
-*.ts
-# to enable d.ts consumption remove the next line
-!*.d.ts
+/types/

--- a/addon/.npmignore
+++ b/addon/.npmignore
@@ -49,7 +49,6 @@
 /.github/
 /documentation.yml
 /server/
-/types/
 
 # typescript
 #

--- a/addon/package.json
+++ b/addon/package.json
@@ -149,7 +149,7 @@
   "typesVersions": {
     "*": {
       "*": [
-        "public-types/@ember/test-helpers/*"
+        "public-types/*"
       ]
     }
   }

--- a/addon/package.json
+++ b/addon/package.json
@@ -149,7 +149,7 @@
   "typesVersions": {
     "*": {
       "*": [
-        "./public-types/*"
+        "./dist-types/*"
       ]
     }
   }

--- a/addon/package.json
+++ b/addon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ember/test-helpers",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Helpers for testing Ember.js applications",
   "keywords": [
     "ember-addon"

--- a/addon/package.json
+++ b/addon/package.json
@@ -149,7 +149,7 @@
   "typesVersions": {
     "*": {
       "*": [
-        "public-types/*"
+        "./public-types/*"
       ]
     }
   }

--- a/addon/types.tsconfig.json
+++ b/addon/types.tsconfig.json
@@ -4,6 +4,6 @@
     // Use TS to emit declarations
     "noEmit": false,
     "emitDeclarationOnly": true,
-    "outDir": "public-types"
+    "outDir": "dist-types"
   }
 }


### PR DESCRIPTION
in #1397 a user has reported that types are missing and they are getting an error. 

This PR updates the `.npmignore`  file and the package.json file to more correctly reflect what should be getting published re:types. 

This error seems to be related to the differences between `npm pack` and `yarn pack`.

Also not 100% sure this will be the fix but thanks to @gitKrystan @chriskrycho and @NullVoxPopuli for working through this toward a potential solution.