### PR TITLE
Fix `isComponent` types

### DIFF
--- a/addon/addon-test-support/@ember/test-helpers/-internal/get-component-manager.ts
+++ b/addon/addon-test-support/@ember/test-helpers/-internal/get-component-manager.ts
@@ -1,3 +1,0 @@
-import { getInternalComponentManager as getComponentManager } from '@glimmer/manager';
-
-export default getComponentManager;

--- a/addon/addon-test-support/@ember/test-helpers/-internal/is-component.ts
+++ b/addon/addon-test-support/@ember/test-helpers/-internal/is-component.ts
@@ -10,22 +10,7 @@ import { getInternalComponentManager as getComponentManager } from '@glimmer/man
  * @returns {boolean} True if it's a component, false if not
  */
 function isComponent(maybeComponent: object): maybeComponent is ComponentLike {
-  // SAFETY: in more recent versions of @glimmer/manager,
-  //         this throws an error when maybeComponent does not have
-  //         an associated manager.
-  try {
-    return !!getComponentManager(maybeComponent, true);
-  } catch (e) {
-    if (
-      `${e}`.includes(
-        `wasn't a component manager associated with the definition`
-      )
-    ) {
-      return false;
-    }
-
-    throw e;
-  }
+  return !!getComponentManager(maybeComponent, true);
 }
 
 export default isComponent;

--- a/addon/addon-test-support/@ember/test-helpers/-internal/is-component.ts
+++ b/addon/addon-test-support/@ember/test-helpers/-internal/is-component.ts
@@ -1,24 +1,20 @@
 import type { ComponentLike } from '@glint/template';
 
-import getComponentManager from './get-component-manager';
+import { getInternalComponentManager as getComponentManager } from '@glimmer/manager';
 
 /**
  * We should ultimately get a new API from @glimmer/runtime that provides this functionality
  * (see https://github.com/emberjs/rfcs/pull/785 for more info).
  * @private
  * @param {Object} maybeComponent The thing you think might be a component
- * @param {Object} owner Owner, we need this for old versions of getComponentManager
  * @returns {boolean} True if it's a component, false if not
  */
-function isComponent(
-  maybeComponent: object,
-  owner: object
-): maybeComponent is ComponentLike {
+function isComponent(maybeComponent: object): maybeComponent is ComponentLike {
   // SAFETY: in more recent versions of @glimmer/manager,
   //         this throws an error when maybeComponent does not have
   //         an associated manager.
   try {
-    return !!getComponentManager(maybeComponent, owner);
+    return !!getComponentManager(maybeComponent, true);
   } catch (e) {
     if (
       `${e}`.includes(

--- a/addon/addon-test-support/@ember/test-helpers/setup-rendering-context.ts
+++ b/addon/addon-test-support/@ember/test-helpers/setup-rendering-context.ts
@@ -128,7 +128,7 @@ export function render(
       let OutletTemplate = lookupOutletTemplate(owner);
       let ownerToRenderFrom = options?.owner || owner;
 
-      if (isComponent(templateOrComponent, owner)) {
+      if (isComponent(templateOrComponent)) {
         // We use this to track when `render` is used with a component so that we can throw an
         // assertion if `this.{set,setProperty} is used in the same test
         ComponentRenderMap.set(context, true);


### PR DESCRIPTION
AFAICT [this change](https://github.com/emberjs/ember-test-helpers/pull/1382/files#diff-d3135c2567a56aba0c3f1dd551a3eca6e8c8287a802a584c2b127d8a032ad51a) from #1382 is incorrect but coincidentally works because `owner` is truthy.

It appears that `getInternalComponentManager`'s signature is `(definition: object, isOptional?: true | undefined) => InternalComponentManager | null` and has been for a while:

https://github.com/glimmerjs/glimmer-vm/blob/14413355ef6b48c1ab416a91fb7ff950cf8511d8/packages/%40glimmer/manager/lib/internal/index.ts#L177-L211

This issue was exposed by https://github.com/emberjs/ember-test-helpers/pull/1389