### PR TITLE
fix embroider tests

### DIFF
--- a/addon/package.json
+++ b/addon/package.json
@@ -59,6 +59,7 @@
     "@babel/preset-typescript": "^7.21.0",
     "@ember/optional-features": "^2.0.0",
     "@ember/string": "^3.0.1",
+    "@embroider/test-setup": "^3.0.1",
     "@glimmer/component": "^1.1.2",
     "@glimmer/interfaces": "^0.84.1",
     "@glimmer/reference": "^0.84.2",

--- a/addon/tests/dummy/config/ember-try.js
+++ b/addon/tests/dummy/config/ember-try.js
@@ -1,46 +1,9 @@
 'use strict';
 
 const getChannelURL = require('ember-source-channel-url');
-const latestVersion = require('latest-version');
+const { embroiderSafe } = require('@embroider/test-setup');
 
 module.exports = async function () {
-  const embroiderCore = await latestVersion('@embroider/core');
-  const embroiderWebpack = await latestVersion('@embroider/webpack');
-  const embroiderCompat = await latestVersion('@embroider/compat');
-  const embroiderTestSetup = await latestVersion('@embroider/test-setup');
-
-  const embroider = {
-    safe: {
-      name: 'embroider-safe',
-      npm: {
-        devDependencies: {
-          '@embroider/core': embroiderCore,
-          '@embroider/webpack': embroiderWebpack,
-          '@embroider/compat': embroiderCompat,
-          '@embroider/test-setup': embroiderTestSetup,
-        },
-      },
-      env: {
-        EMBROIDER_TEST_SETUP_OPTIONS: 'safe',
-      },
-    },
-
-    optimized: {
-      name: 'embroider-optimized',
-      npm: {
-        devDependencies: {
-          '@embroider/core': embroiderCore,
-          '@embroider/webpack': embroiderWebpack,
-          '@embroider/compat': embroiderCompat,
-          '@embroider/test-setup': embroiderTestSetup,
-        },
-      },
-      env: {
-        EMBROIDER_TEST_SETUP_OPTIONS: 'optimized',
-      },
-    },
-  };
-
   return {
     useYarn: true,
     scenarios: [
@@ -92,16 +55,16 @@ module.exports = async function () {
           devDependencies: {},
         },
       },
-      embroider.safe,
+      embroiderSafe(),
       // disable embroider optimized test scenarios, as the dynamism these
       // tests use is not compatible with embroider we are still exploring
       // appropriate paths forward.
       //
       // Steps to re-enable:
       //
-      // 1. have a strategy to make this work
+      // 1. have a strategy to make this work, import from '@embroider/test-setup'
       // 2. uncomment the next line
-      // embroider.optimized,
+      // embroiderOptimized();
       //
       // 3. add "embroider-optimized" to .github/workflows/ci-build.yml's
       //    ember-try-scenario list.

--- a/addon/tests/dummy/config/ember-try.js
+++ b/addon/tests/dummy/config/ember-try.js
@@ -4,17 +4,20 @@ const getChannelURL = require('ember-source-channel-url');
 const latestVersion = require('latest-version');
 
 module.exports = async function () {
-  const EMBROIDER_VERSION = await latestVersion('@embroider/core');
+  const embroiderCore = await latestVersion('@embroider/core');
+  const embroiderWebpack = await latestVersion('@embroider/webpack');
+  const embroiderCompat = await latestVersion('@embroider/compat');
+  const embroiderTestSetup = await latestVersion('@embroider/testSetup');
 
   const embroider = {
     safe: {
       name: 'embroider-safe',
       npm: {
         devDependencies: {
-          '@embroider/core': EMBROIDER_VERSION,
-          '@embroider/webpack': EMBROIDER_VERSION,
-          '@embroider/compat': EMBROIDER_VERSION,
-          '@embroider/test-setup': EMBROIDER_VERSION,
+          '@embroider/core': embroiderCore,
+          '@embroider/webpack': embroiderWebpack,
+          '@embroider/compat': embroiderCompat,
+          '@embroider/test-setup': embroiderTestSetup,
         },
       },
       env: {
@@ -26,10 +29,10 @@ module.exports = async function () {
       name: 'embroider-optimized',
       npm: {
         devDependencies: {
-          '@embroider/core': EMBROIDER_VERSION,
-          '@embroider/webpack': EMBROIDER_VERSION,
-          '@embroider/compat': EMBROIDER_VERSION,
-          '@embroider/test-setup': EMBROIDER_VERSION,
+          '@embroider/core': embroiderCore,
+          '@embroider/webpack': embroiderWebpack,
+          '@embroider/compat': embroiderCompat,
+          '@embroider/test-setup': embroiderTestSetup,
         },
       },
       env: {

--- a/addon/tests/dummy/config/ember-try.js
+++ b/addon/tests/dummy/config/ember-try.js
@@ -7,7 +7,7 @@ module.exports = async function () {
   const embroiderCore = await latestVersion('@embroider/core');
   const embroiderWebpack = await latestVersion('@embroider/webpack');
   const embroiderCompat = await latestVersion('@embroider/compat');
-  const embroiderTestSetup = await latestVersion('@embroider/testSetup');
+  const embroiderTestSetup = await latestVersion('@embroider/test-setup');
 
   const embroider = {
     safe: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1101,6 +1101,14 @@
     semver "^7.3.5"
     typescript-memoize "^1.0.1"
 
+"@embroider/test-setup@^3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@embroider/test-setup/-/test-setup-3.0.1.tgz#603b21a809708ac928fe9f002905ee3711dc6864"
+  integrity sha512-t7R2f10iZDSNw3ovWAPM63GRQTu63uihpVh6CvHev5XkLt8B7tdxcxGyO6RbdF5Hu+pbsUu8sD0kAlR1gopmxg==
+  dependencies:
+    lodash "^4.17.21"
+    resolve "^1.20.0"
+
 "@eslint/eslintrc@^0.4.3":
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-0.4.3.tgz#9e42981ef035beb3dd49add17acb96e8ff6f394c"


### PR DESCRIPTION
the `@embroider/*` packages are no longer released in lockstep, so each version must individually be fetched