### PR TITLE
Cleanup code predating Ember v4

### DIFF
--- a/addon/src/setup-application-context.ts
+++ b/addon/src/setup-application-context.ts
@@ -4,21 +4,16 @@ import {
   isTestContext,
   type TestContext,
 } from './setup-context.ts';
-import hasEmberVersion from './has-ember-version.ts';
 import settled from './settled.ts';
 import getTestMetadata from './test-metadata.ts';
 import { runHooks } from './helper-hooks.ts';
-import type Router from '@ember/routing/router';
-import type RouterService from '@ember/routing/router-service';
 import { assert } from '@ember/debug';
 
 export interface ApplicationTestContext extends TestContext {
   element?: Element | null;
 }
 
-const CAN_USE_ROUTER_EVENTS = hasEmberVersion(3, 6);
 let routerTransitionsPending: boolean | null = null;
-const ROUTER = new WeakMap();
 const HAS_SETUP_ROUTER = new WeakMap();
 
 // eslint-disable-next-line require-jsdoc
@@ -35,33 +30,7 @@ export function isApplicationTestContext(
   @returns {(boolean|null)} if there are pending transitions
 */
 export function hasPendingTransitions(): boolean | null {
-  if (CAN_USE_ROUTER_EVENTS) {
-    return routerTransitionsPending;
-  }
-
-  const context = getContext();
-
-  // there is no current context, we cannot check
-  if (context === undefined) {
-    return null;
-  }
-
-  const router = ROUTER.get(context);
-
-  if (router === undefined) {
-    // if there is no router (e.g. no `visit` calls made yet), we cannot
-    // check for pending transitions but this is explicitly not an error
-    // condition
-    return null;
-  }
-
-  const routerMicrolib = router._routerMicrolib || router.router;
-
-  if (routerMicrolib === undefined) {
-    return null;
-  }
-
-  return !!routerMicrolib.activeTransition;
+  return routerTransitionsPending;
 }
 
 /**
@@ -87,29 +56,19 @@ export function setupRouterSettlednessTracking() {
   HAS_SETUP_ROUTER.set(context, true);
 
   const { owner } = context;
-  let router: Router | RouterService;
-  if (CAN_USE_ROUTER_EVENTS) {
-    // SAFETY: unfortunately we cannot `assert` here at present because the
-    // class is not exported, only the type, since it is not designed to be
-    // sub-classed. The most we can do at present is assert that it at least
-    // *exists* and assume that if it does exist, it is bound correctly.
-    const routerService = owner.lookup('service:router');
-    assert('router service is not set up correctly', !!routerService);
-    router = routerService as RouterService;
 
-    // track pending transitions via the public routeWillChange / routeDidChange APIs
-    // routeWillChange can fire many times and is only useful to know when we have _started_
-    // transitioning, we can then use routeDidChange to signal that the transition has settled
-    router.on('routeWillChange', () => (routerTransitionsPending = true));
-    router.on('routeDidChange', () => (routerTransitionsPending = false));
-  } else {
-    // SAFETY: similarly, this cast cannot be made safer because on the versions
-    // where we fall into this path, this is *also* not an exported class.
-    const mainRouter = owner.lookup('router:main');
-    assert('router:main is not available', !!mainRouter);
-    router = mainRouter as Router;
-    ROUTER.set(context, router);
-  }
+  // SAFETY: unfortunately we cannot `assert` here at present because the
+  // class is not exported, only the type, since it is not designed to be
+  // sub-classed. The most we can do at present is assert that it at least
+  // *exists* and assume that if it does exist, it is bound correctly.
+  const router = owner.lookup('service:router');
+  assert('router service is not set up correctly', !!router);
+
+  // track pending transitions via the public routeWillChange / routeDidChange APIs
+  // routeWillChange can fire many times and is only useful to know when we have _started_
+  // transitioning, we can then use routeDidChange to signal that the transition has settled
+  router.on('routeWillChange', () => (routerTransitionsPending = true));
+  router.on('routeDidChange', () => (routerTransitionsPending = false));
 
   // hook into teardown to reset local settledness state
   const ORIGINAL_WILL_DESTROY = router.willDestroy;
@@ -196,8 +155,6 @@ export function currentRouteName(): string {
   return currentRouteName;
 }
 
-const HAS_CURRENT_URL_ON_ROUTER = hasEmberVersion(2, 13);
-
 /**
   @public
   @returns {string} the applications current url
@@ -211,30 +168,22 @@ export function currentURL(): string {
   }
 
   const router = context.owner.lookup('router:main') as any;
+  const routerCurrentURL = router.currentURL;
 
-  if (HAS_CURRENT_URL_ON_ROUTER) {
-    const routerCurrentURL = router.currentURL;
-
-    // SAFETY: this path is a lie for the sake of the public-facing types. The
-    // framework itself sees this path, but users never do. A user who calls the
-    // API without calling `visit()` will see an `UnrecognizedURLError`, rather
-    // than getting back `null`.
-    if (routerCurrentURL === null) {
-      return routerCurrentURL as never as string;
-    }
-
-    assert(
-      `currentUrl should be a string, but was ${typeof routerCurrentURL}`,
-      typeof routerCurrentURL === 'string',
-    );
-
-    return routerCurrentURL;
-  } else {
-    // SAFETY: this is *positively ancient* and should probably be removed at
-    // some point; old routers which don't have `currentURL` *should* have a
-    // `location` with `getURL()` per the docs for 2.12.
-    return (router.location as any).getURL();
+  // SAFETY: this path is a lie for the sake of the public-facing types. The
+  // framework itself sees this path, but users never do. A user who calls the
+  // API without calling `visit()` will see an `UnrecognizedURLError`, rather
+  // than getting back `null`.
+  if (routerCurrentURL === null) {
+    return routerCurrentURL as never as string;
   }
+
+  assert(
+    `currentUrl should be a string, but was ${typeof routerCurrentURL}`,
+    typeof routerCurrentURL === 'string',
+  );
+
+  return routerCurrentURL;
 }
 
 /**

--- a/test-app/tests/integration/rerender-test.js
+++ b/test-app/tests/integration/rerender-test.js
@@ -18,13 +18,8 @@ import GlimmerComponent from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
-import hasEmberVersion from '@ember/test-helpers/has-ember-version';
 
 module('rerender real-world', function (hooks) {
-  // this test requires Ember 3.25 in order to use lexically scoped values in templates
-  if (!hasEmberVersion(3, 25)) {
-    return;
-  }
   hooks.beforeEach(async function () {
     await setupContext(this);
     await setupRenderingContext(this);

--- a/test-app/tests/integration/settled-test.js
+++ b/test-app/tests/integration/settled-test.js
@@ -12,7 +12,6 @@ import {
   render,
   rerender,
 } from '@ember/test-helpers';
-import hasEmberVersion from '@ember/test-helpers/has-ember-version';
 import { module, test } from 'qunit';
 import { hbs } from 'ember-cli-htmlbars';
 import Pretender from 'pretender';
@@ -111,10 +110,6 @@ const TestComponent5 = Component.extend({
 });
 
 module('settled real-world scenarios', function (hooks) {
-  if (!hasEmberVersion(2, 4)) {
-    return;
-  }
-
   hooks.beforeEach(async function () {
     await setupContext(this);
     await setupRenderingContext(this);

--- a/test-app/tests/integration/setup-rendering-context-test.js
+++ b/test-app/tests/integration/setup-rendering-context-test.js
@@ -14,7 +14,6 @@ import {
 } from '@ember/test-helpers';
 import templateOnly from '@ember/component/template-only';
 
-import hasEmberVersion from '@ember/test-helpers/has-ember-version';
 import { setResolverRegistry } from '../helpers/resolver';
 import { hbs } from 'ember-cli-htmlbars';
 import { precompileTemplate } from '@ember/template-compilation';
@@ -148,60 +147,56 @@ module('setupRenderingContext "real world"', function (hooks) {
   });
 
   module('lexical scope access', function () {
-    if (hasEmberVersion(3, 28)) {
-      test('can render components passed as locals', async function (assert) {
-        let add = helper(function ([first, second]) {
-          return first + second;
-        });
-
-        await render(
-          precompileTemplate('{{add 1 3}}', {
-            scope() {
-              return { add };
-            },
-          })
-        );
-
-        assert.equal(this.element.textContent, '4');
+    test('can render components passed as locals', async function (assert) {
+      let add = helper(function ([first, second]) {
+        return first + second;
       });
-    }
+
+      await render(
+        precompileTemplate('{{add 1 3}}', {
+          scope() {
+            return { add };
+          },
+        })
+      );
+
+      assert.equal(this.element.textContent, '4');
+    });
   });
 
   module('render with a component', function () {
-    if (hasEmberVersion(3, 25)) {
-      test('can render locally defined components', async function (assert) {
-        class MyComponent extends GlimmerComponent {}
+    test('can render locally defined components', async function (assert) {
+      class MyComponent extends GlimmerComponent {}
 
-        setComponentTemplate(hbs`my name is {{@name}}`, MyComponent);
+      setComponentTemplate(hbs`my name is {{@name}}`, MyComponent);
 
-        const somePerson = new (class {
-          @tracked name = 'Zoey';
-        })();
+      const somePerson = new (class {
+        @tracked name = 'Zoey';
+      })();
 
-        const template = precompileTemplate(
-          '<MyComponent @name={{somePerson.name}} />',
-          {
-            scope() {
-              return {
-                somePerson,
-                MyComponent,
-              };
-            },
-          }
-        );
+      const template = precompileTemplate(
+        '<MyComponent @name={{somePerson.name}} />',
+        {
+          scope() {
+            return {
+              somePerson,
+              MyComponent,
+            };
+          },
+        }
+      );
 
-        const component = setComponentTemplate(template, templateOnly());
+      const component = setComponentTemplate(template, templateOnly());
 
-        await render(component);
+      await render(component);
 
-        assert.equal(this.element.textContent, 'my name is Zoey');
+      assert.equal(this.element.textContent, 'my name is Zoey');
 
-        somePerson.name = 'Tomster';
+      somePerson.name = 'Tomster';
 
-        await rerender();
+      await rerender();
 
-        assert.equal(this.element.textContent, 'my name is Tomster');
-      });
-    }
+      assert.equal(this.element.textContent, 'my name is Tomster');
+    });
   });
 });

--- a/test-app/tests/unit/dom/blur-test.js
+++ b/test-app/tests/unit/dom/blur-test.js
@@ -8,7 +8,6 @@ import {
 } from '@ember/test-helpers';
 import { buildInstrumentedElement, insertElement } from '../../helpers/events';
 import { isEdge, isChrome } from '../../helpers/browser-detect';
-import hasEmberVersion from '@ember/test-helpers/has-ember-version';
 import { createDescriptor } from 'dom-element-descriptors';
 
 let focusSteps = ['focus', 'focusin'];
@@ -23,10 +22,6 @@ if (isChrome) {
 }
 
 module('DOM Helper: blur', function (hooks) {
-  if (!hasEmberVersion(2, 4)) {
-    return;
-  }
-
   let context, elementWithFocus;
 
   hooks.beforeEach(async function (assert) {

--- a/test-app/tests/unit/dom/click-test.js
+++ b/test-app/tests/unit/dom/click-test.js
@@ -5,7 +5,6 @@ import {
   instrumentElement,
   insertElement,
 } from '../../helpers/events';
-import hasEmberVersion from '@ember/test-helpers/has-ember-version';
 import { isChrome } from '../../helpers/browser-detect';
 import {
   registerHooks,
@@ -15,10 +14,6 @@ import {
 import { createDescriptor } from 'dom-element-descriptors';
 
 module('DOM Helper: click', function (hooks) {
-  if (!hasEmberVersion(2, 4)) {
-    return;
-  }
-
   let context, element;
 
   hooks.beforeEach(function () {

--- a/test-app/tests/unit/dom/double-click-test.js
+++ b/test-app/tests/unit/dom/double-click-test.js
@@ -10,7 +10,6 @@ import {
   instrumentElement,
   insertElement,
 } from '../../helpers/events';
-import hasEmberVersion from '@ember/test-helpers/has-ember-version';
 import {
   registerHooks,
   unregisterHooks,
@@ -33,10 +32,6 @@ if (isChrome) {
 }
 
 module('DOM Helper: doubleClick', function (hooks) {
-  if (!hasEmberVersion(2, 4)) {
-    return;
-  }
-
   let context, element;
 
   hooks.beforeEach(function () {

--- a/test-app/tests/unit/dom/fill-in-test.js
+++ b/test-app/tests/unit/dom/fill-in-test.js
@@ -2,7 +2,6 @@ import { module, test } from 'qunit';
 import { fillIn, setupContext, teardownContext } from '@ember/test-helpers';
 import { buildInstrumentedElement, insertElement } from '../../helpers/events';
 import { isFirefox, isChrome } from '../../helpers/browser-detect';
-import hasEmberVersion from '@ember/test-helpers/has-ember-version';
 import {
   registerHooks,
   unregisterHooks,
@@ -17,10 +16,6 @@ if (isFirefox || isChrome) {
 }
 
 module('DOM Helper: fillIn', function (hooks) {
-  if (!hasEmberVersion(2, 4)) {
-    return;
-  }
-
   let context, element;
 
   hooks.beforeEach(function () {

--- a/test-app/tests/unit/dom/find-all-test.js
+++ b/test-app/tests/unit/dom/find-all-test.js
@@ -1,12 +1,7 @@
 import { module, test } from 'qunit';
 import { findAll, setupContext, teardownContext } from '@ember/test-helpers';
-import hasEmberVersion from '@ember/test-helpers/has-ember-version';
 
 module('DOM Helper: findAll', function (hooks) {
-  if (!hasEmberVersion(2, 4)) {
-    return;
-  }
-
   let context, element1, element2;
 
   hooks.beforeEach(function () {

--- a/test-app/tests/unit/dom/find-test.js
+++ b/test-app/tests/unit/dom/find-test.js
@@ -1,12 +1,7 @@
 import { module, test } from 'qunit';
 import { find, setupContext, teardownContext } from '@ember/test-helpers';
-import hasEmberVersion from '@ember/test-helpers/has-ember-version';
 
 module('DOM Helper: find', function (hooks) {
-  if (!hasEmberVersion(2, 4)) {
-    return;
-  }
-
   let context, element;
 
   hooks.beforeEach(function () {

--- a/test-app/tests/unit/dom/focus-test.js
+++ b/test-app/tests/unit/dom/focus-test.js
@@ -11,7 +11,6 @@ import {
   instrumentElement,
 } from '../../helpers/events';
 import { isEdge, isChrome } from '../../helpers/browser-detect';
-import hasEmberVersion from '@ember/test-helpers/has-ember-version';
 import { createDescriptor } from 'dom-element-descriptors';
 
 let focusSteps = ['focus', 'focusin'];
@@ -26,10 +25,6 @@ if (isChrome) {
 }
 
 module('DOM Helper: focus', function (hooks) {
-  if (!hasEmberVersion(2, 4)) {
-    return;
-  }
-
   let context, element;
 
   hooks.beforeEach(function () {

--- a/test-app/tests/unit/dom/get-root-element-test.js
+++ b/test-app/tests/unit/dom/get-root-element-test.js
@@ -4,13 +4,8 @@ import {
   setupContext,
   teardownContext,
 } from '@ember/test-helpers';
-import hasEmberVersion from '@ember/test-helpers/has-ember-version';
 
 module('DOM Helper: getRootElement', function (hooks) {
-  if (!hasEmberVersion(2, 4)) {
-    return;
-  }
-
   let context;
 
   hooks.beforeEach(function () {

--- a/test-app/tests/unit/dom/logging-test.js
+++ b/test-app/tests/unit/dom/logging-test.js
@@ -6,15 +6,10 @@ import {
   setupRenderingContext,
   teardownContext,
 } from '@ember/test-helpers';
-import hasEmberVersion from '@ember/test-helpers/has-ember-version';
 import { elementToString } from '@ember/test-helpers/dom/-logging';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('elementToString()', function (hooks) {
-  if (!hasEmberVersion(2, 4)) {
-    return;
-  }
-
   hooks.beforeEach(async function () {
     await setupContext(this);
     await setupRenderingContext(this);

--- a/test-app/tests/unit/dom/select-files-test.js
+++ b/test-app/tests/unit/dom/select-files-test.js
@@ -5,13 +5,8 @@ import {
   teardownContext,
 } from '@ember/test-helpers';
 import { buildInstrumentedElement } from '../../helpers/events';
-import hasEmberVersion from '@ember/test-helpers/has-ember-version';
 
 module('DOM Helper: selectFiles', function (hooks) {
-  if (!hasEmberVersion(2, 4)) {
-    return;
-  }
-
   let context, element;
 
   const textFile = new Blob(['Hello World'], { type: 'text/plain' });

--- a/test-app/tests/unit/dom/tab-test.js
+++ b/test-app/tests/unit/dom/tab-test.js
@@ -11,7 +11,6 @@ import {
   instrumentElement,
 } from '../../helpers/events';
 import { isEdge, isChrome } from '../../helpers/browser-detect';
-import hasEmberVersion from '@ember/test-helpers/has-ember-version';
 
 let _focusSteps = ['focus', 'focusin'];
 let _blurSteps = isEdge ? ['focusout', 'blur'] : ['blur', 'focusout'];
@@ -34,10 +33,6 @@ function moveFocus(from, to) {
 }
 
 module('DOM Helper: tab', function (hooks) {
-  if (!hasEmberVersion(2, 4)) {
-    return;
-  }
-
   let context, element, elements;
 
   hooks.beforeEach(function () {

--- a/test-app/tests/unit/dom/tap-test.js
+++ b/test-app/tests/unit/dom/tap-test.js
@@ -1,7 +1,6 @@
 import { module, test } from 'qunit';
 import { tap, setupContext, teardownContext } from '@ember/test-helpers';
 import { buildInstrumentedElement, insertElement } from '../../helpers/events';
-import hasEmberVersion from '@ember/test-helpers/has-ember-version';
 import { isChrome } from '../../helpers/browser-detect';
 import {
   registerHooks,
@@ -11,10 +10,6 @@ import {
 import { createDescriptor } from 'dom-element-descriptors';
 
 module('DOM Helper: tap', function (hooks) {
-  if (!hasEmberVersion(2, 4)) {
-    return;
-  }
-
   let context, element;
 
   hooks.beforeEach(function () {

--- a/test-app/tests/unit/dom/trigger-event-test.js
+++ b/test-app/tests/unit/dom/trigger-event-test.js
@@ -6,14 +6,9 @@ import {
   registerHook,
 } from '@ember/test-helpers';
 import { buildInstrumentedElement, insertElement } from '../../helpers/events';
-import hasEmberVersion from '@ember/test-helpers/has-ember-version';
 import { createDescriptor } from 'dom-element-descriptors';
 
 module('DOM Helper: triggerEvent', function (hooks) {
-  if (!hasEmberVersion(2, 4)) {
-    return;
-  }
-
   let context, element;
 
   hooks.beforeEach(function () {

--- a/test-app/tests/unit/dom/trigger-key-event-test.js
+++ b/test-app/tests/unit/dom/trigger-key-event-test.js
@@ -6,14 +6,9 @@ import {
   registerHook,
 } from '@ember/test-helpers';
 import { buildInstrumentedElement, insertElement } from '../../helpers/events';
-import hasEmberVersion from '@ember/test-helpers/has-ember-version';
 import { createDescriptor } from 'dom-element-descriptors';
 
 module('DOM Helper: triggerKeyEvent', function (hooks) {
-  if (!hasEmberVersion(2, 4)) {
-    return;
-  }
-
   let context, element;
 
   hooks.beforeEach(function () {

--- a/test-app/tests/unit/dom/type-in-test.js
+++ b/test-app/tests/unit/dom/type-in-test.js
@@ -4,7 +4,6 @@ import { buildInstrumentedElement, insertElement } from '../../helpers/events';
 import { isFirefox, isChrome } from '../../helpers/browser-detect';
 import { debounce } from '@ember/runloop';
 import { Promise } from 'rsvp';
-import hasEmberVersion from '@ember/test-helpers/has-ember-version';
 import {
   registerHooks,
   unregisterHooks,
@@ -82,10 +81,6 @@ if (isChrome) {
 }
 
 module('DOM Helper: typeIn', function (hooks) {
-  if (!hasEmberVersion(2, 4)) {
-    return;
-  }
-
   let context, element;
 
   hooks.beforeEach(function () {

--- a/test-app/tests/unit/dom/wait-for-focus-test.js
+++ b/test-app/tests/unit/dom/wait-for-focus-test.js
@@ -5,14 +5,9 @@ import {
   teardownContext,
   find,
 } from '@ember/test-helpers';
-import hasEmberVersion from '@ember/test-helpers/has-ember-version';
 import { registerDescriptorData } from 'dom-element-descriptors';
 
 module('DOM Helper: waitForFocus', function (hooks) {
-  if (!hasEmberVersion(2, 4)) {
-    return;
-  }
-
   let context, rootElement;
 
   hooks.beforeEach(function () {

--- a/test-app/tests/unit/dom/wait-for-test.js
+++ b/test-app/tests/unit/dom/wait-for-test.js
@@ -1,13 +1,8 @@
 import { module, test } from 'qunit';
 import { waitFor, setupContext, teardownContext } from '@ember/test-helpers';
-import hasEmberVersion from '@ember/test-helpers/has-ember-version';
 import { registerDescriptorData } from 'dom-element-descriptors';
 
 module('DOM Helper: waitFor', function (hooks) {
-  if (!hasEmberVersion(2, 4)) {
-    return;
-  }
-
   let context, rootElement;
 
   hooks.beforeEach(function () {

--- a/test-app/tests/unit/settled-test.js
+++ b/test-app/tests/unit/settled-test.js
@@ -3,7 +3,6 @@ import { module, test } from 'qunit';
 import { isSettled, getSettledState } from '@ember/test-helpers';
 import { macroCondition, dependencySatisfies } from '@embroider/macros';
 import { TestDebugInfo } from '@ember/test-helpers/-internal/debug-info';
-import hasEmberVersion from '@ember/test-helpers/has-ember-version';
 import {
   _setupAJAXHooks,
   _teardownAJAXHooks,
@@ -17,10 +16,6 @@ import ajax from '../helpers/ajax';
 const WAITER_NAME = 'custom-waiter';
 
 module('settled', function (hooks) {
-  if (!hasEmberVersion(2, 4)) {
-    return;
-  }
-
   hooks.beforeEach(function (assert) {
     _setupAJAXHooks();
 

--- a/test-app/tests/unit/setup-application-context-test.js
+++ b/test-app/tests/unit/setup-application-context-test.js
@@ -15,7 +15,6 @@ import {
   registerHook,
   isSettled,
 } from '@ember/test-helpers';
-import hasEmberVersion from '@ember/test-helpers/has-ember-version';
 import { setResolverRegistry } from '../helpers/resolver';
 import { hbs } from 'ember-cli-htmlbars';
 
@@ -30,10 +29,6 @@ Router.map(function () {
 });
 
 module('setupApplicationContext', function (hooks) {
-  if (!hasEmberVersion(2, 4)) {
-    return;
-  }
-
   hooks.beforeEach(async function () {
     let registry = {
       'router:main': Router,
@@ -68,19 +63,6 @@ module('setupApplicationContext', function (hooks) {
         },
       }),
     };
-
-    if (!hasEmberVersion(3, 12)) {
-      registry = {
-        ...registry,
-        // overrides for older Ember's
-        'template:application': hbs`
-            <div class="nav">{{#link-to "posts"}}posts{{/link-to}} | {{#link-to "widgets"}}widgets{{/link-to}}</div>
-            {{outlet}}
-          `,
-        'template:links-to-slow': hbs`{{#link-to "slow" class="to-slow"}}to slow{{/link-to}}`,
-        'template:posts/post': hbs`<div class="post-id">{{this.model.post_id}}</div>`,
-      };
-    }
 
     setResolverRegistry(registry);
 

--- a/test-app/tests/unit/setup-context-test.js
+++ b/test-app/tests/unit/setup-context-test.js
@@ -18,7 +18,6 @@ import {
 } from '@ember/test-helpers';
 import { getDeprecationsForContext } from '@ember/test-helpers/-internal/deprecations';
 import { getWarningsForContext } from '@ember/test-helpers/-internal/warnings';
-import hasEmberVersion from '@ember/test-helpers/has-ember-version';
 import {
   setResolverRegistry,
   createCustomResolver,
@@ -30,10 +29,6 @@ import config from '../../config/environment';
 import { deprecate, warn } from '@ember/debug';
 
 module('setupContext', function (hooks) {
-  if (!hasEmberVersion(2, 4)) {
-    return;
-  }
-
   hooks.beforeEach(function () {
     setResolverRegistry({
       'service:foo': Service.extend({ isFoo: true }),
@@ -74,14 +69,11 @@ module('setupContext', function (hooks) {
           'function',
           'has expected lookup interface'
         );
-
-        if (hasEmberVersion(2, 12)) {
-          assert.equal(
-            typeof owner.factoryFor,
-            'function',
-            'has expected factory interface'
-          );
-        }
+        assert.equal(
+          typeof owner.factoryFor,
+          'function',
+          'has expected factory interface'
+        );
       });
 
       overwriteTest(context, 'owner');

--- a/test-app/tests/unit/setup-ember-onerror-test.js
+++ b/test-app/tests/unit/setup-ember-onerror-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { getOnerror } from '@ember/-internals/error-handling';
-import hasEmberVersion from '@ember/test-helpers/has-ember-version';
 import { setupContext, teardownContext } from '@ember/test-helpers';
 import { setupOnerror, resetOnerror } from '@ember/test-helpers';
 
@@ -17,56 +16,54 @@ module('setupOnerror', function (hooks) {
     }
   });
 
-  if (hasEmberVersion(2, 4)) {
-    module('with context set', function (hooks) {
-      hooks.beforeEach(async function () {
-        await setupContext(context);
-      });
-
-      test('onerror is undefined by default', function (assert) {
-        assert.expect(1);
-
-        assert.equal(getOnerror(), undefined);
-      });
-
-      test('onerror is setup correctly', async function (assert) {
-        assert.expect(2);
-
-        let onerror = (err) => err;
-
-        assert.equal(getOnerror(), undefined);
-
-        setupOnerror(onerror);
-
-        assert.equal(getOnerror(), onerror);
-      });
-
-      test('onerror is reset correctly', async function (assert) {
-        assert.expect(3);
-
-        let onerror = (err) => err;
-
-        assert.equal(getOnerror(), undefined);
-
-        setupOnerror(onerror);
-
-        assert.equal(getOnerror(), onerror);
-
-        resetOnerror();
-
-        assert.equal(getOnerror(), undefined);
-      });
+  module('with context set', function (hooks) {
+    hooks.beforeEach(async function () {
+      await setupContext(context);
     });
 
-    test('it raises an error without context', function (assert) {
-      assert.throws(() => {
-        setupOnerror();
-      }, /Must setup test context before calling setupOnerror/);
+    test('onerror is undefined by default', function (assert) {
+      assert.expect(1);
+
+      assert.equal(getOnerror(), undefined);
     });
 
-    test('resetOnerror does not raise an error without context', function (assert) {
+    test('onerror is setup correctly', async function (assert) {
+      assert.expect(2);
+
+      let onerror = (err) => err;
+
+      assert.equal(getOnerror(), undefined);
+
+      setupOnerror(onerror);
+
+      assert.equal(getOnerror(), onerror);
+    });
+
+    test('onerror is reset correctly', async function (assert) {
+      assert.expect(3);
+
+      let onerror = (err) => err;
+
+      assert.equal(getOnerror(), undefined);
+
+      setupOnerror(onerror);
+
+      assert.equal(getOnerror(), onerror);
+
       resetOnerror();
-      assert.ok(true, 'nothing was thrown');
+
+      assert.equal(getOnerror(), undefined);
     });
-  }
+  });
+
+  test('it raises an error without context', function (assert) {
+    assert.throws(() => {
+      setupOnerror();
+    }, /Must setup test context before calling setupOnerror/);
+  });
+
+  test('resetOnerror does not raise an error without context', function (assert) {
+    resetOnerror();
+    assert.ok(true, 'nothing was thrown');
+  });
 });

--- a/test-app/tests/unit/setup-rendering-context-test.js
+++ b/test-app/tests/unit/setup-rendering-context-test.js
@@ -30,7 +30,6 @@ import { getOwner } from '@ember/application';
 import Engine from '@ember/engine';
 import { precompileTemplate } from '@ember/template-compilation';
 import templateOnly from '@ember/component/template-only';
-import hasEmberVersion from '@ember/test-helpers/has-ember-version';
 
 async function buildEngineOwner(parentOwner, registry) {
   parentOwner.register(
@@ -538,206 +537,112 @@ module('setupRenderingContext', function (hooks) {
       assert.equal(getOwner(this), this.owner);
     });
 
-    if (hasEmberVersion(3, 25)) {
-      // render tests for components in 3.25+ where we can use lexical scope
-      module('using render with a component in Ember >= 3.25', function () {
-        test('works with a template-only component', async function (assert) {
-          const name = 'Chris';
+    module('using render with a component', function () {
+      test('works with a template-only component', async function (assert) {
+        const name = 'Chris';
 
-          const template = precompileTemplate(
-            '<p>hello my name is {{name}}</p>',
-            {
-              scope() {
-                return {
-                  name,
-                };
-              },
-            }
-          );
-          const component = setComponentTemplate(template, templateOnly());
-          await render(component);
-          assert.equal(
-            this.element.textContent,
-            'hello my name is Chris',
-            'has rendered content'
-          );
-        });
-
-        test('works with a glimmer component', async function (assert) {
-          const name = 'Chris';
-          const template = precompileTemplate(
-            '<p>hello my name is {{name}} and my favorite color is {{this.favoriteColor}}</p>',
-            {
-              scope() {
-                return {
-                  name,
-                };
-              },
-            }
-          );
-
-          class Foo extends GlimmerComponent {
-            favoriteColor = 'red';
+        const template = precompileTemplate(
+          '<p>hello my name is {{name}}</p>',
+          {
+            scope() {
+              return {
+                name,
+              };
+            },
           }
-
-          setComponentTemplate(template, Foo);
-          await render(Foo);
-
-          assert.equal(
-            this.element.textContent,
-            'hello my name is Chris and my favorite color is red',
-            'has rendered content'
-          );
-        });
-
-        test('works with a classic component', async function (assert) {
-          const name = 'Chris';
-          const template = precompileTemplate(
-            '<p>hello my name is {{name}} and my favorite color is {{this.favoriteColor}}</p>',
-            {
-              scope() {
-                return {
-                  name,
-                };
-              },
-            }
-          );
-
-          const Foo = Component.extend({
-            favoriteColor: 'red',
-          });
-
-          setComponentTemplate(template, Foo);
-          await render(Foo);
-
-          assert.equal(
-            this.element.textContent,
-            'hello my name is Chris and my favorite color is red',
-            'has rendered content'
-          );
-        });
-
-        test('components passed to render do *not* have access to the test context', async function (assert) {
-          const template = precompileTemplate(
-            'the value of foo is {{this.foo}}'
-          );
-
-          class Foo extends GlimmerComponent {
-            foo = 'foo';
-          }
-
-          const component = setComponentTemplate(template, Foo);
-
-          this.foo = 'bar';
-
-          await render(component);
-
-          assert.equal(this.element.textContent, 'the value of foo is foo');
-        });
-
-        test('setting properties on the test context when rendering a template does not throw an assertion', async function (assert) {
-          const template = precompileTemplate(
-            'the value of foo is {{this.foo}}'
-          );
-
-          this.set('foo', 'FOO');
-          this.setProperties({
-            foo: 'bar?',
-          });
-
-          await render(template);
-
-          assert.true(true, 'no assertions are thrown');
-        });
+        );
+        const component = setComponentTemplate(template, templateOnly());
+        await render(component);
+        assert.equal(
+          this.element.textContent,
+          'hello my name is Chris',
+          'has rendered content'
+        );
       });
-    } else if (hasEmberVersion(3, 24)) {
-      module('using render with a component in Ember < 3.25', function () {
-        test('works with a template-only component', async function (assert) {
-          const template = precompileTemplate(
-            '<p>this is a template-only component with no dynamic content</p>'
-          );
-          const component = setComponentTemplate(template, templateOnly());
-          await render(component);
-          assert.equal(
-            this.element.textContent,
-            'this is a template-only component with no dynamic content',
-            'has rendered content'
-          );
-        });
 
-        test('works with a glimmer component', async function (assert) {
-          const template = precompileTemplate(
-            '<p>hello my favorite color is {{this.favoriteColor}}</p>'
-          );
-
-          class Foo extends GlimmerComponent {
-            favoriteColor = 'red';
+      test('works with a glimmer component', async function (assert) {
+        const name = 'Chris';
+        const template = precompileTemplate(
+          '<p>hello my name is {{name}} and my favorite color is {{this.favoriteColor}}</p>',
+          {
+            scope() {
+              return {
+                name,
+              };
+            },
           }
+        );
 
-          const component = setComponentTemplate(template, Foo);
+        class Foo extends GlimmerComponent {
+          favoriteColor = 'red';
+        }
 
-          await render(component);
-          assert.equal(
-            this.element.textContent,
-            'hello my favorite color is red',
-            'has rendered content'
-          );
-        });
+        setComponentTemplate(template, Foo);
+        await render(Foo);
 
-        test('works with a classic component', async function (assert) {
-          const template = precompileTemplate(
-            '<p>hello my favorite color is {{this.favoriteColor}}</p>'
-          );
-
-          const Foo = Component.extend({
-            favoriteColor: 'red',
-          });
-
-          const component = setComponentTemplate(template, Foo);
-
-          await render(component);
-
-          assert.equal(
-            this.element.textContent,
-            'hello my favorite color is red',
-            'has rendered content'
-          );
-        });
-
-        test('components passed to render do *not* have access to the test context', async function (assert) {
-          const template = precompileTemplate(
-            'the value of foo is {{this.foo}}'
-          );
-
-          class Foo extends GlimmerComponent {
-            foo = 'foo';
-          }
-
-          const component = setComponentTemplate(template, Foo);
-
-          this.foo = 'bar';
-
-          await render(component);
-
-          assert.equal(this.element.textContent, 'the value of foo is foo');
-        });
-
-        test('setting properties on the test context when rendering a template does not throw an assertion', async function (assert) {
-          const template = precompileTemplate(
-            'the value of foo is {{this.foo}}'
-          );
-
-          this.set('foo', 'FOO');
-          this.setProperties({
-            foo: 'bar?',
-          });
-
-          await render(template);
-
-          assert.true(true, 'no assertions are thrown');
-        });
+        assert.equal(
+          this.element.textContent,
+          'hello my name is Chris and my favorite color is red',
+          'has rendered content'
+        );
       });
-    }
+
+      test('works with a classic component', async function (assert) {
+        const name = 'Chris';
+        const template = precompileTemplate(
+          '<p>hello my name is {{name}} and my favorite color is {{this.favoriteColor}}</p>',
+          {
+            scope() {
+              return {
+                name,
+              };
+            },
+          }
+        );
+
+        const Foo = Component.extend({
+          favoriteColor: 'red',
+        });
+
+        setComponentTemplate(template, Foo);
+        await render(Foo);
+
+        assert.equal(
+          this.element.textContent,
+          'hello my name is Chris and my favorite color is red',
+          'has rendered content'
+        );
+      });
+
+      test('components passed to render do *not* have access to the test context', async function (assert) {
+        const template = precompileTemplate('the value of foo is {{this.foo}}');
+
+        class Foo extends GlimmerComponent {
+          foo = 'foo';
+        }
+
+        const component = setComponentTemplate(template, Foo);
+
+        this.foo = 'bar';
+
+        await render(component);
+
+        assert.equal(this.element.textContent, 'the value of foo is foo');
+      });
+
+      test('setting properties on the test context when rendering a template does not throw an assertion', async function (assert) {
+        const template = precompileTemplate('the value of foo is {{this.foo}}');
+
+        this.set('foo', 'FOO');
+        this.setProperties({
+          foo: 'bar?',
+        });
+
+        await render(template);
+
+        assert.true(true, 'no assertions are thrown');
+      });
+    });
   }
 
   module('with only application set', function (hooks) {

--- a/test-app/tests/unit/teardown-context-test.js
+++ b/test-app/tests/unit/teardown-context-test.js
@@ -9,7 +9,6 @@ import {
   isSettled,
 } from '@ember/test-helpers';
 import { setResolverRegistry } from '../helpers/resolver';
-import hasEmberVersion from '@ember/test-helpers/has-ember-version';
 import { isTesting } from '@ember/debug';
 
 import hasjQuery from '../helpers/has-jquery';
@@ -18,10 +17,6 @@ import Pretender from 'pretender';
 import setupManualTestWaiter from '../helpers/manual-test-waiter';
 
 module('teardownContext', function (hooks) {
-  if (!hasEmberVersion(2, 4)) {
-    return;
-  }
-
   setupManualTestWaiter(hooks);
 
   let context;


### PR DESCRIPTION
Remove _unused_ code paths due to the fact, that `@ember/test-helpers` add-on supports Ember v4+, see https://github.com/emberjs/ember-test-helpers#compatibility.