### PR TITLE
Run settled before destroy()

### DIFF
--- a/addon/src/teardown-context.ts
+++ b/addon/src/teardown-context.ts
@@ -29,6 +29,7 @@ export default function teardownContext(
   { waitForSettled = true }: TeardownContextOptions = {},
 ): Promise<void> {
   return Promise.resolve()
+    .then(settled)
     .then(() => {
       _cleanupOnerror(context);
       _teardownAJAXHooks();


### PR DESCRIPTION
Situation:
- have old code
- do things in constructor instead of deriving data "on page load"
- switch to `@embroider/router`
- tests can sometimes fail now depending on execution order due to registerBundle being async (with waiters! (good)), but not all tests that call the aforementioned constructor are async, and thus wouldn't be doing anything with settled behavior anyway

Solution:
- call await settled before destruction