### PR TITLE
Check types in test matrix

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -45,9 +45,9 @@ jobs:
       fail-fast: false
       matrix:
         ember-try-scenario:
-          - ember-lts-5.0
           - ember-lts-4.4
           - ember-lts-4.8
+          - ember-lts-5.0
           - ember-release
           - ember-beta
           - ember-canary

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -63,6 +63,9 @@ jobs:
       - name: test
         working-directory: addon
         run: node_modules/.bin/ember try:one ${{ matrix.ember-try-scenario }} --skip-cleanup
+      - name: types compatibility
+        working-directory: addon
+        run: yarn lint:ts
 
   types:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -45,6 +45,7 @@ jobs:
       fail-fast: false
       matrix:
         ember-try-scenario:
+          - ember-lts-5.0
           - ember-lts-4.4
           - ember-lts-4.8
           - ember-release

--- a/addon/package.json
+++ b/addon/package.json
@@ -42,7 +42,7 @@
     "test:all": "ember try:each"
   },
   "peerDependencies": {
-    "ember-source": "^4.0.0"
+    "ember-source": "^4.0.0 || ^5.0.0"
   },
   "dependencies": {
     "@ember/test-waiters": "^3.0.2",

--- a/addon/tests/dummy/config/ember-try.js
+++ b/addon/tests/dummy/config/ember-try.js
@@ -38,6 +38,34 @@ module.exports = async function () {
     },
   };
 
+  const atTypes = {
+    '@types/ember': await latestVersion('@types/ember'),
+    '@types/ember__application': await latestVersion(
+      '@types/ember__application'
+    ),
+    '@types/ember__array': await latestVersion('@types/ember__array'),
+    '@types/ember__component': await latestVersion('@types/ember__component'),
+    '@types/ember__controller': await latestVersion('@types/ember__controller'),
+    '@types/ember__debug': await latestVersion('@types/ember__debug'),
+    '@types/ember__destroyable': await latestVersion(
+      '@types/ember__destroyable'
+    ),
+    '@types/ember__engine': await latestVersion('@types/ember__engine'),
+    '@types/ember__error': await latestVersion('@types/ember__error'),
+    '@types/ember__helper': await latestVersion('@types/ember__helper'),
+    '@types/ember__modifier': await latestVersion('@types/ember__modifier'),
+    '@types/ember__object': await latestVersion('@types/ember__object'),
+    '@types/ember__owner': await latestVersion('@types/ember__owner'),
+    '@types/ember__polyfills': await latestVersion('@types/ember__polyfills'),
+    '@types/ember__routing': await latestVersion('@types/ember__routing'),
+    '@types/ember__runloop': await latestVersion('@types/ember__runloop'),
+    '@types/ember__service': await latestVersion('@types/ember__service'),
+    '@types/ember__string': await latestVersion('@types/ember__string'),
+    '@types/ember__template': await latestVersion('@types/ember__template'),
+    '@types/ember__test': await latestVersion('@types/ember__test'),
+    '@types/ember__utils': await latestVersion('@types/ember__utils'),
+  };
+
   return {
     useYarn: true,
     scenarios: [
@@ -46,11 +74,12 @@ module.exports = async function () {
         npm: {
           devDependencies: {
             'ember-source': '~4.4.0',
+            ...atTypes,
           },
         },
       },
       {
-        name: 'ember-lts-4.8',
+        name: 'ember-lts-4.8', // preview types introduced
         npm: {
           devDependencies: {
             'ember-source': '~4.8.0',

--- a/addon/tests/dummy/config/ember-try.js
+++ b/addon/tests/dummy/config/ember-try.js
@@ -42,14 +42,6 @@ module.exports = async function () {
     useYarn: true,
     scenarios: [
       {
-        name: 'ember-lts-5.0',
-        npm: {
-          devDependencies: {
-            'ember-source': '~5.0.0',
-          },
-        },
-      },
-      {
         name: 'ember-lts-4.4',
         npm: {
           devDependencies: {
@@ -62,6 +54,14 @@ module.exports = async function () {
         npm: {
           devDependencies: {
             'ember-source': '~4.8.0',
+          },
+        },
+      },
+      {
+        name: 'ember-lts-5.0',
+        npm: {
+          devDependencies: {
+            'ember-source': '~5.0.0',
           },
         },
       },

--- a/addon/tests/dummy/config/ember-try.js
+++ b/addon/tests/dummy/config/ember-try.js
@@ -42,6 +42,14 @@ module.exports = async function () {
     useYarn: true,
     scenarios: [
       {
+        name: 'ember-lts-5.0',
+        npm: {
+          devDependencies: {
+            'ember-source': '~5.0.0',
+          },
+        },
+      },
+      {
         name: 'ember-lts-4.4',
         npm: {
           devDependencies: {


### PR DESCRIPTION
With this change, CI for this package will detect issues caused by "breaking" differences between `@types` packages, ember preview types, and ember stable types.