### PR TITLE
Remove unneeded peers

### DIFF
--- a/addon/package.json
+++ b/addon/package.json
@@ -47,9 +47,6 @@
     "start": "rollup --config --watch --no-watch.clearScreen",
     "test": "echo 'A v2 addon does not have tests, run tests in test-app'"
   },
-  "peerDependencies": {
-    "ember-source": ">= 4.0.0"
-  },
   "dependencies": {
     "@ember/test-waiters": "^3.1.0 || ^4.0.0",
     "@embroider/addon-shim": "^1.8.7",


### PR DESCRIPTION
embroider, auto-import, and ember-cli before them handled virtual deps without a package.json entry.

package.json entries win over virtual deps, so we don't want to declare ember-source or @glimmer/tracking as peers.


Related:
- https://github.com/tracked-tools/tracked-toolbox/pull/211
- https://github.com/emberjs/ember-test-helpers/pull/1543
- https://github.com/NullVoxPopuli/ember-resources/pull/1189
- https://github.com/universal-ember/kolay/pull/187
- https://github.com/universal-ember/reactiveweb/pull/139
- https://github.com/universal-ember/ember-primitives/pull/471
- https://github.com/universal-ember/docs-support/pull/77
