### PR TITLE
Don't export checkWaiters

### DIFF
--- a/addon/src/settled.ts
+++ b/addon/src/settled.ts
@@ -3,7 +3,6 @@
 // this type will be `any`.
 import { _backburner } from '@ember/runloop';
 import { Test } from 'ember-testing';
-export const checkWaiters = Test.checkWaiters;
 import { pendingRequests as _internalGetPendingRequestsCount } from 'ember-testing/lib/test/pending_requests';
 
 import { nextTick } from './-utils.ts';
@@ -14,6 +13,7 @@ import type DebugInfo from './-internal/debug-info.ts';
 import { TestDebugInfo } from './-internal/debug-info.ts';
 
 let requests: XMLHttpRequest[];
+const checkWaiters = Test.checkWaiters;
 
 /**
   @private


### PR DESCRIPTION
This was mistakenly exported in https://github.com/emberjs/ember-test-helpers/pull/1486/files#r1744091959

Resolves: https://github.com/emberjs/ember-test-helpers/issues/1502