### PR TITLE
correct git clone url for the repo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## Installation
 
-* `git clone <repository-url>`
+* `git clone https://github.com/emberjs/ember-test-helpers.git`
 * `cd ember-test-helpers`
 * `yarn install`
 


### PR DESCRIPTION
Fixes #1461 

Fix the git clone url in `CONTRIBUTING.md` file