### PR TITLE
Don't swallow deprecations and warnings when there is no test context: backport to v2

### DIFF
--- a/addon-test-support/@ember/test-helpers/setup-context.ts
+++ b/addon-test-support/@ember/test-helpers/setup-context.ts
@@ -39,6 +39,7 @@ import {
 registerDeprecationHandler((message, options, next) => {
   const context = getContext();
   if (context === undefined) {
+    next.apply(null, [message, options]);
     return;
   }
 
@@ -53,6 +54,7 @@ registerDeprecationHandler((message, options, next) => {
 registerWarnHandler((message, options, next) => {
   const context = getContext();
   if (context === undefined) {
+    next.apply(null, [message, options]);
     return;
   }
 


### PR DESCRIPTION
This fix https://github.com/emberjs/ember-test-helpers/pull/1320 has been available for `@ember/test-helpers` v3 only, which is only compatible with Ember 4+.

The bug fixed is affecting Ember 3 apps and addons, so we need to backport it.

CC @kategengler 