### PR TITLE
Add `force` argument to `triggerEvent`

### DIFF
--- a/addon/src/dom/trigger-event.ts
+++ b/addon/src/dom/trigger-event.ts
@@ -18,6 +18,7 @@ registerHook('triggerEvent', 'start', (target: Target, eventType: string) => {
  * @param {string|Element|IDOMElementDescriptor} target the element, selector, or descriptor to trigger the event on
  * @param {string} eventType the type of event to trigger
  * @param {Object} options additional properties to be set on the event
+ * @param {boolean} force if true, will bypass availability checks (false by default)
  * @return {Promise<void>} resolves when the application is settled
  *
  * @example
@@ -58,6 +59,7 @@ export default function triggerEvent(
   target: Target,
   eventType: string,
   options?: Record<string, unknown>,
+  force: boolean = false,
 ): Promise<void> {
   return Promise.resolve()
     .then(() => {
@@ -82,7 +84,7 @@ export default function triggerEvent(
         );
       }
 
-      if (isFormControl(element) && element.disabled) {
+      if (!force && isFormControl(element) && element.disabled) {
         throw new Error(`Can not \`triggerEvent\` on disabled ${element}`);
       }
 

--- a/test-app/tests/unit/dom/trigger-event-test.js
+++ b/test-app/tests/unit/dom/trigger-event-test.js
@@ -177,6 +177,24 @@ module('DOM Helper: triggerEvent', function (hooks) {
     );
   });
 
+  test('allows triggering events on disabled form control when `force` is true', async function (assert) {
+    element = buildInstrumentedElement('textarea');
+    element.setAttribute('disabled', true);
+
+    element.addEventListener('fliberty', (e) => {
+      assert.step('fliberty');
+      assert.ok(
+        e instanceof Event,
+        `fliberty listener receives a native event`
+      );
+    });
+
+    await setupContext(context);
+    await triggerEvent(element, 'fliberty', {}, true);
+
+    assert.verifySteps(['fliberty']);
+  });
+
   test('events properly bubble upwards', async function (assert) {
     await setupContext(context);
     element = buildInstrumentedElement('div');

--- a/type-tests/api.ts
+++ b/type-tests/api.ts
@@ -122,7 +122,8 @@ expectTypeOf(triggerEvent).toEqualTypeOf<
   (
     target: Target,
     eventType: string,
-    options?: Record<string, unknown>
+    options?: Record<string, unknown>,
+    force?: boolean,
   ) => Promise<void>
 >();
 expectTypeOf(triggerKeyEvent).toEqualTypeOf<


### PR DESCRIPTION
I believe `triggerEvent` is too restrictive if it forbids all events on a form control with the `disabled` attribute. While the specification only mentions "click events" and MDN refers to "browsing events," all browsers currently allow mouse tracking events, such as `mouseenter` and `mouseleave`, to trigger on disabled controls. Additionally, there are events unrelated to user interaction, like `transitionend` and `animationend`.  

Beyond known events, there's also the case of `CustomEvent`, which is entirely valid in browsers but is currently blocked by `triggerEvent`.  

Maintaining a comprehensive list of forbidden or allowed events might not be practical or sustainable. However, I suggest providing testers with an option to trigger events on disabled elements if necessary.

This PR allows to bypass the availability check on a `disabled` form control using the `force` argument.