### PR TITLE
Re-enable try scenarios against 5.10, 5.11-beta and 5.12-canary

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -91,10 +91,9 @@ jobs:
           - ember-lts-4.12
           - ember-lts-5.4
           - ember-lts-5.8
-          # All of these are failing with the waiter tests (needs to be debugged separately)
-          # - ember-release
-          # - ember-beta
-          # - ember-canary
+          - ember-release
+          - ember-beta
+          - ember-canary
           - ember-default
           - embroider-safe
           # - embroider-optimized # see comments in ember-try.js


### PR DESCRIPTION
I need to figure out what went wrong in ember-source, so here is step one -- see what tests were failing

Blocked by: https://github.com/emberjs/ember-test-helpers/pull/1473