### PR TITLE
Add Ember 5.0 to support matrix (Fixes #1403)

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -45,9 +45,9 @@ jobs:
       fail-fast: false
       matrix:
         ember-try-scenario:
-          - ember-lts-5.0
           - ember-lts-4.4
           - ember-lts-4.8
+          - ember-lts-5.0
           - ember-release
           - ember-beta
           - ember-canary

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -45,6 +45,7 @@ jobs:
       fail-fast: false
       matrix:
         ember-try-scenario:
+          - ember-lts-5.0
           - ember-lts-4.4
           - ember-lts-4.8
           - ember-release

--- a/addon/package.json
+++ b/addon/package.json
@@ -42,7 +42,7 @@
     "test:all": "ember try:each"
   },
   "peerDependencies": {
-    "ember-source": "^4.0.0"
+    "ember-source": "^4.0.0 || ^5.0.0"
   },
   "dependencies": {
     "@ember/test-waiters": "^3.0.2",

--- a/addon/tests/dummy/config/ember-try.js
+++ b/addon/tests/dummy/config/ember-try.js
@@ -42,14 +42,6 @@ module.exports = async function () {
     useYarn: true,
     scenarios: [
       {
-        name: 'ember-lts-5.0',
-        npm: {
-          devDependencies: {
-            'ember-source': '~5.0.0',
-          },
-        },
-      },
-      {
         name: 'ember-lts-4.4',
         npm: {
           devDependencies: {
@@ -62,6 +54,14 @@ module.exports = async function () {
         npm: {
           devDependencies: {
             'ember-source': '~4.8.0',
+          },
+        },
+      },
+      {
+        name: 'ember-lts-5.0',
+        npm: {
+          devDependencies: {
+            'ember-source': '~5.0.0',
           },
         },
       },

--- a/addon/tests/dummy/config/ember-try.js
+++ b/addon/tests/dummy/config/ember-try.js
@@ -42,6 +42,14 @@ module.exports = async function () {
     useYarn: true,
     scenarios: [
       {
+        name: 'ember-lts-5.0',
+        npm: {
+          devDependencies: {
+            'ember-source': '~5.0.0',
+          },
+        },
+      },
+      {
         name: 'ember-lts-4.4',
         npm: {
           devDependencies: {


### PR DESCRIPTION
Note that there are still issues with types support for Ember 5.1, which will #1389 will address.