### PR TITLE
Ignore TypeScript deprecations in type-test

### DIFF
--- a/type-tests/tsconfig.json
+++ b/type-tests/tsconfig.json
@@ -3,6 +3,7 @@
     // We can't upgrade @tsconfig ember until we only support TS v5+
   "extends": "@tsconfig/ember",
   "compilerOptions": {
+    "ignoreDeprecations": "6.0",
     "baseUrl": ".",
     "paths": {
       "*": [


### PR DESCRIPTION
type-test is failing for the latest version of TypeScript due to deprecated settings in the type-test config.