### PR TITLE
Make test context reusable during a test

### DIFF
--- a/addon/src/setup-context.ts
+++ b/addon/src/setup-context.ts
@@ -7,7 +7,7 @@ import type { Resolver } from '@ember/owner';
 import { setOwner } from '@ember/application';
 
 import buildOwner, { type Owner } from './build-owner.ts';
-import { _setupAJAXHooks, _teardownAJAXHooks } from './settled.ts';
+import { _setupAJAXHooks } from './settled.ts';
 import { _prepareOnerror } from './setup-onerror.ts';
 import Ember from 'ember';
 import {
@@ -19,10 +19,6 @@ import global from './global.ts';
 import { getResolver } from './resolver.ts';
 import { getApplication } from './application.ts';
 import getTestMetadata from './test-metadata.ts';
-import {
-  registerDestructor,
-  associateDestroyableChild,
-} from '@ember/destroyable';
 import {
   getDeprecationsForContext,
   getDeprecationsDuringCallbackForContext,
@@ -212,20 +208,6 @@ export function resumeTest(): void {
 }
 
 /**
-  @private
-  @param {Object} context the test context being cleaned up
-*/
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-function cleanup(context: BaseContext) {
-  _teardownAJAXHooks();
-
-  // SAFETY: this is intimate API *designed* for us to override.
-  (Ember as any).testing = false;
-
-  unsetContext();
-}
-
-/**
  * Returns deprecations which have occurred so far for a the current test context
  *
  * @public
@@ -410,8 +392,6 @@ export default function setupContext<T extends object>(
 
   _backburner.DEBUG = true;
 
-  registerDestructor(context, cleanup);
-
   _prepareOnerror(context);
 
   return Promise.resolve()
@@ -438,8 +418,6 @@ export default function setupContext<T extends object>(
       return buildOwner(getApplication(), getResolver());
     })
     .then((owner) => {
-      associateDestroyableChild(context, owner);
-
       Object.defineProperty(context, 'owner', {
         configurable: true,
         enumerable: true,

--- a/addon/src/teardown-context.ts
+++ b/addon/src/teardown-context.ts
@@ -1,5 +1,7 @@
 import type { TestContext } from './setup-context';
-import settled from './settled.ts';
+import Ember from 'ember';
+import { unsetContext } from './setup-context.ts';
+import settled, { _teardownAJAXHooks } from './settled.ts';
 import { _cleanupOnerror } from './setup-onerror.ts';
 import { destroy } from '@ember/destroyable';
 
@@ -30,7 +32,14 @@ export default function teardownContext(
     .then(() => {
       _cleanupOnerror(context);
 
-      destroy(context);
+      _teardownAJAXHooks();
+
+      // SAFETY: this is intimate API *designed* for us to override.
+      (Ember as any).testing = false;
+
+      unsetContext();
+
+      destroy(context.owner);
     })
     .finally(() => {
       if (waitForSettled) {

--- a/test-app/tests/unit/dom/fill-in-test.js
+++ b/test-app/tests/unit/dom/fill-in-test.js
@@ -16,16 +16,6 @@ if (isFirefox || isChrome) {
   clickSteps.push('selectionchange');
 }
 
-/**
- * Prior to Chrome 129 (canary),
- * Chrome 127.x emits an extra selectionchange event sometimes
- *
- * Delete this once we don't want to test against Chrome 127
- */
-if (isChrome) {
-  clickSteps.push('selectionchange');
-}
-
 module('DOM Helper: fillIn', function (hooks) {
   if (!hasEmberVersion(2, 4)) {
     return;

--- a/test-app/tests/unit/setup-application-context-test.js
+++ b/test-app/tests/unit/setup-application-context-test.js
@@ -257,4 +257,17 @@ module('setupApplicationContext', function (hooks) {
       'after click resolved',
     ]);
   });
+
+  test('can reset context during a test', async function (assert) {
+    await visit('/');
+    assert.equal(currentURL(), '/');
+
+    await teardownContext(this);
+    await setupContext(this);
+    await setupApplicationContext(this);
+    assert.equal(currentURL(), null);
+
+    await visit('/');
+    assert.equal(currentURL(), '/');
+  });
 });

--- a/test-app/tests/unit/setup-context-test.js
+++ b/test-app/tests/unit/setup-context-test.js
@@ -943,5 +943,19 @@ module('setupContext', function (hooks) {
         }
       }
     });
+
+    test('can reset context during a test', async function (assert) {
+      assert.expect(1);
+
+      let context = await setupContext({});
+      try {
+        await teardownContext(context);
+        context = await setupContext(context);
+      } finally {
+        await teardownContext(context);
+      }
+
+      assert.ok(true, 'No error calling setupContext after teardownContext');
+    });
   });
 });

--- a/test-app/tests/unit/teardown-context-test.js
+++ b/test-app/tests/unit/teardown-context-test.js
@@ -15,7 +15,6 @@ import hasjQuery from '../helpers/has-jquery';
 import ajax from '../helpers/ajax';
 import Pretender from 'pretender';
 import setupManualTestWaiter from '../helpers/manual-test-waiter';
-import { registerDestructor } from '@ember/destroyable';
 
 module('teardownContext', function (hooks) {
   if (!hasEmberVersion(2, 4)) {

--- a/test-app/tests/unit/teardown-context-test.js
+++ b/test-app/tests/unit/teardown-context-test.js
@@ -65,28 +65,17 @@ module('teardownContext', function (hooks) {
     assert.strictEqual(getContext(), undefined, 'context is unset');
   });
 
-  test('destroyables registered with the context are invoked', async function (assert) {
-    registerDestructor(context, () => {
-      assert.step('destructor was ran');
-    });
-
-    assert.step('teardown started');
-
-    await teardownContext(context);
-
-    assert.step('teardown completed');
-
-    assert.verifySteps([
-      'teardown started',
-      'destructor was ran',
-      'teardown completed',
-    ]);
-  });
-
   test('the owner is destroyed', async function (assert) {
     await teardownContext(context);
 
     assert.ok(context.owner.isDestroyed);
+  });
+
+  test('the context is not destroyed', async function (assert) {
+    await teardownContext(context);
+
+    assert.ok(context.owner.isDestroyed);
+    assert.notOk(context.isDestroyed);
   });
 
   test('the application instance is destroyed and unwatched', async function (assert) {


### PR DESCRIPTION
In v2.0.0 @ember/test-helpers refactored to use `@ember/destroyable` for teardown which also meant
that the application context was destroyed during teardown, where previously it was only cleaned up
and the application (`context.owner`) was destroyed.

In our application tests we simulate a page refresh by calling `teardownContext` and
`setupContext`. The destroyable change broke this functionality because the context is now marked
as destroyed.

This commit effectively reverts the change to use `@ember/destroyable` and adds tests to ensure that
the context is not destroyed so that it can be reset during a test.

This addresses https://github.com/emberjs/ember-test-helpers/issues/1452 raised by @mixonic 

The @ember/destroyable change was made in #914 