### PR TITLE
(backport) bugfix: handle `null` and `undefined` in `setProperties`

### DIFF
--- a/addon-test-support/@ember/test-helpers/setup-context.ts
+++ b/addon-test-support/@ember/test-helpers/setup-context.ts
@@ -464,14 +464,20 @@ export default function setupContext<T extends object>(
                 'You cannot call `this.setProperties` when passing a component to `render()` (the rendered component does not have access to the test context)'
               );
             } else {
-              let setCalls = SetUsage.get(context);
+              // While neither the types nor the API documentation indicate that passing `null` or
+              // `undefined` to `setProperties` is allowed, it works and *has worked* for a long
+              // time, so there is considerable real-world code which relies on the fact that it
+              // does in fact work. Checking and no-op-ing here handles that.
+              if (hash != null) {
+                let setCalls = SetUsage.get(context);
 
-              if (SetUsage.get(context) === undefined) {
-                setCalls = [];
-                SetUsage.set(context, setCalls);
+                if (SetUsage.get(context) === undefined) {
+                  setCalls = [];
+                  SetUsage.set(context, setCalls);
+                }
+
+                setCalls?.push(...Object.keys(hash));
               }
-
-              setCalls?.push(...Object.keys(hash));
             }
             return setProperties(context, hash);
           });

--- a/tests/unit/setup-context-test.js
+++ b/tests/unit/setup-context-test.js
@@ -116,6 +116,28 @@ module('setupContext', function (hooks) {
         );
       });
 
+      test('this.setProperties handles `null` and `undefined` (back-compat only!)', function (assert) {
+        assert.expect(3);
+
+        context.setProperties();
+        assert.ok(
+          true,
+          'this.setProperties works with no args (for back-compat only)'
+        );
+
+        context.setProperties(null);
+        assert.ok(
+          true,
+          'this.setProperties works with `null` (for back-compat only)'
+        );
+
+        context.setProperties(undefined);
+        assert.ok(
+          true,
+          'this.setProperties works with `undefined` (for back-compat only)'
+        );
+      });
+
       test('it sets up this.get', function (assert) {
         context.set('foo', 'bar');
 


### PR DESCRIPTION
Backport #1417 to v2.x:

> This implicitly worked for as long as `this.setProperties` existed, because it ultimately forwards to Ember's `setProperties`, which also implicitly works with this. Although this is not public API, and indeed is not desirable, changing it (implicitly and accidentally!) will break many consumers who are relying on it (most likely to end up happening transitively, e.g. via local/custom test helpers).
