### PR TITLE
adds new workflow file to provide release branches

### DIFF
--- a/.github/workflows/push-dist.yml
+++ b/.github/workflows/push-dist.yml
@@ -16,7 +16,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: volta-cli/action@v4
       - run: yarn install --frozen-lockfile --ignore-engines
-      - run: npm run build # Add whatever you need to build your pacakage here
       - uses: kategengler/put-built-npm-package-contents-on-branch@v1.0.0
         with:
           branch: ${{ github.head_ref || github.ref_name }}-dist

--- a/.github/workflows/push-dist.yml
+++ b/.github/workflows/push-dist.yml
@@ -1,0 +1,21 @@
+# .github/workflows/push-dist.yml
+
+name: Push dist
+
+on:
+  push:
+    branches:
+      - main
+      - master
+
+jobs:
+  push-dist:
+    name: Push dist
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: npm run build # Add whatever you need to build your pacakage here
+      - uses: kategengler/put-built-npm-package-contents-on-branch@v1.0.0
+        with:
+          branch: ${{ github.head_ref || github.ref_name }}-dist
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/push-dist.yml
+++ b/.github/workflows/push-dist.yml
@@ -14,6 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: volta-cli/action@v4
+      - run: yarn install --frozen-lockfile --ignore-engines
       - run: npm run build # Add whatever you need to build your pacakage here
       - uses: kategengler/put-built-npm-package-contents-on-branch@v1.0.0
         with:


### PR DESCRIPTION
If merged, this PR adds https://github.com/kategengler/put-built-npm-package-contents-on-branch/ which should provide a little extra confidence for folks doing new releases (especially as we add new maintainers and update packages to use the v2/embroider guidance). 

Still need to confirm some of the config settings but after that I will mark it ready for review.