### PR TITLE
Cleanup some private API and now-unsupported usage

### DIFF
--- a/addon/src/-internal/build-registry.ts
+++ b/addon/src/-internal/build-registry.ts
@@ -3,7 +3,6 @@ import ApplicationInstance from '@ember/application/instance';
 import Application from '@ember/application';
 import EmberObject from '@ember/object';
 import { Registry } from '@ember/-internals/container';
-import { ComponentLookup } from '@ember/-internals/views';
 
 import type { FullName } from '@ember/owner';
 
@@ -97,9 +96,6 @@ export default function buildRegistry(resolver: Resolver) {
 
   // @ts-ignore: this is private API.
   const fallbackRegistry = Application.buildRegistry(namespace);
-  // TODO: only do this on Ember < 3.13
-  // @ts-ignore: this is private API.
-  fallbackRegistry.register('component-lookup:main', ComponentLookup);
 
   const registry = new Registry({
     fallback: fallbackRegistry,

--- a/addon/src/setup-rendering-context.ts
+++ b/addon/src/setup-rendering-context.ts
@@ -12,7 +12,6 @@ import getRootElement from './dom/get-root-element.ts';
 import type { Owner } from './build-owner.ts';
 import getTestMetadata from './test-metadata.ts';
 import { runHooks } from './helper-hooks.ts';
-import hasEmberVersion from './has-ember-version.ts';
 import isComponent from './-internal/is-component.ts';
 
 // the built in types do not provide types for @ember/template-compilation
@@ -171,20 +170,6 @@ export function render(
         },
       };
       toplevelView.setOutletState(outletState);
-
-      // Ember's rendering engine is integration with the run loop so that when a run
-      // loop starts, the rendering is scheduled to be done.
-      //
-      // Ember should be ensuring an instance on its own here (the act of
-      // setting outletState should ensureInstance, since we know we need to
-      // render), but on Ember < 3.23 that is not guaranteed.
-      if (!hasEmberVersion(3, 23)) {
-        // SAFETY: this was correct and type checked on the Ember v3 types, but
-        // since the `run` namespace does not exist in Ember v4, this no longer
-        // can be type checked. When (eventually) dropping support for Ember v3,
-        // and therefore for versions before 3.23, this can be removed entirely.
-        (run as any).backburner.ensureInstance();
-      }
 
       // returning settled here because the actual rendering does not happen until
       // the renderer detects it is dirty (which happens on backburner's end


### PR DESCRIPTION
Private APIs I'm not removing, but _are_ tested in ember.js, so we don't accidentally break:

- Owner-related Mixins: https://github.com/emberjs/ember.js/blob/aedf98854d89887f5779a3ee0d4f0ff2a26a8039/packages/ember/tests/reexports_test.js#L344-L345
- Registry: https://github.com/emberjs/ember.js/blob/aedf98854d89887f5779a3ee0d4f0ff2a26a8039/packages/ember/tests/reexports_test.js#L283
- getOnerror / setOnerror: https://github.com/emberjs/ember.js/blob/aedf98854d89887f5779a3ee0d4f0ff2a26a8039/packages/ember/tests/reexports_test.js#L302


Note: 
- we should have a public API way to build an owner so we can have `@ember/test-helpers` not use private APIs.
  - would allow us to not use the Mixins
- I can delete more, but it would technically be a breaking change for this library, I think
  - we have support for custom registries, custom owners, etc... I don't think this makes sense 
