### PR TITLE
Support RFC#1132, strict-resolver

### DIFF
--- a/addon/src/application.ts
+++ b/addon/src/application.ts
@@ -23,7 +23,7 @@ export function setApplication(application: Application): void {
    * SAFETY: modules is a new API, so older Application
    *         types will not have it.
    */
-  if ((application as any).modules) return;
+  if ((application as any)?.modules) return;
 
   if (!getResolver()) {
     const Resolver = (application as any).Resolver;

--- a/addon/src/application.ts
+++ b/addon/src/application.ts
@@ -16,6 +16,15 @@ let __application__: Application | undefined;
 export function setApplication(application: Application): void {
   __application__ = application;
 
+  /**
+   * For RFC#1132, the strict resolver is not accessible.
+   * It is closed off from extension.
+   *
+   * SAFETY: modules is a new API, so older Application
+   *         types will not have it.
+   */
+  if ((application as any).modules) return;
+
   if (!getResolver()) {
     const Resolver = (application as any).Resolver;
     const resolver = Resolver.create({ namespace: application });

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -55,6 +55,7 @@
     "ember-resolver": "^13.1.0",
     "ember-source": "~5.12.0",
     "ember-source-channel-url": "^3.0.0",
+    "ember-strict-application-resolver": "^0.1.1",
     "ember-template-lint": "^5.7.2",
     "ember-try": "^3.0.0",
     "eslint": "^8.37.0",

--- a/test-app/pnpm-lock.yaml
+++ b/test-app/pnpm-lock.yaml
@@ -93,6 +93,9 @@ importers:
       ember-source-channel-url:
         specifier: ^3.0.0
         version: 3.0.0
+      ember-strict-application-resolver:
+        specifier: ^0.1.1
+        version: 0.1.1(@babel/core@7.29.0)
       ember-template-lint:
         specifier: ^5.7.2
         version: 5.13.0
@@ -2685,6 +2688,9 @@ packages:
     engines: {node: '>= 18.*'}
     peerDependencies:
       '@glimmer/component': ^1.1.2
+
+  ember-strict-application-resolver@0.1.1:
+    resolution: {integrity: sha512-/49JZ2Yk2ggicAGIoFNWcz05llhe2i+/2dpH5Pv1KlwZOBKkqMMJpTKEB4IMg+FjKBiE0r2yxuZzo9Oly9vc1A==}
 
   ember-template-imports@3.4.2:
     resolution: {integrity: sha512-OS8TUVG2kQYYwP3netunLVfeijPoOKIs1SvPQRTNOQX4Pu8xGGBEZmrv0U1YTnQn12Eg+p6w/0UdGbUnITjyzw==}
@@ -9567,6 +9573,14 @@ snapshots:
       - rsvp
       - supports-color
       - webpack
+
+  ember-strict-application-resolver@0.1.1(@babel/core@7.29.0):
+    dependencies:
+      '@embroider/addon-shim': 1.10.2
+      decorator-transforms: 2.3.1(@babel/core@7.29.0)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
 
   ember-template-imports@3.4.2:
     dependencies:

--- a/test-app/tests/unit/application-test.js
+++ b/test-app/tests/unit/application-test.js
@@ -22,13 +22,24 @@ module('application', function (hooks) {
   test('RFC#1132: calling set application does not set resolver if the application has modules = {}', function (assert) {
     class App extends Application {
       modules = {};
+
+      // TODO: This isn't needed once we upgrade to
+      //       a new enough ember that supports this.
+      //       But to support the implementation PR, @ember/test-helpers
+      //       needs to be compatible with modules = {} first for the smoke tests
+      //       to pass in https://github.com/emberjs/ember.js/pull/21303
+      //
+      //       Once the above PR lands, we'll want to wrap this test in a macroCondition
+      buildRegistry() {}
     }
 
-    setApplication(App);
+    setApplication(
+      App.create({ autoboot: false, rootElement: '#ember-testing' })
+    );
 
     let actualResolver = getResolver();
     assert.notOk(actualResolver, 'there is no resolver');
-    assert.deepEqual(getApplication().constructor, application.constructor);
+    assert.deepEqual(getApplication().constructor, App);
   });
 
   test('calling setApplication sets resolver when resolver is unset', function (assert) {

--- a/test-app/tests/unit/application-test.js
+++ b/test-app/tests/unit/application-test.js
@@ -1,3 +1,4 @@
+import Application from '@ember/application';
 import { module, test } from 'qunit';
 import { application, resolver } from '../helpers/resolver';
 import {
@@ -16,6 +17,18 @@ module('application', function (hooks) {
   hooks.afterEach(function () {
     setApplication(application);
     setResolver(resolver);
+  });
+
+  test('RFC#1132: calling set application does not set resolver if the application has modules = {}', function (assert) {
+    class App extends Application {
+      modules = {};
+    }
+
+    setApplication(App);
+
+    let actualResolver = getResolver();
+    assert.notOk(actualResolver, 'there is no resolver');
+    assert.deepEqual(getApplication().constructor, application.constructor);
   });
 
   test('calling setApplication sets resolver when resolver is unset', function (assert) {

--- a/test-app/tests/unit/application-test.js
+++ b/test-app/tests/unit/application-test.js
@@ -1,6 +1,7 @@
 import Application from '@ember/application';
 import { module, test } from 'qunit';
 import { application, resolver } from '../helpers/resolver';
+import ApplicationPolyfill from 'ember-strict-application-resolver';
 import {
   getApplication,
   setApplication,
@@ -31,6 +32,20 @@ module('application', function (hooks) {
       //
       //       Once the above PR lands, we'll want to wrap this test in a macroCondition
       buildRegistry() {}
+    }
+
+    setApplication(
+      App.create({ autoboot: false, rootElement: '#ember-testing' })
+    );
+
+    let actualResolver = getResolver();
+    assert.notOk(actualResolver, 'there is no resolver');
+    assert.deepEqual(getApplication().constructor, App);
+  });
+
+  test('RFC#1132 (polyfilled): calling set application does not set resolver if the application has modules = {}', function (assert) {
+    class App extends ApplicationPolyfill {
+      modules = {};
     }
 
     setApplication(


### PR DESCRIPTION
Unblocks:
- https://github.com/emberjs/ember-test-helpers/blob/6acc00677b33e621bf69b627715d24e1f57b91ad/addon/src/build-owner.ts#L44


--------------------
--------------------

setResolver is called here:
- https://github.com/emberjs/ember-test-helpers/blob/6acc00677b33e621bf69b627715d24e1f57b91ad/addon/src/application.ts#L17
- which just does https://github.com/emberjs/ember-test-helpers/blob/6acc00677b33e621bf69b627715d24e1f57b91ad/addon/src/resolver.ts#L15

usages of getResolver:

- not-important, a re-export: https://github.com/emberjs/ember-test-helpers/blob/6acc00677b33e621bf69b627715d24e1f57b91ad/addon/src/index.ts#L6
- setupContext: https://github.com/emberjs/ember-test-helpers/blob/6acc00677b33e621bf69b627715d24e1f57b91ad/addon/src/setup-context.ts#L413
  - this is not important, because if we pass an application (which we do), the resolver stuff isn't touched: https://github.com/emberjs/ember-test-helpers/blob/6acc00677b33e621bf69b627715d24e1f57b91ad/addon/src/build-owner.ts#L44