### PR TITLE
Update addon/.gitignore

### DIFF
--- a/addon/.gitignore
+++ b/addon/.gitignore
@@ -1,7 +1,7 @@
 # tyescript related output files
 addon-test-support/**/*.js
 addon-test-support/**/*.d.ts
-public-types
+dist-types
 
 # Other build artifacts
 README.md


### PR DESCRIPTION
In #1408 I should have caught that we now use `dist-types` instead of `public-types`, so updating the `.gitignore` to reflect that change. 