### PR TITLE
[CLEANUP] remove manually annoted legacy code

### DIFF
--- a/addon/src/-internal/build-registry.ts
+++ b/addon/src/-internal/build-registry.ts
@@ -100,9 +100,6 @@ export default function buildRegistry(resolver: Resolver) {
 
   // @ts-ignore: this is private API.
   const fallbackRegistry = Application.buildRegistry(namespace);
-  // TODO: only do this on Ember < 3.13
-  // @ts-ignore: this is private API.
-  fallbackRegistry.register('component-lookup:main', Ember.ComponentLookup);
 
   // @ts-ignore: this is private API.
   const registry = new Ember.Registry({

--- a/test-app/tests/integration/settled-test.js
+++ b/test-app/tests/integration/settled-test.js
@@ -1,6 +1,6 @@
-import Ember from 'ember';
 import { later, run } from '@ember/runloop';
 import Component from '@ember/component';
+import { registerWaiter, unregisterWaiter } from '@ember/test';
 import {
   settled,
   setupContext,
@@ -95,14 +95,7 @@ const TestComponent5 = Component.extend({
 
   init() {
     this._super.apply(this, arguments);
-    // In Ember < 2.8 `registerWaiter` expected to be bound to
-    // `Ember.Test` 😭
-    //
-    // Once we have dropped support for < 2.8 we should swap this to
-    // use:
-    //
-    // import { registerWaiter } from '@ember/test';
-    Ember.Test.registerWaiter(this, this.isReady);
+    registerWaiter(this, this.isReady);
     later(() => {
       this.setProperties({
         internalValue: 'async value',
@@ -113,8 +106,7 @@ const TestComponent5 = Component.extend({
 
   willDestroy() {
     this._super.apply(this, arguments);
-    // must be called with `Ember.Test` as context for Ember < 2.8
-    Ember.Test.unregisterWaiter(this, this.isReady);
+    unregisterWaiter(this, this.isReady);
   },
 });
 


### PR DESCRIPTION
These are slightly riskier in that you'd have to take the comment author's word for it, as the proposed code was never execrised or tested in the real world (unlike in #20798, where, if there were no bugs in the branchgin, we should have been running the correct branch all along and for a while now).

But I manually audited these spots and to my knowledge they seemed safe.