### PR TITLE
Fix ci due to floating deps

### DIFF
--- a/addon/addon-test-support/@ember/test-helpers/dom/fill-in.ts
+++ b/addon/addon-test-support/@ember/test-helpers/dom/fill-in.ts
@@ -30,62 +30,63 @@ registerHook('fillIn', 'start', (target: Target, text: string) => {
 
   fillIn('input', 'hello world');
 */
-export default function fillIn(target: Target, text: string): Promise<void> {
-  return Promise.resolve()
-    .then(() => runHooks('fillIn', 'start', target, text))
-    .then(() => {
-      if (!target) {
+export default async function fillIn(
+  target: Target,
+  text: string
+): Promise<void> {
+  await Promise.resolve();
+  await runHooks('fillIn', 'start', target, text);
+
+  let element = await (async () => {
+    if (!target) {
+      throw new Error(
+        'Must pass an element, selector, or descriptor to `fillIn`.'
+      );
+    }
+
+    let element = getElement(target) as Element | HTMLElement;
+    if (!element) {
+      let description = getDescription(target);
+      throw new Error(
+        `Element not found when calling \`fillIn('${description}')\`.`
+      );
+    }
+
+    if (typeof text === 'undefined' || text === null) {
+      throw new Error('Must provide `text` when calling `fillIn`.');
+    }
+
+    if (isFormControl(element)) {
+      if (element.disabled) {
         throw new Error(
-          'Must pass an element, selector, or descriptor to `fillIn`.'
+          `Can not \`fillIn\` disabled '${getDescription(target)}'.`
         );
       }
 
-      let element = getElement(target) as Element | HTMLElement;
-      if (!element) {
-        let description = getDescription(target);
+      if ('readOnly' in element && element.readOnly) {
         throw new Error(
-          `Element not found when calling \`fillIn('${description}')\`.`
+          `Can not \`fillIn\` readonly '${getDescription(target)}'.`
         );
       }
 
-      if (typeof text === 'undefined' || text === null) {
-        throw new Error('Must provide `text` when calling `fillIn`.');
-      }
+      guardForMaxlength(element, text, 'fillIn');
 
-      if (isFormControl(element)) {
-        if (element.disabled) {
-          throw new Error(
-            `Can not \`fillIn\` disabled '${getDescription(target)}'.`
-          );
-        }
+      await __focus__(element);
+      (element as FormControl).value = text;
+      return element;
+    } else if (isContentEditable(element)) {
+      await __focus__(element);
+      element.innerHTML = text;
+      return element;
+    } else {
+      throw new Error(
+        '`fillIn` is only usable on form controls or contenteditable elements.'
+      );
+    }
+  })();
 
-        if ('readOnly' in element && element.readOnly) {
-          throw new Error(
-            `Can not \`fillIn\` readonly '${getDescription(target)}'.`
-          );
-        }
-
-        guardForMaxlength(element, text, 'fillIn');
-
-        return __focus__(element).then(() => {
-          (element as FormControl).value = text;
-          return element;
-        });
-      } else if (isContentEditable(element)) {
-        return __focus__(element).then(() => {
-          element.innerHTML = text;
-          return element as Element;
-        });
-      } else {
-        throw new Error(
-          '`fillIn` is only usable on form controls or contenteditable elements.'
-        );
-      }
-    })
-    .then((element) =>
-      fireEvent(element, 'input')
-        .then(() => fireEvent(element, 'change'))
-        .then(settled)
-    )
-    .then(() => runHooks('fillIn', 'end', target, text));
+  await fireEvent(element, 'input');
+  await fireEvent(element, 'change');
+  await settled();
+  await runHooks('fillIn', 'end', target, text);
 }


### PR DESCRIPTION
~~Unblocks: https://github.com/emberjs/ember-test-helpers/pull/1449~~
(takes a different approach from the above)

Resolves this problem on the main branch: 

```bash
❯ yarn install --no-lockfile
❯ yarn lint:ts
yarn run v1.22.19
$ tsc --noEmit && tsc --noEmit --project type-tests
addon-test-support/@ember/test-helpers/dom/fill-in.ts:36:11 - error TS2345: Argument of type '() => Promise<HTMLInputElement | HTMLButtonElement | HTMLSelectElement | HTMLTextAreaElement> | Promise<...>' is not assignable to parameter of type '(value: void) => HTMLInputElement | HTMLButtonElement | HTMLSelectElement | HTMLTextAreaElement | PromiseLike<...>'.
  Type 'Promise<HTMLInputElement | HTMLButtonElement | HTMLSelectElement | HTMLTextAreaElement> | Promise<...>' is not assignable to type 'HTMLInputElement | HTMLButtonElement | HTMLSelectElement | HTMLTextAreaElement | PromiseLike<HTMLInputElement | HTMLButtonElement | HTMLSelectElement | HTMLTextAreaElement>'.
    Type 'Promise<HTMLElementContentEditable>' is not assignable to type 'HTMLInputElement | HTMLButtonElement | HTMLSelectElement | HTMLTextAreaElement | PromiseLike<HTMLInputElement | HTMLButtonElement | HTMLSelectElement | HTMLTextAreaElement>'.
      Type 'Promise<HTMLElementContentEditable>' is not assignable to type 'PromiseLike<HTMLInputElement | HTMLButtonElement | HTMLSelectElement | HTMLTextAreaElement>'.
        Types of property 'then' are incompatible.
          Type '<TResult1 = HTMLElementContentEditable, TResult2 = never>(onfulfilled?: ((value: HTMLElementContentEditable) => TResult1 | PromiseLike<TResult1>) | null | undefined, onrejected?: ((reason: any) => TResult2 | PromiseLike<...>) | ... 1 more ... | undefined) => Promise<...>' is not assignable to type '<TResult1 = HTMLInputElement | HTMLButtonElement | HTMLSelectElement | HTMLTextAreaElement, TResult2 = never>(onfulfilled?: ((value: HTMLInputElement | ... 2 more ... | HTMLTextAreaElement) => TResult1 | PromiseLike<...>) | ... 1 more ... | undefined, onrejected?: ((reason: any) => TResult2 | PromiseLike<...>) | ......'.
            Types of parameters 'onfulfilled' and 'onfulfilled' are incompatible.
              Types of parameters 'value' and 'value' are incompatible.
                Type 'HTMLElementContentEditable' is not assignable to type 'HTMLInputElement | HTMLButtonElement | HTMLSelectElement | HTMLTextAreaElement'.
                  Type 'HTMLElementContentEditable' is missing the following properties from type 'HTMLTextAreaElement': autocomplete, cols, defaultValue, dirName, and 26 more.

36     .then(() => {
             ~~~~~~~


Found 1 error in addon-test-support/@ember/test-helpers/dom/fill-in.ts:36

error Command failed with exit code 2.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

TS couldn't figure out how to type element with the promise chain, and fireEvent  was being passed an element with invalid type -- with the refactor, it now narrows correctly, and element is appropriately narrowed for fireEvent