### PR TITLE
Use the right attribute - `maxlength` instead of `maxLength`

### DIFF
--- a/addon/addon-test-support/@ember/test-helpers/dom/-guard-for-maxlength.ts
+++ b/addon/addon-test-support/@ember/test-helpers/dom/-guard-for-maxlength.ts
@@ -19,7 +19,7 @@ function isMaxLengthConstrained(
   element: Element
 ): element is HTMLInputElement | HTMLTextAreaElement {
   return (
-    !!Number(element.getAttribute('maxLength')) &&
+    !!Number(element.getAttribute('maxlength')) &&
     (element instanceof HTMLTextAreaElement ||
       (element instanceof HTMLInputElement &&
         constrainedInputTypes.indexOf(element.type) > -1))


### PR DESCRIPTION
Fixes #1459 

Issue: `maxLength` attribute is being read instead of the correct `maxlength` attribute.