### PR TITLE
Fix: You attempted to render a path ({{model.post_id}}), but model was not in scope:

### DIFF
--- a/addon/tests/unit/setup-application-context-test.js
+++ b/addon/tests/unit/setup-application-context-test.js
@@ -78,7 +78,7 @@ module('setupApplicationContext', function (hooks) {
             {{outlet}}
           `,
         'template:links-to-slow': hbs`{{#link-to "slow" class="to-slow"}}to slow{{/link-to}}`,
-        'template:posts/post': hbs`<div class="post-id">{{model.post_id}}</div>`,
+        'template:posts/post': hbs`<div class="post-id">{{this.model.post_id}}</div>`,
       };
     }
 


### PR DESCRIPTION

Extracted from: https://github.com/emberjs/ember-test-helpers/pull/1450


Example of the failure in CI on main: https://github.com/emberjs/ember-test-helpers/actions/runs/10014604943/job/27684657206#step:5:582