### PR TITLE
Get tests passing w/ Chrome's new selectionchange event behavior

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -37,6 +37,9 @@ jobs:
           cache: pnpm
       - name: Install Dependencies
         run: pnpm install 
+      - run: |
+          google-chrome --version
+
       - name: Build addon
         working-directory: addon
         run: pnpm build

--- a/test-app/tests/helpers/browser-detect.js
+++ b/test-app/tests/helpers/browser-detect.js
@@ -1,4 +1,7 @@
 export const isEdge = navigator.userAgent.indexOf('Edge') >= 0;
 
-// Unlike Chrome, Firefox emits `selectionchange` events.
+// Firefox emits `selectionchange` events.
 export const isFirefox = navigator.userAgent.indexOf('Firefox') >= 0;
+
+// Chrome emits `selectionchange` events.
+export const isChrome = navigator.userAgent.indexOf('Chrome') >= 0;

--- a/test-app/tests/unit/dom/blur-test.js
+++ b/test-app/tests/unit/dom/blur-test.js
@@ -7,7 +7,7 @@ import {
   registerHook,
 } from '@ember/test-helpers';
 import { buildInstrumentedElement, insertElement } from '../../helpers/events';
-import { isEdge } from '../../helpers/browser-detect';
+import { isEdge, isChrome } from '../../helpers/browser-detect';
 import hasEmberVersion from '@ember/test-helpers/has-ember-version';
 import { createDescriptor } from 'dom-element-descriptors';
 
