### PR TITLE
Emit fewer modules to optimize vite

### DIFF
--- a/addon/rollup.config.mjs
+++ b/addon/rollup.config.mjs
@@ -34,10 +34,10 @@ export default {
       '-internal/debug-info-helpers.js',
       '-internal/deprecations.js',
       '-internal/is-promise.js',
-      '-internal/test-metadata.js',
       '-internal/warnings.js',
       'dom/-logging.js',
       'settled.js',
+      'test-metadata.js',
     ]),
 
     // Follow the V2 Addon rules about dependencies. Your code can import from


### PR DESCRIPTION
TODO:
- [ ] fix documentation generator


----------

I maintain that we should not _just use_ the default blueprint, unmodified.

Before:
```
❯ du dist/ | wc -l
      21
```

After:
```
❯ du dist/ | wc -l
       7
# This can shrink when we move to the new blueprint setup
```

Ideally:
```
❯ du dist/ | wc -l
       3
```

This translates to 18 fewer modules for vite to optimize -- which (if many libraries start optimizing on their public API entrypoints), should improve the dep optimization speed of vite apps.