### PR TITLE
Drop support for TS < 5

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -124,9 +124,6 @@ jobs:
       fail-fast: false
       matrix:
         ts-version:
-          - 4.7
-          - 4.8
-          - 4.9
           - 5.0
           - 5.1
           - 5.2


### PR DESCRIPTION
Extracted from https://github.com/emberjs/ember-test-helpers/pull/1471/commits/6a0c2e4d73cc44d6f262e2c25887e5b6c189c44a

Reason:
 - we want to use modern tooling (and specify extensions in imports), and TS < 5 doesn't support specifying ts extensions in import paths.