@@ -16,6 +16,10 @@ let blurSteps = ['blur', 'focusout'];
 
 if (isEdge) {
   blurSteps = ['focusout', 'blur'];
+}
+
+if (isChrome) {
+  focusSteps.push('selectionchange');
 }
 
 module('DOM Helper: blur', function (hooks) {
@@ -53,7 +57,11 @@ module('DOM Helper: blur', function (hooks) {
   });
 
   test('it executes registered blur hooks', async function (assert) {
-    assert.expect(13);
+    if (isChrome) {
+      assert.expect(15);
+    } else {
+      assert.expect(13);
+    }
 
     let element = document.createElement('input');
     insertElement(element);

--- a/test-app/tests/unit/dom/click-test.js
+++ b/test-app/tests/unit/dom/click-test.js
@@ -200,14 +200,7 @@ module('DOM Helper: click', function (hooks) {
   });
 
   module('focusable element types', function () {
-    let clickSteps = [
-      'mousedown',
-      'focus',
-      'focusin',
-      'selectionchange',
-      'mouseup',
-      'click',
-    ];
+    let clickSteps = ['mousedown', 'focus', 'focusin', 'mouseup', 'click'];
 
     test('clicking a input via selector with context set', async function (assert) {
       element = buildInstrumentedElement('input');

--- a/test-app/tests/unit/dom/click-test.js
+++ b/test-app/tests/unit/dom/click-test.js
@@ -6,6 +6,7 @@ import {
   insertElement,
 } from '../../helpers/events';
 import hasEmberVersion from '@ember/test-helpers/has-ember-version';
+import { isChrome } from '../../helpers/browser-detect';
 import {
   registerHooks,
   unregisterHooks,
@@ -202,6 +203,17 @@ module('DOM Helper: click', function (hooks) {
   module('focusable element types', function () {
     let clickSteps = ['mousedown', 'focus', 'focusin', 'mouseup', 'click'];
 
+    if (isChrome) {
+      clickSteps = [
+        'mousedown',
+        'focus',
+        'focusin',
+        'mouseup',
+        'click',
+        'selectionchange',
+      ];
+    }
+
     test('clicking a input via selector with context set', async function (assert) {
       element = buildInstrumentedElement('input');
 
@@ -297,7 +309,17 @@ module('DOM Helper: click', function (hooks) {
 
       await click(child);
 
-      assert.verifySteps(clickSteps);
+      if (isChrome) {
+        assert.verifySteps([
+          'mousedown',
+          'focus',
+          'focusin',
+          'mouseup',
+          'click',
+        ]);
+      } else {
+        assert.verifySteps(clickSteps);
+      }
       assert.strictEqual(
         document.activeElement,
         element,
@@ -334,15 +356,28 @@ module('DOM Helper: click', function (hooks) {
       await click(focusableElement);
       await click(element);
 
-      assert.verifySteps([
-        'mousedown',
-        'focus',
-        'focusin',
-        'mouseup',
-        'click',
-        'blur',
-        'focusout',
-      ]);
+      if (isChrome) {
+        assert.verifySteps([
+          'mousedown',
+          'focus',
+          'focusin',
+          'mouseup',
+          'click',
+          'selectionchange',
+          'blur',
+          'focusout',
+        ]);
+      } else {
+        assert.verifySteps([
+          'mousedown',
+          'focus',
+          'focusin',
+          'mouseup',
+          'click',
+          'blur',
+          'focusout',
+        ]);
+      }
     });
 
     test('clicking on non-focusable element inside active element does not trigger blur on active element', async function (assert) {
@@ -377,15 +412,28 @@ module('DOM Helper: click', function (hooks) {
       await click(focusableElement);
       await click(element);
 
-      assert.verifySteps([
-        'mousedown',
-        'focus',
-        'focusin',
-        'mouseup',
-        'click',
-        'blur',
-        'focusout',
-      ]);
+      if (isChrome) {
+        assert.verifySteps([
+          'mousedown',
+          'focus',
+          'focusin',
+          'mouseup',
+          'click',
+          'selectionchange',
+          'blur',
+          'focusout',
+        ]);
+      } else {
+        assert.verifySteps([
+          'mousedown',
+          'focus',
+          'focusin',
+          'mouseup',
+          'click',
+          'blur',
+          'focusout',
+        ]);
+      }
     });
 
     test('clicking on non-focusable element does not trigger blur on non-focusable active element', async function (assert) {
@@ -417,7 +465,24 @@ module('DOM Helper: click', function (hooks) {
       await click(focusableElement);
       await click(element);
 
-      assert.verifySteps(['mousedown', 'focus', 'focusin', 'mouseup', 'click']);
+      if (isChrome) {
+        assert.verifySteps([
+          'mousedown',
+          'focus',
+          'focusin',
+          'mouseup',
+          'click',
+          'selectionchange',
+        ]);
+      } else {
+        assert.verifySteps([
+          'mousedown',
+          'focus',
+          'focusin',
+          'mouseup',
+          'click',
+        ]);
+      }
 
       element.removeEventListener('mousedown', preventDefault);
       await click(element);

--- a/test-app/tests/unit/dom/click-test.js
+++ b/test-app/tests/unit/dom/click-test.js
@@ -200,7 +200,14 @@ module('DOM Helper: click', function (hooks) {
   });
 
   module('focusable element types', function () {
-    let clickSteps = ['mousedown', 'focus', 'focusin', 'mouseup', 'click'];
+    let clickSteps = [
+      'mousedown',
+      'focus',
+      'focusin',
+      'selectionchange',
+      'mouseup',
+      'click',
+    ];
 
     test('clicking a input via selector with context set', async function (assert) {
       element = buildInstrumentedElement('input');

--- a/test-app/tests/unit/dom/fill-in-test.js
+++ b/test-app/tests/unit/dom/fill-in-test.js
@@ -314,7 +314,11 @@ module('DOM Helper: fillIn', function (hooks) {
     await fillIn(`#${element.id}`, '');
 
     // For this specific case, Firefox does not emit `selectionchange`.
-    assert.verifySteps(clickSteps.filter((s) => s !== 'selectionchange'));
+    if (isChrome) {
+      assert.verifySteps(clickSteps);
+    } else {
+      assert.verifySteps(clickSteps.filter((s) => s !== 'selectionchange'));
+    }
     assert.strictEqual(
       document.activeElement,
       element,

--- a/test-app/tests/unit/dom/fill-in-test.js
+++ b/test-app/tests/unit/dom/fill-in-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { fillIn, setupContext, teardownContext } from '@ember/test-helpers';
 import { buildInstrumentedElement, insertElement } from '../../helpers/events';
-import { isFirefox } from '../../helpers/browser-detect';
+import { isFirefox, isChrome } from '../../helpers/browser-detect';
 import hasEmberVersion from '@ember/test-helpers/has-ember-version';
 import {
   registerHooks,
@@ -12,7 +12,7 @@ import { createDescriptor } from 'dom-element-descriptors';
 
 let clickSteps = ['focus', 'focusin', 'input', 'change'];
 
-if (isFirefox) {
+if (isFirefox || isChrome) {
   clickSteps.push('selectionchange');
 }
 
@@ -270,7 +270,7 @@ module('DOM Helper: fillIn', function (hooks) {
     await setupContext(context);
     await fillIn(createDescriptor({ element }), 'foo');
 
-    assert.verifySteps(clickSteps);
+    assert.verifySteps(['focus', 'focusin', 'input', 'change']);
     assert.strictEqual(
       document.activeElement,
       element,

--- a/test-app/tests/unit/dom/fill-in-test.js
+++ b/test-app/tests/unit/dom/fill-in-test.js
@@ -16,6 +16,16 @@ if (isFirefox || isChrome) {
   clickSteps.push('selectionchange');
 }
 
+/**
+ * Prior to Chrome 129 (canary),
+ * Chrome 127.x emits an extra selectionchange event sometimes
+ *
+ * Delete this once we don't want to test against Chrome 127
+ */
+if (isChrome) {
+  clickSteps.push('selectionchange');
+}
+
 module('DOM Helper: fillIn', function (hooks) {
   if (!hasEmberVersion(2, 4)) {
     return;
@@ -313,12 +323,14 @@ module('DOM Helper: fillIn', function (hooks) {
     await setupContext(context);
     await fillIn(`#${element.id}`, '');
 
-    // For this specific case, Firefox does not emit `selectionchange`.
     if (isChrome) {
-      assert.verifySteps(clickSteps);
+      // For this specific case, Chrome 127 doesn't emit two selectionchange events
+      assert.verifySteps([...new Set(clickSteps)]);
     } else {
+      // For this specific case, Firefox does not emit `selectionchange`.
       assert.verifySteps(clickSteps.filter((s) => s !== 'selectionchange'));
     }
+
     assert.strictEqual(
       document.activeElement,
       element,

--- a/test-app/tests/unit/dom/tap-test.js
+++ b/test-app/tests/unit/dom/tap-test.js
@@ -2,6 +2,7 @@ import { module, test } from 'qunit';
 import { tap, setupContext, teardownContext } from '@ember/test-helpers';
 import { buildInstrumentedElement, insertElement } from '../../helpers/events';
 import hasEmberVersion from '@ember/test-helpers/has-ember-version';
+import { isChrome } from '../../helpers/browser-detect';
 import {
   registerHooks,
   unregisterHooks,
@@ -205,6 +206,10 @@ module('DOM Helper: tap', function (hooks) {
       'click',
     ];
 
+    if (isChrome) {
+      tapSteps.push('selectionchange');
+    }
+
     test('tapping a input via selector with context set', async function (assert) {
       element = buildInstrumentedElement('input');
 
@@ -304,17 +309,32 @@ module('DOM Helper: tap', function (hooks) {
       await tap(focusableElement);
       await tap(element);
 
-      assert.verifySteps([
-        'touchstart',
-        'touchend',
-        'mousedown',
-        'focus',
-        'focusin',
-        'mouseup',
-        'click',
-        'blur',
-        'focusout',
-      ]);
+      if (isChrome) {
+        assert.verifySteps([
+          'touchstart',
+          'touchend',
+          'mousedown',
+          'focus',
+          'focusin',
+          'mouseup',
+          'click',
+          'selectionchange',
+          'blur',
+          'focusout',
+        ]);
+      } else {
+        assert.verifySteps([
+          'touchstart',
+          'touchend',
+          'mousedown',
+          'focus',
+          'focusin',
+          'mouseup',
+          'click',
+          'blur',
+          'focusout',
+        ]);
+      }
     });
 
     test('tapping on focusable element triggers blur on active element', async function (assert) {
@@ -327,17 +347,32 @@ module('DOM Helper: tap', function (hooks) {
       await tap(focusableElement);
       await tap(element);
 
-      assert.verifySteps([
-        'touchstart',
-        'touchend',
-        'mousedown',
-        'focus',
-        'focusin',
-        'mouseup',
-        'click',
-        'blur',
-        'focusout',
-      ]);
+      if (isChrome) {
+        assert.verifySteps([
+          'touchstart',
+          'touchend',
+          'mousedown',
+          'focus',
+          'focusin',
+          'mouseup',
+          'click',
+          'selectionchange',
+          'blur',
+          'focusout',
+        ]);
+      } else {
+        assert.verifySteps([
+          'touchstart',
+          'touchend',
+          'mousedown',
+          'focus',
+          'focusin',
+          'mouseup',
+          'click',
+          'blur',
+          'focusout',
+        ]);
+      }
     });
 
     test('tapping on non-focusable element does not trigger blur on non-focusable active element', async function (assert) {

--- a/test-app/tests/unit/dom/type-in-test.js
+++ b/test-app/tests/unit/dom/type-in-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { typeIn, setupContext, teardownContext } from '@ember/test-helpers';
 import { buildInstrumentedElement, insertElement } from '../../helpers/events';
-import { isFirefox } from '../../helpers/browser-detect';
+import { isFirefox, isChrome } from '../../helpers/browser-detect';
 import { debounce } from '@ember/runloop';
 import { Promise } from 'rsvp';
 import hasEmberVersion from '@ember/test-helpers/has-ember-version';
@@ -38,6 +38,30 @@ if (isFirefox) {
   expectedEvents = [
     'focus',
     'focusin',
+    'keydown',
+    'keypress',
+    'input',
+    'keyup',
+    'selectionchange',
+    'keydown',
+    'keypress',
+    'input',
+    'keyup',
+    'selectionchange',
+    'keydown',
+    'keypress',
+    'input',
+    'keyup',
+    'change',
+    'selectionchange',
+  ];
+}
+
+if (isChrome) {
+  expectedEvents = [
+    'focus',
+    'focusin',
+    'selectionchange',
     'keydown',
     'keypress',
     'input',
@@ -333,8 +357,13 @@ module('DOM Helper: typeIn', function (hooks) {
     await assert.rejects(
       typeIn(element, tooLongString).finally(() => {
         // should throw before the second input event (or second keyup for IE)
-        const expectedNumberOfSteps = isFirefox ? 9 : 8;
-        assert.verifySteps(expectedEvents.slice(0, expectedNumberOfSteps));
+        if (isFirefox) {
+          assert.verifySteps(expectedEvents.slice(0, 9));
+        } else if (isChrome) {
+          assert.verifySteps(expectedEvents.slice(0, 10));
+        } else {
+          assert.verifySteps(expectedEvents.slice(0, 8));
+        }
       }),
       new Error("Can not `typeIn` with text: 'fo' that exceeds maxlength: '1'.")
     );
@@ -385,9 +414,13 @@ module('DOM Helper: typeIn', function (hooks) {
 
     await assert.rejects(
       typeIn(element, tooLongString).finally(() => {
-        // should throw before the second input event (or second keyup for IE)
-        const expectedNumberOfSteps = isFirefox ? 9 : 8;
-        assert.verifySteps(expectedEvents.slice(0, expectedNumberOfSteps));
+        if (isFirefox) {
+          assert.verifySteps(expectedEvents.slice(0, 9));
+        } else if (isChrome) {
+          assert.verifySteps(expectedEvents.slice(0, 10));
+        } else {
+          assert.verifySteps(expectedEvents.slice(0, 8));
+        }
       }),
       new Error("Can not `typeIn` with text: 'fo' that exceeds maxlength: '1'.")
     );


### PR DESCRIPTION
Unblocks: https://github.com/emberjs/ember-test-helpers/pull/1470

Last successful build (nightly cron): https://github.com/emberjs/ember-test-helpers/actions/runs/10173407362
Next nightly cron failed: https://github.com/emberjs/ember-test-helpers/actions/runs/10191329093


Findings:

- failures only affect chrome (127.0.6533.99, 127.0.6533.100, (etc?))
  - Chrome Canary (129.0.6658.0) has the same behavior
  - relevant changes https://chromium.googlesource.com/chromium/src/+log/127.0.6533.77..127.0.6533.120?pretty=fuller&n=10000
  - potentially related bug reports
    - https://issues.chromium.org/issues/346898523 
      - but none of them recent: https://issues.chromium.org/issues?q=selectionchange%20created%3E2024-07-30
  - Could this be caused by https://chromestatus.com/feature/5255454895898624 ? 
    - Relates to this: https://w3c.github.io/selection-api/#selectionchange-event
      - which _could_ imply that we _are_ changing the selection range somehow in tests. 
        - I could see this being true for dblclick tests, but not for single click 🤔 
        - We can reproduce lots of `selectionchange` events in this jsbin demo I made: https://jsbin.com/feseyif/edit?html,output
- no failures are present in firefox (129.0.1, 130.0b5)
- no failures are present in safari (7.5 (19618.2.12.11.6))


In the changes in this PR:
- added selection event, where appropriate, conditioned on "isChrome"  
  - of note, if the browser doesn't have focus the order of the keyup and selection change events flip
    - same for the mouseup, click and selectionchange behavior